### PR TITLE
extended grammar to allow style definition of the form ./style n args…

### DIFF
--- a/TikzParser/output/simpletikzLexer.cs
+++ b/TikzParser/output/simpletikzLexer.cs
@@ -1,4 +1,4 @@
-// $ANTLR 3.1.1 C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g 2013-07-01 14:00:50
+// $ANTLR 3.1.1 E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g 2016-09-21 11:07:05
 
 using System;
 using Antlr.Runtime;
@@ -8,98 +8,99 @@ using Stack 		= Antlr.Runtime.Collections.StackList;
 
 
 public partial class simpletikzLexer : Lexer {
-    public const int EXPONENT = 34;
-    public const int TIKZEDT_CMD_COMMENT = 27;
-    public const int IM_PATH = 4;
-    public const int IM_ID = 18;
-    public const int IM_DONTCARE = 25;
-    public const int SOMETHING = 37;
-    public const int EOF = -1;
-    public const int IM_ARC = 26;
-    public const int COMMAND = 29;
-    public const int IM_ENDTAG = 14;
-    public const int T__93 = 93;
-    public const int T__94 = 94;
-    public const int T__91 = 91;
-    public const int T__92 = 92;
-    public const int IM_DOCUMENT = 11;
-    public const int IM_STRING = 21;
-    public const int T__90 = 90;
-    public const int IM_TIKZSET = 19;
-    public const int COMMENT = 33;
-    public const int SOMETHING1 = 38;
+    public const int T__50 = 50;
+    public const int IM_NUMBERUNIT = 9;
     public const int IM_OPTIONS = 15;
-    public const int T__80 = 80;
-    public const int T__81 = 81;
-    public const int IM_OPTION_STYLE = 16;
-    public const int T__82 = 82;
-    public const int T__83 = 83;
-    public const int IM_COORD = 6;
-    public const int INT = 31;
-    public const int T__85 = 85;
-    public const int T__84 = 84;
-    public const int T__87 = 87;
-    public const int T__86 = 86;
-    public const int T__89 = 89;
-    public const int IM_NODE = 5;
-    public const int T__88 = 88;
-    public const int IM_STYLE = 22;
-    public const int WS = 32;
-    public const int T__71 = 71;
-    public const int T__72 = 72;
-    public const int T__70 = 70;
-    public const int T__76 = 76;
-    public const int T__75 = 75;
-    public const int T__74 = 74;
-    public const int T__73 = 73;
-    public const int T__79 = 79;
-    public const int T__78 = 78;
-    public const int T__77 = 77;
-    public const int T__68 = 68;
-    public const int T__69 = 69;
-    public const int T__66 = 66;
-    public const int T__67 = 67;
-    public const int T__64 = 64;
-    public const int T__65 = 65;
-    public const int IM_STARTTAG = 13;
-    public const int T__62 = 62;
-    public const int T__63 = 63;
-    public const int IM_CONTROLS = 23;
-    public const int T__61 = 61;
-    public const int ID = 28;
-    public const int T__60 = 60;
-    public const int MATHSTRING = 36;
+    public const int IM_PATH = 4;
+    public const int T__59 = 59;
     public const int T__55 = 55;
-    public const int IM_USETIKZLIB = 20;
+    public const int IM_TIKZEDT_CMD = 24;
     public const int T__56 = 56;
     public const int T__57 = 57;
+    public const int IM_SCOPE = 12;
     public const int T__58 = 58;
-    public const int ESC_SEQ = 35;
+    public const int ID = 28;
     public const int T__51 = 51;
     public const int T__52 = 52;
+    public const int IM_NODENAME = 8;
     public const int T__53 = 53;
     public const int T__54 = 54;
-    public const int T__59 = 59;
-    public const int IM_OPTION_KV = 17;
-    public const int T__50 = 50;
-    public const int IM_TIKZEDT_CMD = 24;
-    public const int T__42 = 42;
-    public const int T__43 = 43;
-    public const int T__40 = 40;
-    public const int T__41 = 41;
-    public const int T__46 = 46;
-    public const int T__47 = 47;
-    public const int T__44 = 44;
-    public const int T__45 = 45;
+    public const int T__60 = 60;
+    public const int T__61 = 61;
+    public const int SOMETHING1 = 38;
+    public const int SOMETHING = 37;
+    public const int T__66 = 66;
+    public const int T__67 = 67;
+    public const int T__68 = 68;
+    public const int T__69 = 69;
+    public const int T__62 = 62;
+    public const int T__63 = 63;
+    public const int T__64 = 64;
+    public const int T__65 = 65;
+    public const int IM_ID = 18;
+    public const int COMMENT = 33;
+    public const int IM_SIZE = 7;
+    public const int T__39 = 39;
+    public const int IM_NODE = 5;
+    public const int COMMAND = 29;
+    public const int IM_DOCUMENT = 11;
+    public const int IM_STARTTAG = 13;
+    public const int IM_ARC = 26;
     public const int T__48 = 48;
     public const int T__49 = 49;
-    public const int IM_PICTURE = 10;
-    public const int IM_NUMBERUNIT = 9;
-    public const int IM_SCOPE = 12;
-    public const int T__39 = 39;
-    public const int IM_SIZE = 7;
-    public const int IM_NODENAME = 8;
+    public const int T__44 = 44;
+    public const int T__45 = 45;
+    public const int EXPONENT = 34;
+    public const int T__46 = 46;
+    public const int T__47 = 47;
+    public const int T__40 = 40;
+    public const int T__41 = 41;
+    public const int IM_TIKZSET = 19;
+    public const int T__42 = 42;
+    public const int T__43 = 43;
+    public const int T__91 = 91;
+    public const int T__92 = 92;
+    public const int T__93 = 93;
+    public const int T__94 = 94;
+    public const int T__90 = 90;
+    public const int IM_ENDTAG = 14;
+    public const int IM_STRING = 21;
+    public const int MATHSTRING = 36;
+    public const int T__95 = 95;
+    public const int IM_COORD = 6;
+    public const int IM_USETIKZLIB = 20;
     public const int FLOAT_WO_EXP = 30;
+    public const int IM_PICTURE = 10;
+    public const int IM_DONTCARE = 25;
+    public const int T__70 = 70;
+    public const int T__71 = 71;
+    public const int T__72 = 72;
+    public const int IM_OPTION_STYLE = 16;
+    public const int INT = 31;
+    public const int IM_OPTION_KV = 17;
+    public const int T__77 = 77;
+    public const int T__78 = 78;
+    public const int ESC_SEQ = 35;
+    public const int T__79 = 79;
+    public const int T__73 = 73;
+    public const int WS = 32;
+    public const int EOF = -1;
+    public const int T__74 = 74;
+    public const int T__75 = 75;
+    public const int T__76 = 76;
+    public const int T__80 = 80;
+    public const int T__81 = 81;
+    public const int T__82 = 82;
+    public const int T__83 = 83;
+    public const int TIKZEDT_CMD_COMMENT = 27;
+    public const int T__88 = 88;
+    public const int T__89 = 89;
+    public const int T__84 = 84;
+    public const int T__85 = 85;
+    public const int IM_STYLE = 22;
+    public const int T__86 = 86;
+    public const int T__87 = 87;
+    public const int IM_CONTROLS = 23;
 
         //@Override
         public override void ReportError(RecognitionException e) {
@@ -139,7 +140,7 @@ public partial class simpletikzLexer : Lexer {
     
     override public string GrammarFileName
     {
-    	get { return "C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g";} 
+    	get { return "E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g";} 
     }
 
     // $ANTLR start "T__39"
@@ -149,8 +150,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__39;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:28:7: ( '\\\\begin' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:28:9: '\\\\begin'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:28:7: ( '\\\\begin' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:28:9: '\\\\begin'
             {
             	Match("\\begin"); 
 
@@ -173,8 +174,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__40;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:29:7: ( '\\\\tikzstyle' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:29:9: '\\\\tikzstyle'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:29:7: ( '\\\\tikzstyle' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:29:9: '\\\\tikzstyle'
             {
             	Match("\\tikzstyle"); 
 
@@ -197,8 +198,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__41;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:30:7: ( '\\\\tikzset' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:30:9: '\\\\tikzset'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:30:7: ( '\\\\tikzset' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:30:9: '\\\\tikzset'
             {
             	Match("\\tikzset"); 
 
@@ -221,8 +222,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__42;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:31:7: ( '\\\\tikz' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:31:9: '\\\\tikz'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:31:7: ( '\\\\tikz' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:31:9: '\\\\tikz'
             {
             	Match("\\tikz"); 
 
@@ -245,8 +246,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__43;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:32:7: ( '{' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:32:9: '{'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:32:7: ( '{' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:32:9: '{'
             {
             	Match('{'); 
 
@@ -268,8 +269,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__44;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:33:7: ( '}' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:33:9: '}'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:33:7: ( '}' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:33:9: '}'
             {
             	Match('}'); 
 
@@ -291,8 +292,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__45;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:34:7: ( '=' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:34:9: '='
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:34:7: ( '=' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:34:9: '='
             {
             	Match('='); 
 
@@ -314,8 +315,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__46;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:35:7: ( '+=' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:35:9: '+='
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:35:7: ( '+=' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:35:9: '+='
             {
             	Match("+="); 
 
@@ -338,8 +339,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__47;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:36:7: ( ',' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:36:9: ','
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:36:7: ( ',' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:36:9: ','
             {
             	Match(','); 
 
@@ -361,8 +362,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__48;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:37:7: ( ':' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:37:9: ':'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:37:7: ( ':' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:37:9: ':'
             {
             	Match(':'); 
 
@@ -384,8 +385,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__49;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:38:7: ( '/.style' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:38:9: '/.style'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:38:7: ( '/.style' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:38:9: '/.style'
             {
             	Match("/.style"); 
 
@@ -408,8 +409,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__50;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:39:7: ( '/.append' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:39:9: '/.append'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:39:7: ( '/.append' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:39:9: '/.append'
             {
             	Match("/.append"); 
 
@@ -432,8 +433,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__51;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:40:7: ( 'style' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:40:9: 'style'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:40:7: ( 'style' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:40:9: 'style'
             {
             	Match("style"); 
 
@@ -456,10 +457,11 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__52;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:41:7: ( '(' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:41:9: '('
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:41:7: ( 'args' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:41:9: 'args'
             {
-            	Match('('); 
+            	Match("args"); 
+
 
             }
 
@@ -479,10 +481,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__53;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:42:7: ( ')' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:42:9: ')'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:42:7: ( '(' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:42:9: '('
             {
-            	Match(')'); 
+            	Match('('); 
 
             }
 
@@ -502,10 +504,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__54;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:43:7: ( '[' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:43:9: '['
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:43:7: ( ')' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:43:9: ')'
             {
-            	Match('['); 
+            	Match(')'); 
 
             }
 
@@ -525,10 +527,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__55;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:44:7: ( ']' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:44:9: ']'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:44:7: ( '[' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:44:9: '['
             {
-            	Match(']'); 
+            	Match('['); 
 
             }
 
@@ -548,10 +550,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__56;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:45:7: ( ';' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:45:9: ';'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:45:7: ( ']' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:45:9: ']'
             {
-            	Match(';'); 
+            	Match(']'); 
 
             }
 
@@ -571,11 +573,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__57;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:46:7: ( 'cm' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:46:9: 'cm'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:46:7: ( ';' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:46:9: ';'
             {
-            	Match("cm"); 
-
+            	Match(';'); 
 
             }
 
@@ -595,10 +596,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__58;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:47:7: ( 'in' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:47:9: 'in'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:47:7: ( 'cm' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:47:9: 'cm'
             {
-            	Match("in"); 
+            	Match("cm"); 
 
 
             }
@@ -619,10 +620,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__59;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:48:7: ( 'ex' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:48:9: 'ex'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:48:7: ( 'in' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:48:9: 'in'
             {
-            	Match("ex"); 
+            	Match("in"); 
 
 
             }
@@ -643,10 +644,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__60;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:49:7: ( 'mm' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:49:9: 'mm'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:49:7: ( 'ex' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:49:9: 'ex'
             {
-            	Match("mm"); 
+            	Match("ex"); 
 
 
             }
@@ -667,10 +668,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__61;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:50:7: ( 'pt' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:50:9: 'pt'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:50:7: ( 'mm' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:50:9: 'mm'
             {
-            	Match("pt"); 
+            	Match("mm"); 
 
 
             }
@@ -691,10 +692,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__62;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:51:7: ( 'em' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:51:9: 'em'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:51:7: ( 'pt' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:51:9: 'pt'
             {
-            	Match("em"); 
+            	Match("pt"); 
 
 
             }
@@ -715,10 +716,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__63;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:52:7: ( '\\\\end' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:52:9: '\\\\end'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:52:7: ( 'em' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:52:9: 'em'
             {
-            	Match("\\end"); 
+            	Match("em"); 
 
 
             }
@@ -739,10 +740,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__64;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:53:7: ( '\\\\node' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:53:9: '\\\\node'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:53:7: ( '\\\\end' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:53:9: '\\\\end'
             {
-            	Match("\\node"); 
+            	Match("\\end"); 
 
 
             }
@@ -763,10 +764,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__65;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:54:7: ( '\\\\matrix' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:54:9: '\\\\matrix'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:54:7: ( '\\\\node' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:54:9: '\\\\node'
             {
-            	Match("\\matrix"); 
+            	Match("\\node"); 
 
 
             }
@@ -787,10 +788,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__66;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:55:7: ( '\\\\coordinate' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:55:9: '\\\\coordinate'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:55:7: ( '\\\\matrix' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:55:9: '\\\\matrix'
             {
-            	Match("\\coordinate"); 
+            	Match("\\matrix"); 
 
 
             }
@@ -811,10 +812,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__67;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:56:7: ( '\\\\draw' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:56:9: '\\\\draw'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:56:7: ( '\\\\coordinate' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:56:9: '\\\\coordinate'
             {
-            	Match("\\draw"); 
+            	Match("\\coordinate"); 
 
 
             }
@@ -835,10 +836,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__68;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:57:7: ( '\\\\path' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:57:9: '\\\\path'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:57:7: ( '\\\\draw' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:57:9: '\\\\draw'
             {
-            	Match("\\path"); 
+            	Match("\\draw"); 
 
 
             }
@@ -859,10 +860,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__69;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:58:7: ( '\\\\def' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:58:9: '\\\\def'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:58:7: ( '\\\\path' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:58:9: '\\\\path'
             {
-            	Match("\\def"); 
+            	Match("\\path"); 
 
 
             }
@@ -883,10 +884,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__70;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:59:7: ( '\\\\filldraw' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:59:9: '\\\\filldraw'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:59:7: ( '\\\\def' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:59:9: '\\\\def'
             {
-            	Match("\\filldraw"); 
+            	Match("\\def"); 
 
 
             }
@@ -907,10 +908,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__71;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:60:7: ( '\\\\pattern' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:60:9: '\\\\pattern'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:60:7: ( '\\\\filldraw' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:60:9: '\\\\filldraw'
             {
-            	Match("\\pattern"); 
+            	Match("\\filldraw"); 
 
 
             }
@@ -931,10 +932,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__72;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:61:7: ( '\\\\shade' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:61:9: '\\\\shade'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:61:7: ( '\\\\pattern' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:61:9: '\\\\pattern'
             {
-            	Match("\\shade"); 
+            	Match("\\pattern"); 
 
 
             }
@@ -955,10 +956,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__73;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:62:7: ( '\\\\shadedraw' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:62:9: '\\\\shadedraw'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:62:7: ( '\\\\shade' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:62:9: '\\\\shade'
             {
-            	Match("\\shadedraw"); 
+            	Match("\\shade"); 
 
 
             }
@@ -979,10 +980,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__74;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:63:7: ( '\\\\useasboundingbox' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:63:9: '\\\\useasboundingbox'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:63:7: ( '\\\\shadedraw' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:63:9: '\\\\shadedraw'
             {
-            	Match("\\useasboundingbox"); 
+            	Match("\\shadedraw"); 
 
 
             }
@@ -1003,10 +1004,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__75;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:64:7: ( '\\\\fill' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:64:9: '\\\\fill'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:64:7: ( '\\\\useasboundingbox' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:64:9: '\\\\useasboundingbox'
             {
-            	Match("\\fill"); 
+            	Match("\\useasboundingbox"); 
 
 
             }
@@ -1027,10 +1028,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__76;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:65:7: ( '\\\\clip' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:65:9: '\\\\clip'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:65:7: ( '\\\\fill' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:65:9: '\\\\fill'
             {
-            	Match("\\clip"); 
+            	Match("\\fill"); 
 
 
             }
@@ -1051,10 +1052,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__77;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:66:7: ( 'let' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:66:9: 'let'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:66:7: ( '\\\\clip' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:66:9: '\\\\clip'
             {
-            	Match("let"); 
+            	Match("\\clip"); 
 
 
             }
@@ -1075,10 +1076,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__78;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:67:7: ( 'and' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:67:9: 'and'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:67:7: ( 'let' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:67:9: 'let'
             {
-            	Match("and"); 
+            	Match("let"); 
 
 
             }
@@ -1099,10 +1100,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__79;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:68:7: ( 'coordinate' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:68:9: 'coordinate'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:68:7: ( 'and' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:68:9: 'and'
             {
-            	Match("coordinate"); 
+            	Match("and"); 
 
 
             }
@@ -1123,10 +1124,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__80;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:69:7: ( 'node' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:69:9: 'node'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:69:7: ( 'coordinate' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:69:9: 'coordinate'
             {
-            	Match("node"); 
+            	Match("coordinate"); 
 
 
             }
@@ -1147,10 +1148,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__81;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:70:7: ( 'at' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:70:9: 'at'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:70:7: ( 'node' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:70:9: 'node'
             {
-            	Match("at"); 
+            	Match("node"); 
 
 
             }
@@ -1171,10 +1172,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__82;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:71:7: ( 'circle' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:71:9: 'circle'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:71:7: ( 'at' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:71:9: 'at'
             {
-            	Match("circle"); 
+            	Match("at"); 
 
 
             }
@@ -1195,10 +1196,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__83;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:72:7: ( 'ellipse' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:72:9: 'ellipse'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:72:7: ( 'circle' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:72:9: 'circle'
             {
-            	Match("ellipse"); 
+            	Match("circle"); 
 
 
             }
@@ -1219,10 +1220,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__84;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:73:7: ( 'arc' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:73:9: 'arc'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:73:7: ( 'ellipse' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:73:9: 'ellipse'
             {
-            	Match("arc"); 
+            	Match("ellipse"); 
 
 
             }
@@ -1243,10 +1244,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__85;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:74:7: ( '--' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:74:9: '--'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:74:7: ( 'arc' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:74:9: 'arc'
             {
-            	Match("--"); 
+            	Match("arc"); 
 
 
             }
@@ -1267,10 +1268,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__86;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:75:7: ( '->' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:75:9: '->'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:75:7: ( '--' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:75:9: '--'
             {
-            	Match("->"); 
+            	Match("--"); 
 
 
             }
@@ -1291,10 +1292,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__87;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:76:7: ( '|-' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:76:9: '|-'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:76:7: ( '->' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:76:9: '->'
             {
-            	Match("|-"); 
+            	Match("->"); 
 
 
             }
@@ -1315,10 +1316,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__88;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:77:7: ( '-|' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:77:9: '-|'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:77:7: ( '|-' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:77:9: '|-'
             {
-            	Match("-|"); 
+            	Match("|-"); 
 
 
             }
@@ -1339,10 +1340,11 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__89;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:78:7: ( '+' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:78:9: '+'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:78:7: ( '-|' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:78:9: '-|'
             {
-            	Match('+'); 
+            	Match("-|"); 
+
 
             }
 
@@ -1362,11 +1364,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__90;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:79:7: ( '++' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:79:9: '++'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:79:7: ( '+' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:79:9: '+'
             {
-            	Match("++"); 
-
+            	Match('+'); 
 
             }
 
@@ -1386,10 +1387,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__91;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:80:7: ( '..' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:80:9: '..'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:80:7: ( '++' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:80:9: '++'
             {
-            	Match(".."); 
+            	Match("++"); 
 
 
             }
@@ -1410,10 +1411,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__92;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:81:7: ( 'controls' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:81:9: 'controls'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:81:7: ( '..' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:81:9: '..'
             {
-            	Match("controls"); 
+            	Match(".."); 
 
 
             }
@@ -1434,10 +1435,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__93;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:82:7: ( 'tikzpicture' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:82:9: 'tikzpicture'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:82:7: ( 'controls' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:82:9: 'controls'
             {
-            	Match("tikzpicture"); 
+            	Match("controls"); 
 
 
             }
@@ -1458,10 +1459,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__94;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:83:7: ( 'scope' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:83:9: 'scope'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:83:7: ( 'tikzpicture' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:83:9: 'tikzpicture'
             {
-            	Match("scope"); 
+            	Match("tikzpicture"); 
 
 
             }
@@ -1475,6 +1476,30 @@ public partial class simpletikzLexer : Lexer {
     }
     // $ANTLR end "T__94"
 
+    // $ANTLR start "T__95"
+    public void mT__95() // throws RecognitionException [2]
+    {
+    		try
+    		{
+            int _type = T__95;
+    	int _channel = DEFAULT_TOKEN_CHANNEL;
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:84:7: ( 'scope' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:84:9: 'scope'
+            {
+            	Match("scope"); 
+
+
+            }
+
+            state.type = _type;
+            state.channel = _channel;
+        }
+        finally 
+    	{
+        }
+    }
+    // $ANTLR end "T__95"
+
     // $ANTLR start "ID"
     public void mID() // throws RecognitionException [2]
     {
@@ -1482,8 +1507,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = ID;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:585:5: ( ( 'a' .. 'z' | 'A' .. 'Z' | '_' ) ( 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '.' | '!' )* )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:585:7: ( 'a' .. 'z' | 'A' .. 'Z' | '_' ) ( 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '.' | '!' )*
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:585:5: ( ( 'a' .. 'z' | 'A' .. 'Z' | '_' ) ( 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '.' | '!' )* )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:585:7: ( 'a' .. 'z' | 'A' .. 'Z' | '_' ) ( 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '.' | '!' )*
             {
             	if ( (input.LA(1) >= 'A' && input.LA(1) <= 'Z') || input.LA(1) == '_' || (input.LA(1) >= 'a' && input.LA(1) <= 'z') ) 
             	{
@@ -1496,7 +1521,7 @@ public partial class simpletikzLexer : Lexer {
             	    Recover(mse);
             	    throw mse;}
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:585:31: ( 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '.' | '!' )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:585:31: ( 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '.' | '!' )*
             	do 
             	{
             	    int alt1 = 2;
@@ -1511,7 +1536,7 @@ public partial class simpletikzLexer : Lexer {
             	    switch (alt1) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:
             			    {
             			    	if ( input.LA(1) == '!' || input.LA(1) == '.' || (input.LA(1) >= '0' && input.LA(1) <= '9') || (input.LA(1) >= 'A' && input.LA(1) <= 'Z') || input.LA(1) == '_' || (input.LA(1) >= 'a' && input.LA(1) <= 'z') ) 
             			    	{
@@ -1555,10 +1580,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = INT;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:588:5: ( ( '-' )? ( '0' .. '9' )+ )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:588:7: ( '-' )? ( '0' .. '9' )+
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:588:5: ( ( '-' )? ( '0' .. '9' )+ )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:588:7: ( '-' )? ( '0' .. '9' )+
             {
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:588:7: ( '-' )?
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:588:7: ( '-' )?
             	int alt2 = 2;
             	int LA2_0 = input.LA(1);
 
@@ -1569,7 +1594,7 @@ public partial class simpletikzLexer : Lexer {
             	switch (alt2) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:588:7: '-'
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:588:7: '-'
             	        {
             	        	Match('-'); 
 
@@ -1578,7 +1603,7 @@ public partial class simpletikzLexer : Lexer {
 
             	}
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:588:12: ( '0' .. '9' )+
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:588:12: ( '0' .. '9' )+
             	int cnt3 = 0;
             	do 
             	{
@@ -1594,7 +1619,7 @@ public partial class simpletikzLexer : Lexer {
             	    switch (alt3) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:588:12: '0' .. '9'
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:588:12: '0' .. '9'
             			    {
             			    	MatchRange('0','9'); 
 
@@ -1632,7 +1657,7 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = FLOAT_WO_EXP;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:600:5: ( ( '-' )? ( '0' .. '9' )+ '.' ( '0' .. '9' )* | ( '-' )? '.' ( '0' .. '9' )+ )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:600:5: ( ( '-' )? ( '0' .. '9' )+ '.' ( '0' .. '9' )* | ( '-' )? '.' ( '0' .. '9' )+ )
             int alt9 = 2;
             switch ( input.LA(1) ) 
             {
@@ -1640,13 +1665,13 @@ public partial class simpletikzLexer : Lexer {
             	{
                 int LA9_1 = input.LA(2);
 
-                if ( (LA9_1 == '.') )
-                {
-                    alt9 = 2;
-                }
-                else if ( ((LA9_1 >= '0' && LA9_1 <= '9')) )
+                if ( ((LA9_1 >= '0' && LA9_1 <= '9')) )
                 {
                     alt9 = 1;
+                }
+                else if ( (LA9_1 == '.') )
+                {
+                    alt9 = 2;
                 }
                 else 
                 {
@@ -1686,9 +1711,9 @@ public partial class simpletikzLexer : Lexer {
             switch (alt9) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:600:9: ( '-' )? ( '0' .. '9' )+ '.' ( '0' .. '9' )*
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:600:9: ( '-' )? ( '0' .. '9' )+ '.' ( '0' .. '9' )*
                     {
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:600:9: ( '-' )?
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:600:9: ( '-' )?
                     	int alt4 = 2;
                     	int LA4_0 = input.LA(1);
 
@@ -1699,7 +1724,7 @@ public partial class simpletikzLexer : Lexer {
                     	switch (alt4) 
                     	{
                     	    case 1 :
-                    	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:600:9: '-'
+                    	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:600:9: '-'
                     	        {
                     	        	Match('-'); 
 
@@ -1708,7 +1733,7 @@ public partial class simpletikzLexer : Lexer {
 
                     	}
 
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:600:14: ( '0' .. '9' )+
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:600:14: ( '0' .. '9' )+
                     	int cnt5 = 0;
                     	do 
                     	{
@@ -1724,7 +1749,7 @@ public partial class simpletikzLexer : Lexer {
                     	    switch (alt5) 
                     		{
                     			case 1 :
-                    			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:600:15: '0' .. '9'
+                    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:600:15: '0' .. '9'
                     			    {
                     			    	MatchRange('0','9'); 
 
@@ -1744,7 +1769,7 @@ public partial class simpletikzLexer : Lexer {
                     		;	// Stops C# compiler whinging that label 'loop5' has no statements
 
                     	Match('.'); 
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:600:30: ( '0' .. '9' )*
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:600:30: ( '0' .. '9' )*
                     	do 
                     	{
                     	    int alt6 = 2;
@@ -1759,7 +1784,7 @@ public partial class simpletikzLexer : Lexer {
                     	    switch (alt6) 
                     		{
                     			case 1 :
-                    			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:600:31: '0' .. '9'
+                    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:600:31: '0' .. '9'
                     			    {
                     			    	MatchRange('0','9'); 
 
@@ -1778,9 +1803,9 @@ public partial class simpletikzLexer : Lexer {
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:601:9: ( '-' )? '.' ( '0' .. '9' )+
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:601:9: ( '-' )? '.' ( '0' .. '9' )+
                     {
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:601:9: ( '-' )?
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:601:9: ( '-' )?
                     	int alt7 = 2;
                     	int LA7_0 = input.LA(1);
 
@@ -1791,7 +1816,7 @@ public partial class simpletikzLexer : Lexer {
                     	switch (alt7) 
                     	{
                     	    case 1 :
-                    	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:601:9: '-'
+                    	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:601:9: '-'
                     	        {
                     	        	Match('-'); 
 
@@ -1801,7 +1826,7 @@ public partial class simpletikzLexer : Lexer {
                     	}
 
                     	Match('.'); 
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:601:18: ( '0' .. '9' )+
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:601:18: ( '0' .. '9' )+
                     	int cnt8 = 0;
                     	do 
                     	{
@@ -1817,7 +1842,7 @@ public partial class simpletikzLexer : Lexer {
                     	    switch (alt8) 
                     		{
                     			case 1 :
-                    			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:601:19: '0' .. '9'
+                    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:601:19: '0' .. '9'
                     			    {
                     			    	MatchRange('0','9'); 
 
@@ -1857,14 +1882,14 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = TIKZEDT_CMD_COMMENT;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:605:5: ( '%' WS '!TIKZEDT' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:605:9: '%' WS '!TIKZEDT' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:605:5: ( '%' WS '!TIKZEDT' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:605:9: '%' WS '!TIKZEDT' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n'
             {
             	Match('%'); 
             	mWS(); 
             	Match("!TIKZEDT"); 
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:605:29: (~ ( '\\n' | '\\r' ) )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:605:29: (~ ( '\\n' | '\\r' ) )*
             	do 
             	{
             	    int alt10 = 2;
@@ -1879,7 +1904,7 @@ public partial class simpletikzLexer : Lexer {
             	    switch (alt10) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:605:29: ~ ( '\\n' | '\\r' )
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:605:29: ~ ( '\\n' | '\\r' )
             			    {
             			    	if ( (input.LA(1) >= '\u0000' && input.LA(1) <= '\t') || (input.LA(1) >= '\u000B' && input.LA(1) <= '\f') || (input.LA(1) >= '\u000E' && input.LA(1) <= '\uFFFF') ) 
             			    	{
@@ -1904,7 +1929,7 @@ public partial class simpletikzLexer : Lexer {
             	loop10:
             		;	// Stops C# compiler whining that label 'loop10' has no statements
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:605:43: ( '\\r' )?
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:605:43: ( '\\r' )?
             	int alt11 = 2;
             	int LA11_0 = input.LA(1);
 
@@ -1915,7 +1940,7 @@ public partial class simpletikzLexer : Lexer {
             	switch (alt11) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:605:43: '\\r'
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:605:43: '\\r'
             	        {
             	        	Match('\r'); 
 
@@ -1944,16 +1969,16 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = COMMENT;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:609:5: ( '%' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n' | '%/*' ( options {greedy=false; } : . )* '%*/' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:609:5: ( '%' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n' | '%/*' ( options {greedy=false; } : . )* '%*/' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n' )
             int alt17 = 2;
             alt17 = dfa17.Predict(input);
             switch (alt17) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:609:9: '%' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n'
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:609:9: '%' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n'
                     {
                     	Match('%'); 
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:609:13: (~ ( '\\n' | '\\r' ) )*
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:609:13: (~ ( '\\n' | '\\r' ) )*
                     	do 
                     	{
                     	    int alt12 = 2;
@@ -1968,7 +1993,7 @@ public partial class simpletikzLexer : Lexer {
                     	    switch (alt12) 
                     		{
                     			case 1 :
-                    			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:609:13: ~ ( '\\n' | '\\r' )
+                    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:609:13: ~ ( '\\n' | '\\r' )
                     			    {
                     			    	if ( (input.LA(1) >= '\u0000' && input.LA(1) <= '\t') || (input.LA(1) >= '\u000B' && input.LA(1) <= '\f') || (input.LA(1) >= '\u000E' && input.LA(1) <= '\uFFFF') ) 
                     			    	{
@@ -1993,7 +2018,7 @@ public partial class simpletikzLexer : Lexer {
                     	loop12:
                     		;	// Stops C# compiler whining that label 'loop12' has no statements
 
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:609:27: ( '\\r' )?
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:609:27: ( '\\r' )?
                     	int alt13 = 2;
                     	int LA13_0 = input.LA(1);
 
@@ -2004,7 +2029,7 @@ public partial class simpletikzLexer : Lexer {
                     	switch (alt13) 
                     	{
                     	    case 1 :
-                    	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:609:27: '\\r'
+                    	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:609:27: '\\r'
                     	        {
                     	        	Match('\r'); 
 
@@ -2019,11 +2044,11 @@ public partial class simpletikzLexer : Lexer {
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:610:9: '%/*' ( options {greedy=false; } : . )* '%*/' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n'
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:610:9: '%/*' ( options {greedy=false; } : . )* '%*/' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n'
                     {
                     	Match("%/*"); 
 
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:610:15: ( options {greedy=false; } : . )*
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:610:15: ( options {greedy=false; } : . )*
                     	do 
                     	{
                     	    int alt14 = 2;
@@ -2031,7 +2056,7 @@ public partial class simpletikzLexer : Lexer {
                     	    switch (alt14) 
                     		{
                     			case 1 :
-                    			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:610:43: .
+                    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:610:43: .
                     			    {
                     			    	MatchAny(); 
 
@@ -2048,7 +2073,7 @@ public partial class simpletikzLexer : Lexer {
 
                     	Match("%*/"); 
 
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:610:54: (~ ( '\\n' | '\\r' ) )*
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:610:54: (~ ( '\\n' | '\\r' ) )*
                     	do 
                     	{
                     	    int alt15 = 2;
@@ -2063,7 +2088,7 @@ public partial class simpletikzLexer : Lexer {
                     	    switch (alt15) 
                     		{
                     			case 1 :
-                    			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:610:54: ~ ( '\\n' | '\\r' )
+                    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:610:54: ~ ( '\\n' | '\\r' )
                     			    {
                     			    	if ( (input.LA(1) >= '\u0000' && input.LA(1) <= '\t') || (input.LA(1) >= '\u000B' && input.LA(1) <= '\f') || (input.LA(1) >= '\u000E' && input.LA(1) <= '\uFFFF') ) 
                     			    	{
@@ -2088,7 +2113,7 @@ public partial class simpletikzLexer : Lexer {
                     	loop15:
                     		;	// Stops C# compiler whining that label 'loop15' has no statements
 
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:610:68: ( '\\r' )?
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:610:68: ( '\\r' )?
                     	int alt16 = 2;
                     	int LA16_0 = input.LA(1);
 
@@ -2099,7 +2124,7 @@ public partial class simpletikzLexer : Lexer {
                     	switch (alt16) 
                     	{
                     	    case 1 :
-                    	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:610:68: '\\r'
+                    	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:610:68: '\\r'
                     	        {
                     	        	Match('\r'); 
 
@@ -2131,8 +2156,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = WS;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:613:5: ( ( ' ' | '\\t' | '\\r' | '\\n' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:613:9: ( ' ' | '\\t' | '\\r' | '\\n' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:613:5: ( ( ' ' | '\\t' | '\\r' | '\\n' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:613:9: ( ' ' | '\\t' | '\\r' | '\\n' )
             {
             	if ( (input.LA(1) >= '\t' && input.LA(1) <= '\n') || input.LA(1) == '\r' || input.LA(1) == ' ' ) 
             	{
@@ -2163,8 +2188,8 @@ public partial class simpletikzLexer : Lexer {
     {
     		try
     		{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:620:19: ( ( 'e' | 'E' ) ( '+' | '-' )? ( '0' .. '9' )+ )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:620:21: ( 'e' | 'E' ) ( '+' | '-' )? ( '0' .. '9' )+
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:620:19: ( ( 'e' | 'E' ) ( '+' | '-' )? ( '0' .. '9' )+ )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:620:21: ( 'e' | 'E' ) ( '+' | '-' )? ( '0' .. '9' )+
             {
             	if ( input.LA(1) == 'E' || input.LA(1) == 'e' ) 
             	{
@@ -2177,7 +2202,7 @@ public partial class simpletikzLexer : Lexer {
             	    Recover(mse);
             	    throw mse;}
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:620:31: ( '+' | '-' )?
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:620:31: ( '+' | '-' )?
             	int alt18 = 2;
             	int LA18_0 = input.LA(1);
 
@@ -2188,7 +2213,7 @@ public partial class simpletikzLexer : Lexer {
             	switch (alt18) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:
             	        {
             	        	if ( input.LA(1) == '+' || input.LA(1) == '-' ) 
             	        	{
@@ -2207,7 +2232,7 @@ public partial class simpletikzLexer : Lexer {
 
             	}
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:620:42: ( '0' .. '9' )+
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:620:42: ( '0' .. '9' )+
             	int cnt19 = 0;
             	do 
             	{
@@ -2223,7 +2248,7 @@ public partial class simpletikzLexer : Lexer {
             	    switch (alt19) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:620:43: '0' .. '9'
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:620:43: '0' .. '9'
             			    {
             			    	MatchRange('0','9'); 
 
@@ -2259,11 +2284,11 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = MATHSTRING;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:627:2: ( '$' ( ESC_SEQ | ~ ( '\\\\' | '$' ) )* '$' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:627:4: '$' ( ESC_SEQ | ~ ( '\\\\' | '$' ) )* '$'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:627:2: ( '$' ( ESC_SEQ | ~ ( '\\\\' | '$' ) )* '$' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:627:4: '$' ( ESC_SEQ | ~ ( '\\\\' | '$' ) )* '$'
             {
             	Match('$'); 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:627:8: ( ESC_SEQ | ~ ( '\\\\' | '$' ) )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:627:8: ( ESC_SEQ | ~ ( '\\\\' | '$' ) )*
             	do 
             	{
             	    int alt20 = 3;
@@ -2282,14 +2307,14 @@ public partial class simpletikzLexer : Lexer {
             	    switch (alt20) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:627:10: ESC_SEQ
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:627:10: ESC_SEQ
             			    {
             			    	mESC_SEQ(); 
 
             			    }
             			    break;
             			case 2 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:627:20: ~ ( '\\\\' | '$' )
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:627:20: ~ ( '\\\\' | '$' )
             			    {
             			    	if ( (input.LA(1) >= '\u0000' && input.LA(1) <= '#') || (input.LA(1) >= '%' && input.LA(1) <= '[') || (input.LA(1) >= ']' && input.LA(1) <= '\uFFFF') ) 
             			    	{
@@ -2334,8 +2359,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = COMMAND;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:638:2: ( '\\\\' ID )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:638:4: '\\\\' ID
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:638:2: ( '\\\\' ID )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:638:4: '\\\\' ID
             {
             	Match('\\'); 
             	mID(); 
@@ -2358,8 +2383,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = ESC_SEQ;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:643:5: ( '\\\\' . )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:643:9: '\\\\' .
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:643:5: ( '\\\\' . )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:643:9: '\\\\' .
             {
             	Match('\\'); 
             	MatchAny(); 
@@ -2382,8 +2407,8 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = SOMETHING;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:649:2: ( . )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:649:5: .
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:649:2: ( . )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:649:5: .
             {
             	MatchAny(); 
 
@@ -2405,12 +2430,12 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = SOMETHING1;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:653:2: ( '/.' ( 'a' .. 'z' | 'A' .. 'Z' )* )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:653:7: '/.' ( 'a' .. 'z' | 'A' .. 'Z' )*
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:653:2: ( '/.' ( 'a' .. 'z' | 'A' .. 'Z' )* )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:653:7: '/.' ( 'a' .. 'z' | 'A' .. 'Z' )*
             {
             	Match("/."); 
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:653:12: ( 'a' .. 'z' | 'A' .. 'Z' )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:653:12: ( 'a' .. 'z' | 'A' .. 'Z' )*
             	do 
             	{
             	    int alt21 = 2;
@@ -2425,7 +2450,7 @@ public partial class simpletikzLexer : Lexer {
             	    switch (alt21) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:
             			    {
             			    	if ( (input.LA(1) >= 'A' && input.LA(1) <= 'Z') || (input.LA(1) >= 'a' && input.LA(1) <= 'z') ) 
             			    	{
@@ -2464,475 +2489,482 @@ public partial class simpletikzLexer : Lexer {
 
     override public void mTokens() // throws RecognitionException 
     {
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:8: ( T__39 | T__40 | T__41 | T__42 | T__43 | T__44 | T__45 | T__46 | T__47 | T__48 | T__49 | T__50 | T__51 | T__52 | T__53 | T__54 | T__55 | T__56 | T__57 | T__58 | T__59 | T__60 | T__61 | T__62 | T__63 | T__64 | T__65 | T__66 | T__67 | T__68 | T__69 | T__70 | T__71 | T__72 | T__73 | T__74 | T__75 | T__76 | T__77 | T__78 | T__79 | T__80 | T__81 | T__82 | T__83 | T__84 | T__85 | T__86 | T__87 | T__88 | T__89 | T__90 | T__91 | T__92 | T__93 | T__94 | ID | INT | FLOAT_WO_EXP | TIKZEDT_CMD_COMMENT | COMMENT | WS | MATHSTRING | COMMAND | ESC_SEQ | SOMETHING | SOMETHING1 )
-        int alt22 = 67;
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:8: ( T__39 | T__40 | T__41 | T__42 | T__43 | T__44 | T__45 | T__46 | T__47 | T__48 | T__49 | T__50 | T__51 | T__52 | T__53 | T__54 | T__55 | T__56 | T__57 | T__58 | T__59 | T__60 | T__61 | T__62 | T__63 | T__64 | T__65 | T__66 | T__67 | T__68 | T__69 | T__70 | T__71 | T__72 | T__73 | T__74 | T__75 | T__76 | T__77 | T__78 | T__79 | T__80 | T__81 | T__82 | T__83 | T__84 | T__85 | T__86 | T__87 | T__88 | T__89 | T__90 | T__91 | T__92 | T__93 | T__94 | T__95 | ID | INT | FLOAT_WO_EXP | TIKZEDT_CMD_COMMENT | COMMENT | WS | MATHSTRING | COMMAND | ESC_SEQ | SOMETHING | SOMETHING1 )
+        int alt22 = 68;
         alt22 = dfa22.Predict(input);
         switch (alt22) 
         {
             case 1 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:10: T__39
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:10: T__39
                 {
                 	mT__39(); 
 
                 }
                 break;
             case 2 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:16: T__40
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:16: T__40
                 {
                 	mT__40(); 
 
                 }
                 break;
             case 3 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:22: T__41
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:22: T__41
                 {
                 	mT__41(); 
 
                 }
                 break;
             case 4 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:28: T__42
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:28: T__42
                 {
                 	mT__42(); 
 
                 }
                 break;
             case 5 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:34: T__43
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:34: T__43
                 {
                 	mT__43(); 
 
                 }
                 break;
             case 6 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:40: T__44
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:40: T__44
                 {
                 	mT__44(); 
 
                 }
                 break;
             case 7 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:46: T__45
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:46: T__45
                 {
                 	mT__45(); 
 
                 }
                 break;
             case 8 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:52: T__46
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:52: T__46
                 {
                 	mT__46(); 
 
                 }
                 break;
             case 9 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:58: T__47
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:58: T__47
                 {
                 	mT__47(); 
 
                 }
                 break;
             case 10 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:64: T__48
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:64: T__48
                 {
                 	mT__48(); 
 
                 }
                 break;
             case 11 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:70: T__49
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:70: T__49
                 {
                 	mT__49(); 
 
                 }
                 break;
             case 12 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:76: T__50
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:76: T__50
                 {
                 	mT__50(); 
 
                 }
                 break;
             case 13 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:82: T__51
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:82: T__51
                 {
                 	mT__51(); 
 
                 }
                 break;
             case 14 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:88: T__52
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:88: T__52
                 {
                 	mT__52(); 
 
                 }
                 break;
             case 15 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:94: T__53
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:94: T__53
                 {
                 	mT__53(); 
 
                 }
                 break;
             case 16 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:100: T__54
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:100: T__54
                 {
                 	mT__54(); 
 
                 }
                 break;
             case 17 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:106: T__55
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:106: T__55
                 {
                 	mT__55(); 
 
                 }
                 break;
             case 18 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:112: T__56
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:112: T__56
                 {
                 	mT__56(); 
 
                 }
                 break;
             case 19 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:118: T__57
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:118: T__57
                 {
                 	mT__57(); 
 
                 }
                 break;
             case 20 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:124: T__58
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:124: T__58
                 {
                 	mT__58(); 
 
                 }
                 break;
             case 21 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:130: T__59
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:130: T__59
                 {
                 	mT__59(); 
 
                 }
                 break;
             case 22 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:136: T__60
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:136: T__60
                 {
                 	mT__60(); 
 
                 }
                 break;
             case 23 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:142: T__61
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:142: T__61
                 {
                 	mT__61(); 
 
                 }
                 break;
             case 24 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:148: T__62
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:148: T__62
                 {
                 	mT__62(); 
 
                 }
                 break;
             case 25 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:154: T__63
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:154: T__63
                 {
                 	mT__63(); 
 
                 }
                 break;
             case 26 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:160: T__64
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:160: T__64
                 {
                 	mT__64(); 
 
                 }
                 break;
             case 27 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:166: T__65
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:166: T__65
                 {
                 	mT__65(); 
 
                 }
                 break;
             case 28 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:172: T__66
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:172: T__66
                 {
                 	mT__66(); 
 
                 }
                 break;
             case 29 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:178: T__67
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:178: T__67
                 {
                 	mT__67(); 
 
                 }
                 break;
             case 30 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:184: T__68
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:184: T__68
                 {
                 	mT__68(); 
 
                 }
                 break;
             case 31 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:190: T__69
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:190: T__69
                 {
                 	mT__69(); 
 
                 }
                 break;
             case 32 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:196: T__70
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:196: T__70
                 {
                 	mT__70(); 
 
                 }
                 break;
             case 33 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:202: T__71
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:202: T__71
                 {
                 	mT__71(); 
 
                 }
                 break;
             case 34 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:208: T__72
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:208: T__72
                 {
                 	mT__72(); 
 
                 }
                 break;
             case 35 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:214: T__73
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:214: T__73
                 {
                 	mT__73(); 
 
                 }
                 break;
             case 36 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:220: T__74
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:220: T__74
                 {
                 	mT__74(); 
 
                 }
                 break;
             case 37 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:226: T__75
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:226: T__75
                 {
                 	mT__75(); 
 
                 }
                 break;
             case 38 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:232: T__76
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:232: T__76
                 {
                 	mT__76(); 
 
                 }
                 break;
             case 39 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:238: T__77
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:238: T__77
                 {
                 	mT__77(); 
 
                 }
                 break;
             case 40 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:244: T__78
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:244: T__78
                 {
                 	mT__78(); 
 
                 }
                 break;
             case 41 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:250: T__79
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:250: T__79
                 {
                 	mT__79(); 
 
                 }
                 break;
             case 42 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:256: T__80
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:256: T__80
                 {
                 	mT__80(); 
 
                 }
                 break;
             case 43 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:262: T__81
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:262: T__81
                 {
                 	mT__81(); 
 
                 }
                 break;
             case 44 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:268: T__82
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:268: T__82
                 {
                 	mT__82(); 
 
                 }
                 break;
             case 45 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:274: T__83
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:274: T__83
                 {
                 	mT__83(); 
 
                 }
                 break;
             case 46 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:280: T__84
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:280: T__84
                 {
                 	mT__84(); 
 
                 }
                 break;
             case 47 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:286: T__85
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:286: T__85
                 {
                 	mT__85(); 
 
                 }
                 break;
             case 48 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:292: T__86
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:292: T__86
                 {
                 	mT__86(); 
 
                 }
                 break;
             case 49 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:298: T__87
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:298: T__87
                 {
                 	mT__87(); 
 
                 }
                 break;
             case 50 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:304: T__88
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:304: T__88
                 {
                 	mT__88(); 
 
                 }
                 break;
             case 51 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:310: T__89
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:310: T__89
                 {
                 	mT__89(); 
 
                 }
                 break;
             case 52 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:316: T__90
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:316: T__90
                 {
                 	mT__90(); 
 
                 }
                 break;
             case 53 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:322: T__91
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:322: T__91
                 {
                 	mT__91(); 
 
                 }
                 break;
             case 54 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:328: T__92
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:328: T__92
                 {
                 	mT__92(); 
 
                 }
                 break;
             case 55 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:334: T__93
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:334: T__93
                 {
                 	mT__93(); 
 
                 }
                 break;
             case 56 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:340: T__94
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:340: T__94
                 {
                 	mT__94(); 
 
                 }
                 break;
             case 57 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:346: ID
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:346: T__95
+                {
+                	mT__95(); 
+
+                }
+                break;
+            case 58 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:352: ID
                 {
                 	mID(); 
 
                 }
                 break;
-            case 58 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:349: INT
+            case 59 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:355: INT
                 {
                 	mINT(); 
 
                 }
                 break;
-            case 59 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:353: FLOAT_WO_EXP
+            case 60 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:359: FLOAT_WO_EXP
                 {
                 	mFLOAT_WO_EXP(); 
 
                 }
                 break;
-            case 60 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:366: TIKZEDT_CMD_COMMENT
+            case 61 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:372: TIKZEDT_CMD_COMMENT
                 {
                 	mTIKZEDT_CMD_COMMENT(); 
 
                 }
                 break;
-            case 61 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:386: COMMENT
+            case 62 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:392: COMMENT
                 {
                 	mCOMMENT(); 
 
                 }
                 break;
-            case 62 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:394: WS
+            case 63 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:400: WS
                 {
                 	mWS(); 
 
                 }
                 break;
-            case 63 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:397: MATHSTRING
+            case 64 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:403: MATHSTRING
                 {
                 	mMATHSTRING(); 
 
                 }
                 break;
-            case 64 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:408: COMMAND
+            case 65 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:414: COMMAND
                 {
                 	mCOMMAND(); 
 
                 }
                 break;
-            case 65 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:416: ESC_SEQ
+            case 66 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:422: ESC_SEQ
                 {
                 	mESC_SEQ(); 
 
                 }
                 break;
-            case 66 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:424: SOMETHING
+            case 67 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:430: SOMETHING
                 {
                 	mSOMETHING(); 
 
                 }
                 break;
-            case 67 :
-                // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:1:434: SOMETHING1
+            case 68 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:440: SOMETHING1
                 {
                 	mSOMETHING1(); 
 
@@ -2962,17 +2994,17 @@ public partial class simpletikzLexer : Lexer {
     const string DFA17_eofS =
         "\x12\uffff";
     const string DFA17_minS =
-        "\x01\x25\x02\x00\x01\uffff\x05\x00\x01\uffff\x04\x00\x01\uffff"+
-        "\x03\x00";
+        "\x01\x25\x02\x00\x01\uffff\x05\x00\x01\uffff\x03\x00\x01\uffff"+
+        "\x04\x00";
     const string DFA17_maxS =
-        "\x01\x25\x02\uffff\x01\uffff\x05\uffff\x01\uffff\x04\uffff\x01"+
-        "\uffff\x03\uffff";
+        "\x01\x25\x02\uffff\x01\uffff\x05\uffff\x01\uffff\x03\uffff\x01"+
+        "\uffff\x04\uffff";
     const string DFA17_acceptS =
-        "\x03\uffff\x01\x01\x05\uffff\x01\x02\x04\uffff\x01\x01\x03\uffff";
+        "\x03\uffff\x01\x01\x05\uffff\x01\x02\x03\uffff\x01\x01\x04\uffff";
     const string DFA17_specialS =
-        "\x01\uffff\x01\x05\x01\x06\x01\uffff\x01\x0a\x01\x0c\x01\x09\x01"+
-        "\x01\x01\x07\x01\uffff\x01\x03\x01\x02\x01\x04\x01\x0d\x01\uffff"+
-        "\x01\x0b\x01\x00\x01\x08}>";
+        "\x01\uffff\x01\x01\x01\x0c\x01\uffff\x01\x04\x01\x08\x01\x0b\x01"+
+        "\x02\x01\x09\x01\uffff\x01\x03\x01\x0a\x01\x05\x01\uffff\x01\x0d"+
+        "\x01\x07\x01\x00\x01\x06}>";
     static readonly string[] DFA17_transitionS = {
             "\x01\x01",
             "\x2f\x03\x01\x02\uffd0\x03",
@@ -2987,15 +3019,15 @@ public partial class simpletikzLexer : Lexer {
             "",
             "\x0a\x08\x01\x06\x02\x08\x01\x05\x17\x08\x01\x07\x09\x08\x01"+
             "\x0b\uffd0\x08",
-            "\x0a\x0f\x01\x0e\x02\x0f\x01\x0d\x17\x0f\x01\x0c\uffda\x0f",
-            "\x0a\x0f\x01\x0e\x02\x0f\x01\x0d\x17\x0f\x01\x0c\x04\x0f\x01"+
-            "\x10\uffd5\x0f",
-            "\x0a\x09\x01\x0e\ufff5\x09",
+            "\x0a\x0f\x01\x0d\x02\x0f\x01\x0c\x17\x0f\x01\x0e\uffda\x0f",
+            "\x0a\x09\x01\x0d\ufff5\x09",
             "",
-            "\x0a\x0f\x01\x0e\x02\x0f\x01\x0d\x17\x0f\x01\x0c\uffda\x0f",
-            "\x0a\x0f\x01\x0e\x02\x0f\x01\x0d\x17\x0f\x01\x0c\x09\x0f\x01"+
+            "\x0a\x0f\x01\x0d\x02\x0f\x01\x0c\x17\x0f\x01\x0e\x04\x0f\x01"+
+            "\x10\uffd5\x0f",
+            "\x0a\x0f\x01\x0d\x02\x0f\x01\x0c\x17\x0f\x01\x0e\uffda\x0f",
+            "\x0a\x0f\x01\x0d\x02\x0f\x01\x0c\x17\x0f\x01\x0e\x09\x0f\x01"+
             "\x11\uffd0\x0f",
-            "\x0a\x0f\x01\x0e\x02\x0f\x01\x0d\x17\x0f\x01\x0c\uffda\x0f"
+            "\x0a\x0f\x01\x0d\x02\x0f\x01\x0c\x17\x0f\x01\x0e\uffda\x0f"
     };
 
     static readonly short[] DFA17_eot = DFA.UnpackEncodedString(DFA17_eotS);
@@ -3042,17 +3074,27 @@ public partial class simpletikzLexer : Lexer {
                    	s = -1;
                    	if ( (LA17_16 == '/') ) { s = 17; }
 
-                   	else if ( (LA17_16 == '\r') ) { s = 13; }
+                   	else if ( (LA17_16 == '\r') ) { s = 12; }
 
-                   	else if ( (LA17_16 == '\n') ) { s = 14; }
+                   	else if ( (LA17_16 == '\n') ) { s = 13; }
 
-                   	else if ( (LA17_16 == '%') ) { s = 12; }
+                   	else if ( (LA17_16 == '%') ) { s = 14; }
 
                    	else if ( ((LA17_16 >= '\u0000' && LA17_16 <= '\t') || (LA17_16 >= '\u000B' && LA17_16 <= '\f') || (LA17_16 >= '\u000E' && LA17_16 <= '$') || (LA17_16 >= '&' && LA17_16 <= '.') || (LA17_16 >= '0' && LA17_16 <= '\uFFFF')) ) { s = 15; }
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 1 : 
+                   	int LA17_1 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_1 == '/') ) { s = 2; }
+
+                   	else if ( ((LA17_1 >= '\u0000' && LA17_1 <= '.') || (LA17_1 >= '0' && LA17_1 <= '\uFFFF')) ) { s = 3; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 2 : 
                    	int LA17_7 = input.LA(1);
 
                    	s = -1;
@@ -3065,20 +3107,6 @@ public partial class simpletikzLexer : Lexer {
                    	else if ( (LA17_7 == '%') ) { s = 7; }
 
                    	else if ( ((LA17_7 >= '\u0000' && LA17_7 <= '\t') || (LA17_7 >= '\u000B' && LA17_7 <= '\f') || (LA17_7 >= '\u000E' && LA17_7 <= '$') || (LA17_7 >= '&' && LA17_7 <= ')') || (LA17_7 >= '+' && LA17_7 <= '\uFFFF')) ) { s = 8; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 2 : 
-                   	int LA17_11 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA17_11 == '%') ) { s = 12; }
-
-                   	else if ( (LA17_11 == '\r') ) { s = 13; }
-
-                   	else if ( (LA17_11 == '\n') ) { s = 14; }
-
-                   	else if ( ((LA17_11 >= '\u0000' && LA17_11 <= '\t') || (LA17_11 >= '\u000B' && LA17_11 <= '\f') || (LA17_11 >= '\u000E' && LA17_11 <= '$') || (LA17_11 >= '&' && LA17_11 <= '\uFFFF')) ) { s = 15; }
 
                    	if ( s >= 0 ) return s;
                    	break;
@@ -3099,80 +3127,6 @@ public partial class simpletikzLexer : Lexer {
                    	if ( s >= 0 ) return s;
                    	break;
                	case 4 : 
-                   	int LA17_12 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA17_12 == '*') ) { s = 16; }
-
-                   	else if ( (LA17_12 == '\r') ) { s = 13; }
-
-                   	else if ( (LA17_12 == '\n') ) { s = 14; }
-
-                   	else if ( (LA17_12 == '%') ) { s = 12; }
-
-                   	else if ( ((LA17_12 >= '\u0000' && LA17_12 <= '\t') || (LA17_12 >= '\u000B' && LA17_12 <= '\f') || (LA17_12 >= '\u000E' && LA17_12 <= '$') || (LA17_12 >= '&' && LA17_12 <= ')') || (LA17_12 >= '+' && LA17_12 <= '\uFFFF')) ) { s = 15; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 5 : 
-                   	int LA17_1 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA17_1 == '/') ) { s = 2; }
-
-                   	else if ( ((LA17_1 >= '\u0000' && LA17_1 <= '.') || (LA17_1 >= '0' && LA17_1 <= '\uFFFF')) ) { s = 3; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 6 : 
-                   	int LA17_2 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA17_2 == '*') ) { s = 4; }
-
-                   	else if ( ((LA17_2 >= '\u0000' && LA17_2 <= ')') || (LA17_2 >= '+' && LA17_2 <= '\uFFFF')) ) { s = 3; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 7 : 
-                   	int LA17_8 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA17_8 == '\r') ) { s = 5; }
-
-                   	else if ( (LA17_8 == '\n') ) { s = 6; }
-
-                   	else if ( (LA17_8 == '%') ) { s = 7; }
-
-                   	else if ( ((LA17_8 >= '\u0000' && LA17_8 <= '\t') || (LA17_8 >= '\u000B' && LA17_8 <= '\f') || (LA17_8 >= '\u000E' && LA17_8 <= '$') || (LA17_8 >= '&' && LA17_8 <= '\uFFFF')) ) { s = 8; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 8 : 
-                   	int LA17_17 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA17_17 == '%') ) { s = 12; }
-
-                   	else if ( (LA17_17 == '\r') ) { s = 13; }
-
-                   	else if ( (LA17_17 == '\n') ) { s = 14; }
-
-                   	else if ( ((LA17_17 >= '\u0000' && LA17_17 <= '\t') || (LA17_17 >= '\u000B' && LA17_17 <= '\f') || (LA17_17 >= '\u000E' && LA17_17 <= '$') || (LA17_17 >= '&' && LA17_17 <= '\uFFFF')) ) { s = 15; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 9 : 
-                   	int LA17_6 = input.LA(1);
-
-                   	s = -1;
-                   	if ( ((LA17_6 >= '\u0000' && LA17_6 <= '\uFFFF')) ) { s = 9; }
-
-                   	else s = 3;
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 10 : 
                    	int LA17_4 = input.LA(1);
 
                    	s = -1;
@@ -3186,37 +3140,115 @@ public partial class simpletikzLexer : Lexer {
 
                    	if ( s >= 0 ) return s;
                    	break;
-               	case 11 : 
+               	case 5 : 
+                   	int LA17_12 = input.LA(1);
+
+                   	s = -1;
+                   	if ( ((LA17_12 >= '\u0000' && LA17_12 <= '\t') || (LA17_12 >= '\u000B' && LA17_12 <= '\uFFFF')) ) { s = 9; }
+
+                   	else if ( (LA17_12 == '\n') ) { s = 13; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 6 : 
+                   	int LA17_17 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_17 == '\r') ) { s = 12; }
+
+                   	else if ( (LA17_17 == '\n') ) { s = 13; }
+
+                   	else if ( (LA17_17 == '%') ) { s = 14; }
+
+                   	else if ( ((LA17_17 >= '\u0000' && LA17_17 <= '\t') || (LA17_17 >= '\u000B' && LA17_17 <= '\f') || (LA17_17 >= '\u000E' && LA17_17 <= '$') || (LA17_17 >= '&' && LA17_17 <= '\uFFFF')) ) { s = 15; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 7 : 
                    	int LA17_15 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA17_15 == '\r') ) { s = 13; }
+                   	if ( (LA17_15 == '\r') ) { s = 12; }
 
-                   	else if ( (LA17_15 == '\n') ) { s = 14; }
+                   	else if ( (LA17_15 == '\n') ) { s = 13; }
 
-                   	else if ( (LA17_15 == '%') ) { s = 12; }
+                   	else if ( (LA17_15 == '%') ) { s = 14; }
 
                    	else if ( ((LA17_15 >= '\u0000' && LA17_15 <= '\t') || (LA17_15 >= '\u000B' && LA17_15 <= '\f') || (LA17_15 >= '\u000E' && LA17_15 <= '$') || (LA17_15 >= '&' && LA17_15 <= '\uFFFF')) ) { s = 15; }
 
                    	if ( s >= 0 ) return s;
                    	break;
-               	case 12 : 
+               	case 8 : 
                    	int LA17_5 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA17_5 == '\n') ) { s = 6; }
+                   	if ( ((LA17_5 >= '\u0000' && LA17_5 <= '\t') || (LA17_5 >= '\u000B' && LA17_5 <= '\uFFFF')) ) { s = 9; }
 
-                   	else if ( ((LA17_5 >= '\u0000' && LA17_5 <= '\t') || (LA17_5 >= '\u000B' && LA17_5 <= '\uFFFF')) ) { s = 9; }
+                   	else if ( (LA17_5 == '\n') ) { s = 6; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 9 : 
+                   	int LA17_8 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_8 == '\r') ) { s = 5; }
+
+                   	else if ( (LA17_8 == '\n') ) { s = 6; }
+
+                   	else if ( (LA17_8 == '%') ) { s = 7; }
+
+                   	else if ( ((LA17_8 >= '\u0000' && LA17_8 <= '\t') || (LA17_8 >= '\u000B' && LA17_8 <= '\f') || (LA17_8 >= '\u000E' && LA17_8 <= '$') || (LA17_8 >= '&' && LA17_8 <= '\uFFFF')) ) { s = 8; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 10 : 
+                   	int LA17_11 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_11 == '\r') ) { s = 12; }
+
+                   	else if ( (LA17_11 == '\n') ) { s = 13; }
+
+                   	else if ( (LA17_11 == '%') ) { s = 14; }
+
+                   	else if ( ((LA17_11 >= '\u0000' && LA17_11 <= '\t') || (LA17_11 >= '\u000B' && LA17_11 <= '\f') || (LA17_11 >= '\u000E' && LA17_11 <= '$') || (LA17_11 >= '&' && LA17_11 <= '\uFFFF')) ) { s = 15; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 11 : 
+                   	int LA17_6 = input.LA(1);
+
+                   	s = -1;
+                   	if ( ((LA17_6 >= '\u0000' && LA17_6 <= '\uFFFF')) ) { s = 9; }
+
+                   	else s = 3;
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 12 : 
+                   	int LA17_2 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_2 == '*') ) { s = 4; }
+
+                   	else if ( ((LA17_2 >= '\u0000' && LA17_2 <= ')') || (LA17_2 >= '+' && LA17_2 <= '\uFFFF')) ) { s = 3; }
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 13 : 
-                   	int LA17_13 = input.LA(1);
+                   	int LA17_14 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA17_13 == '\n') ) { s = 14; }
+                   	if ( (LA17_14 == '*') ) { s = 16; }
 
-                   	else if ( ((LA17_13 >= '\u0000' && LA17_13 <= '\t') || (LA17_13 >= '\u000B' && LA17_13 <= '\uFFFF')) ) { s = 9; }
+                   	else if ( (LA17_14 == '\r') ) { s = 12; }
+
+                   	else if ( (LA17_14 == '\n') ) { s = 13; }
+
+                   	else if ( (LA17_14 == '%') ) { s = 14; }
+
+                   	else if ( ((LA17_14 >= '\u0000' && LA17_14 <= '\t') || (LA17_14 >= '\u000B' && LA17_14 <= '\f') || (LA17_14 >= '\u000E' && LA17_14 <= '$') || (LA17_14 >= '&' && LA17_14 <= ')') || (LA17_14 >= '+' && LA17_14 <= '\uFFFF')) ) { s = 15; }
 
                    	if ( s >= 0 ) return s;
                    	break;
@@ -3231,27 +3263,27 @@ public partial class simpletikzLexer : Lexer {
     const string DFA14_eofS =
         "\x0c\uffff";
     const string DFA14_minS =
-        "\x02\x00\x01\uffff\x04\x00\x01\uffff\x02\x00\x02\uffff";
+        "\x02\x00\x01\uffff\x05\x00\x01\uffff\x01\x00\x02\uffff";
     const string DFA14_maxS =
-        "\x02\uffff\x01\uffff\x04\uffff\x01\uffff\x02\uffff\x02\uffff";
+        "\x02\uffff\x01\uffff\x05\uffff\x01\uffff\x01\uffff\x02\uffff";
     const string DFA14_acceptS =
-        "\x02\uffff\x01\x01\x04\uffff\x01\x02\x02\uffff\x02\x02";
+        "\x02\uffff\x01\x01\x05\uffff\x01\x02\x01\uffff\x02\x02";
     const string DFA14_specialS =
-        "\x01\x04\x01\x05\x01\uffff\x01\x07\x01\x01\x01\x03\x01\x06\x01"+
-        "\uffff\x01\x02\x01\x00\x02\uffff}>";
+        "\x01\x00\x01\x05\x01\uffff\x01\x06\x01\x07\x01\x01\x01\x04\x01"+
+        "\x02\x01\uffff\x01\x03\x02\uffff}>";
     static readonly string[] DFA14_transitionS = {
             "\x25\x02\x01\x01\uffda\x02",
             "\x2a\x02\x01\x03\uffd5\x02",
             "",
             "\x2f\x02\x01\x04\uffd0\x02",
-            "\x0a\x08\x01\x07\x02\x08\x01\x06\x17\x08\x01\x05\uffda\x08",
-            "\x0a\x08\x01\x07\x02\x08\x01\x06\x17\x08\x01\x05\x04\x08\x01"+
-            "\x09\uffd5\x08",
-            "\x0a\x02\x01\x07\ufff5\x02",
+            "\x0a\x06\x01\x08\x02\x06\x01\x07\x17\x06\x01\x05\uffda\x06",
+            "\x0a\x06\x01\x08\x02\x06\x01\x07\x17\x06\x01\x05\x04\x06\x01"+
+            "\x09\uffd5\x06",
+            "\x0a\x06\x01\x08\x02\x06\x01\x07\x17\x06\x01\x05\uffda\x06",
+            "\x0a\x02\x01\x08\ufff5\x02",
             "",
-            "\x0a\x08\x01\x0a\x02\x08\x01\x06\x17\x08\x01\x05\uffda\x08",
-            "\x0a\x08\x01\x0a\x02\x08\x01\x06\x17\x08\x01\x05\x09\x08\x01"+
-            "\x0b\uffd0\x08",
+            "\x0a\x06\x01\x0b\x02\x06\x01\x07\x17\x06\x01\x05\x09\x06\x01"+
+            "\x0a\uffd0\x06",
             "",
             ""
     };
@@ -3295,72 +3327,68 @@ public partial class simpletikzLexer : Lexer {
         switch ( s )
         {
                	case 0 : 
-                   	int LA14_9 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA14_9 == '/') ) { s = 11; }
-
-                   	else if ( (LA14_9 == '\r') ) { s = 6; }
-
-                   	else if ( (LA14_9 == '\n') ) { s = 10; }
-
-                   	else if ( (LA14_9 == '%') ) { s = 5; }
-
-                   	else if ( ((LA14_9 >= '\u0000' && LA14_9 <= '\t') || (LA14_9 >= '\u000B' && LA14_9 <= '\f') || (LA14_9 >= '\u000E' && LA14_9 <= '$') || (LA14_9 >= '&' && LA14_9 <= '.') || (LA14_9 >= '0' && LA14_9 <= '\uFFFF')) ) { s = 8; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 1 : 
-                   	int LA14_4 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA14_4 == '%') ) { s = 5; }
-
-                   	else if ( (LA14_4 == '\r') ) { s = 6; }
-
-                   	else if ( (LA14_4 == '\n') ) { s = 7; }
-
-                   	else if ( ((LA14_4 >= '\u0000' && LA14_4 <= '\t') || (LA14_4 >= '\u000B' && LA14_4 <= '\f') || (LA14_4 >= '\u000E' && LA14_4 <= '$') || (LA14_4 >= '&' && LA14_4 <= '\uFFFF')) ) { s = 8; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 2 : 
-                   	int LA14_8 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA14_8 == '\r') ) { s = 6; }
-
-                   	else if ( (LA14_8 == '\n') ) { s = 10; }
-
-                   	else if ( (LA14_8 == '%') ) { s = 5; }
-
-                   	else if ( ((LA14_8 >= '\u0000' && LA14_8 <= '\t') || (LA14_8 >= '\u000B' && LA14_8 <= '\f') || (LA14_8 >= '\u000E' && LA14_8 <= '$') || (LA14_8 >= '&' && LA14_8 <= '\uFFFF')) ) { s = 8; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 3 : 
-                   	int LA14_5 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA14_5 == '*') ) { s = 9; }
-
-                   	else if ( (LA14_5 == '\r') ) { s = 6; }
-
-                   	else if ( (LA14_5 == '\n') ) { s = 7; }
-
-                   	else if ( (LA14_5 == '%') ) { s = 5; }
-
-                   	else if ( ((LA14_5 >= '\u0000' && LA14_5 <= '\t') || (LA14_5 >= '\u000B' && LA14_5 <= '\f') || (LA14_5 >= '\u000E' && LA14_5 <= '$') || (LA14_5 >= '&' && LA14_5 <= ')') || (LA14_5 >= '+' && LA14_5 <= '\uFFFF')) ) { s = 8; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 4 : 
                    	int LA14_0 = input.LA(1);
 
                    	s = -1;
                    	if ( (LA14_0 == '%') ) { s = 1; }
 
                    	else if ( ((LA14_0 >= '\u0000' && LA14_0 <= '$') || (LA14_0 >= '&' && LA14_0 <= '\uFFFF')) ) { s = 2; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 1 : 
+                   	int LA14_5 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA14_5 == '*') ) { s = 9; }
+
+                   	else if ( (LA14_5 == '\r') ) { s = 7; }
+
+                   	else if ( (LA14_5 == '\n') ) { s = 8; }
+
+                   	else if ( (LA14_5 == '%') ) { s = 5; }
+
+                   	else if ( ((LA14_5 >= '\u0000' && LA14_5 <= '\t') || (LA14_5 >= '\u000B' && LA14_5 <= '\f') || (LA14_5 >= '\u000E' && LA14_5 <= '$') || (LA14_5 >= '&' && LA14_5 <= ')') || (LA14_5 >= '+' && LA14_5 <= '\uFFFF')) ) { s = 6; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 2 : 
+                   	int LA14_7 = input.LA(1);
+
+                   	s = -1;
+                   	if ( ((LA14_7 >= '\u0000' && LA14_7 <= '\t') || (LA14_7 >= '\u000B' && LA14_7 <= '\uFFFF')) ) { s = 2; }
+
+                   	else if ( (LA14_7 == '\n') ) { s = 8; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 3 : 
+                   	int LA14_9 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA14_9 == '/') ) { s = 10; }
+
+                   	else if ( (LA14_9 == '\r') ) { s = 7; }
+
+                   	else if ( (LA14_9 == '\n') ) { s = 11; }
+
+                   	else if ( (LA14_9 == '%') ) { s = 5; }
+
+                   	else if ( ((LA14_9 >= '\u0000' && LA14_9 <= '\t') || (LA14_9 >= '\u000B' && LA14_9 <= '\f') || (LA14_9 >= '\u000E' && LA14_9 <= '$') || (LA14_9 >= '&' && LA14_9 <= '.') || (LA14_9 >= '0' && LA14_9 <= '\uFFFF')) ) { s = 6; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 4 : 
+                   	int LA14_6 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA14_6 == '\r') ) { s = 7; }
+
+                   	else if ( (LA14_6 == '\n') ) { s = 8; }
+
+                   	else if ( (LA14_6 == '%') ) { s = 5; }
+
+                   	else if ( ((LA14_6 >= '\u0000' && LA14_6 <= '\t') || (LA14_6 >= '\u000B' && LA14_6 <= '\f') || (LA14_6 >= '\u000E' && LA14_6 <= '$') || (LA14_6 >= '&' && LA14_6 <= '\uFFFF')) ) { s = 6; }
 
                    	if ( s >= 0 ) return s;
                    	break;
@@ -3375,22 +3403,26 @@ public partial class simpletikzLexer : Lexer {
                    	if ( s >= 0 ) return s;
                    	break;
                	case 6 : 
-                   	int LA14_6 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA14_6 == '\n') ) { s = 7; }
-
-                   	else if ( ((LA14_6 >= '\u0000' && LA14_6 <= '\t') || (LA14_6 >= '\u000B' && LA14_6 <= '\uFFFF')) ) { s = 2; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 7 : 
                    	int LA14_3 = input.LA(1);
 
                    	s = -1;
                    	if ( (LA14_3 == '/') ) { s = 4; }
 
                    	else if ( ((LA14_3 >= '\u0000' && LA14_3 <= '.') || (LA14_3 >= '0' && LA14_3 <= '\uFFFF')) ) { s = 2; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 7 : 
+                   	int LA14_4 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA14_4 == '%') ) { s = 5; }
+
+                   	else if ( ((LA14_4 >= '\u0000' && LA14_4 <= '\t') || (LA14_4 >= '\u000B' && LA14_4 <= '\f') || (LA14_4 >= '\u000E' && LA14_4 <= '$') || (LA14_4 >= '&' && LA14_4 <= '\uFFFF')) ) { s = 6; }
+
+                   	else if ( (LA14_4 == '\r') ) { s = 7; }
+
+                   	else if ( (LA14_4 == '\n') ) { s = 8; }
 
                    	if ( s >= 0 ) return s;
                    	break;
@@ -3401,122 +3433,124 @@ public partial class simpletikzLexer : Lexer {
         throw nvae;
     }
     const string DFA22_eotS =
-        "\x01\uffff\x01\x20\x03\uffff\x01\x33\x02\uffff\x01\x20\x01\x39"+
-        "\x05\uffff\x08\x39\x03\x20\x01\x39\x01\uffff\x01\x55\x01\x20\x01"+
-        "\uffff\x01\x20\x01\uffff\x0b\x5d\x0a\uffff\x01\x6c\x02\x39\x06\uffff"+
-        "\x01\x6f\x02\x39\x01\x73\x01\x74\x01\x75\x01\x39\x01\x77\x01\x78"+
-        "\x02\x39\x01\x7b\x02\x39\x04\uffff\x01\x55\x02\uffff\x01\x39\x04"+
-        "\uffff\x01\x56\x02\uffff\x01\x5d\x01\uffff\x0c\x5d\x02\x6c\x01\uffff"+
-        "\x02\x39\x01\uffff\x03\x39\x03\uffff\x01\x39\x02\uffff\x01\u0096"+
-        "\x01\u0097\x01\uffff\x01\u0098\x02\x39\x02\uffff\x02\x5d\x01\u009e"+
-        "\x05\x5d\x01\u00a4\x04\x5d\x02\x6c\x06\x39\x03\uffff\x01\u00b2\x01"+
-        "\x39\x01\uffff\x01\x5d\x01\u00b7\x01\uffff\x01\u00b8\x02\x5d\x01"+
-        "\u00bb\x01\u00bc\x01\uffff\x01\u00bd\x01\x5d\x01\u00c0\x02\x5d\x02"+
-        "\x6c\x01\u00c5\x01\u00c6\x04\x39\x01\uffff\x01\x39\x01\uffff\x01"+
-        "\u00cd\x01\x5d\x02\uffff\x02\x5d\x03\uffff\x02\x5d\x01\uffff\x01"+
-        "\u00d5\x01\x5d\x02\x6c\x02\uffff\x02\x39\x01\u00db\x02\x39\x02\uffff"+
-        "\x02\x5d\x01\u00e1\x04\x5d\x01\uffff\x01\x5d\x01\u00e7\x01\x6c\x02"+
-        "\x39\x01\uffff\x01\u00eb\x01\x39\x01\uffff\x01\x5d\x01\u00ef\x01"+
-        "\uffff\x01\x5d\x01\u00f1\x03\x5d\x01\uffff\x01\u00f5\x01\x39\x01"+
-        "\u00f7\x01\uffff\x01\x39\x01\uffff\x01\x5d\x01\uffff\x01\x5d\x01"+
-        "\uffff\x01\u00fc\x02\x5d\x01\uffff\x01\x39\x01\uffff\x01\x39\x01"+
-        "\uffff\x01\u0102\x01\x5d\x01\uffff\x01\u0104\x01\x5d\x01\u0106\x01"+
-        "\x39\x02\uffff\x01\u010b\x01\uffff\x01\x5d\x01\uffff\x01\u010d\x04"+
-        "\uffff\x01\x5d\x01\uffff\x04\x5d\x01\u0113\x01\uffff";
+        "\x01\uffff\x01\x20\x03\uffff\x01\x33\x02\uffff\x01\x20\x02\x39"+
+        "\x05\uffff\x07\x39\x03\x20\x01\x39\x01\uffff\x01\x55\x01\x20\x01"+
+        "\uffff\x01\x20\x01\uffff\x0b\x5d\x0a\uffff\x01\x6c\x02\x39\x01\uffff"+
+        "\x02\x39\x01\x72\x05\uffff\x01\x73\x02\x39\x01\x77\x01\x78\x01\x79"+
+        "\x01\x39\x01\x7b\x01\x7c\x02\x39\x03\uffff\x01\x55\x03\uffff\x01"+
+        "\x39\x04\uffff\x01\x56\x02\uffff\x01\x5d\x01\uffff\x0c\x5d\x02\x6c"+
+        "\x01\uffff\x03\x39\x01\u0094\x01\u0095\x02\uffff\x03\x39\x03\uffff"+
+        "\x01\x39\x02\uffff\x01\u009a\x02\x39\x02\uffff\x02\x5d\x01\u00a0"+
+        "\x05\x5d\x01\u00a6\x04\x5d\x02\x6c\x02\x39\x01\u00b0\x02\uffff\x04"+
+        "\x39\x01\uffff\x01\u00b5\x01\x39\x01\uffff\x01\x5d\x01\u00ba\x01"+
+        "\uffff\x01\u00bb\x02\x5d\x01\u00be\x01\u00bf\x01\uffff\x01\u00c0"+
+        "\x01\x5d\x01\u00c3\x02\x5d\x02\x6c\x01\u00c8\x01\u00c9\x01\uffff"+
+        "\x04\x39\x01\uffff\x01\x39\x01\uffff\x01\u00d0\x01\x5d\x02\uffff"+
+        "\x02\x5d\x03\uffff\x02\x5d\x01\uffff\x01\u00d8\x01\x5d\x02\x6c\x02"+
+        "\uffff\x02\x39\x01\u00de\x02\x39\x02\uffff\x02\x5d\x01\u00e4\x04"+
+        "\x5d\x01\uffff\x01\x5d\x01\u00ea\x01\x6c\x02\x39\x01\uffff\x01\u00ee"+
+        "\x01\x39\x01\uffff\x01\x5d\x01\u00f2\x01\uffff\x01\x5d\x01\u00f4"+
+        "\x03\x5d\x01\uffff\x01\u00f8\x01\x39\x01\u00fa\x01\uffff\x01\x39"+
+        "\x01\uffff\x01\x5d\x01\uffff\x01\x5d\x01\uffff\x01\u00ff\x02\x5d"+
+        "\x01\uffff\x01\x39\x01\uffff\x01\x39\x01\uffff\x01\u0105\x01\x5d"+
+        "\x01\uffff\x01\u0107\x01\x5d\x01\u0109\x01\x39\x02\uffff\x01\u010e"+
+        "\x01\uffff\x01\x5d\x01\uffff\x01\u0110\x04\uffff\x01\x5d\x01\uffff"+
+        "\x04\x5d\x01\u0116\x01\uffff";
     const string DFA22_eofS =
-        "\u0114\uffff";
+        "\u0117\uffff";
     const string DFA22_minS =
-        "\x02\x00\x03\uffff\x01\x2b\x02\uffff\x01\x2e\x01\x63\x05\uffff"+
-        "\x01\x69\x01\x6e\x01\x6c\x01\x6d\x01\x74\x01\x65\x01\x6e\x01\x6f"+
-        "\x02\x2d\x01\x2e\x01\x69\x01\uffff\x01\x2e\x01\x00\x01\uffff\x01"+
-        "\x00\x01\uffff\x01\x65\x01\x69\x01\x6e\x01\x6f\x01\x61\x01\x6c\x01"+
-        "\x65\x01\x61\x01\x69\x01\x68\x01\x73\x0a\uffff\x01\x61\x01\x79\x01"+
-        "\x6f\x06\uffff\x01\x21\x01\x6e\x01\x72\x03\x21\x01\x6c\x02\x21\x01"+
-        "\x74\x01\x64\x01\x21\x01\x63\x01\x64\x04\uffff\x01\x2e\x02\uffff"+
-        "\x01\x6b\x02\uffff\x01\x00\x01\x0a\x01\x21\x02\uffff\x01\x67\x01"+
-        "\uffff\x01\x6b\x02\x64\x01\x74\x01\x6f\x01\x69\x01\x61\x01\x66\x01"+
-        "\x74\x01\x6c\x01\x61\x01\x65\x01\x74\x01\x70\x01\uffff\x01\x6c\x01"+
-        "\x70\x01\uffff\x01\x72\x01\x74\x01\x63\x03\uffff\x01\x69\x02\uffff"+
-        "\x02\x21\x01\uffff\x01\x21\x01\x65\x01\x7a\x01\x00\x01\uffff\x01"+
-        "\x69\x01\x7a\x01\x21\x01\x65\x02\x72\x01\x70\x01\x77\x01\x21\x01"+
-        "\x68\x01\x6c\x01\x64\x01\x61\x01\x79\x01\x70\x02\x65\x01\x64\x01"+
-        "\x72\x01\x6c\x01\x70\x03\uffff\x01\x21\x01\x70\x01\x00\x01\x6e\x01"+
-        "\x21\x01\uffff\x01\x21\x01\x69\x01\x64\x02\x21\x01\uffff\x01\x21"+
-        "\x01\x65\x01\x21\x01\x65\x01\x73\x01\x6c\x01\x65\x02\x21\x01\x69"+
-        "\x01\x6f\x01\x65\x01\x73\x01\uffff\x01\x69\x01\x00\x01\x21\x01\x65"+
-        "\x02\uffff\x01\x78\x01\x69\x03\uffff\x02\x72\x01\uffff\x01\x21\x01"+
-        "\x62\x01\x65\x01\x6e\x02\uffff\x01\x6e\x01\x6c\x01\x21\x01\x65\x01"+
-        "\x63\x01\x00\x01\uffff\x01\x79\x01\x74\x01\x21\x02\x6e\x01\x61\x01"+
-        "\x72\x01\uffff\x01\x6f\x01\x41\x01\x64\x01\x61\x01\x73\x01\uffff"+
-        "\x01\x21\x01\x74\x01\x00\x01\x6c\x01\x21\x01\uffff\x01\x61\x01\x21"+
-        "\x01\x77\x01\x61\x01\x75\x01\uffff\x01\x41\x01\x74\x01\x21\x01\uffff"+
-        "\x01\x75\x01\x00\x01\x65\x01\uffff\x01\x74\x01\uffff\x01\x21\x01"+
-        "\x77\x01\x6e\x01\uffff\x01\x65\x01\uffff\x01\x72\x01\x00\x01\x21"+
-        "\x01\x65\x01\uffff\x01\x21\x01\x64\x01\x21\x01\x65\x01\x00\x01\uffff"+
-        "\x01\x21\x01\uffff\x01\x69\x01\uffff\x01\x21\x01\x0a\x01\uffff\x01"+
-        "\x00\x01\uffff\x01\x6e\x01\uffff\x01\x67\x01\x62\x01\x6f\x01\x78"+
-        "\x01\x21\x01\uffff";
-    const string DFA22_maxS =
-        "\x02\uffff\x03\uffff\x01\x3d\x02\uffff\x01\x2e\x01\x74\x05\uffff"+
-        "\x01\x6f\x01\x6e\x01\x78\x01\x6d\x01\x74\x01\x65\x01\x74\x01\x6f"+
-        "\x01\x7c\x01\x2d\x01\x39\x01\x69\x01\uffff\x01\x39\x01\uffff\x01"+
-        "\uffff\x01\uffff\x01\uffff\x01\x65\x01\x69\x01\x6e\x01\x6f\x01\x61"+
-        "\x01\x6f\x01\x72\x01\x61\x01\x69\x01\x68\x01\x73\x0a\uffff\x01\x73"+
-        "\x01\x79\x01\x6f\x06\uffff\x01\x7a\x01\x6f\x01\x72\x03\x7a\x01\x6c"+
-        "\x02\x7a\x01\x74\x01\x64\x01\x7a\x01\x63\x01\x64\x04\uffff\x01\x39"+
-        "\x02\uffff\x01\x6b\x02\uffff\x01\uffff\x02\x21\x02\uffff\x01\x67"+
+        "\x02\x00\x03\uffff\x01\x2b\x02\uffff\x01\x2e\x01\x63\x01\x6e\x05"+
+        "\uffff\x01\x69\x01\x6e\x01\x6c\x01\x6d\x01\x74\x01\x65\x01\x6f\x02"+
+        "\x2d\x01\x2e\x01\x69\x01\uffff\x01\x2e\x01\x00\x01\uffff\x01\x00"+
+        "\x01\uffff\x01\x65\x01\x69\x01\x6e\x01\x6f\x01\x61\x01\x6c\x01\x65"+
+        "\x01\x61\x01\x69\x01\x68\x01\x73\x0a\uffff\x01\x61\x01\x79\x01\x6f"+
+        "\x01\uffff\x01\x63\x01\x64\x01\x21\x05\uffff\x01\x21\x01\x6e\x01"+
+        "\x72\x03\x21\x01\x6c\x02\x21\x01\x74\x01\x64\x03\uffff\x01\x2e\x03"+
+        "\uffff\x01\x6b\x02\uffff\x01\x00\x01\x0a\x01\x21\x02\uffff\x01\x67"+
         "\x01\uffff\x01\x6b\x02\x64\x01\x74\x01\x6f\x01\x69\x01\x61\x01\x66"+
         "\x01\x74\x01\x6c\x01\x61\x01\x65\x01\x74\x01\x70\x01\uffff\x01\x6c"+
-        "\x01\x70\x01\uffff\x01\x72\x01\x74\x01\x63\x03\uffff\x01\x69\x02"+
-        "\uffff\x02\x7a\x01\uffff\x01\x7a\x01\x65\x01\x7a\x01\uffff\x01\uffff"+
+        "\x01\x70\x01\x73\x02\x21\x02\uffff\x01\x72\x01\x74\x01\x63\x03\uffff"+
+        "\x01\x69\x02\uffff\x01\x21\x01\x65\x01\x7a\x01\x00\x01\uffff\x01"+
+        "\x69\x01\x7a\x01\x21\x01\x65\x02\x72\x01\x70\x01\x77\x01\x21\x01"+
+        "\x68\x01\x6c\x01\x64\x01\x61\x01\x79\x01\x70\x02\x65\x01\x21\x02"+
+        "\uffff\x01\x64\x01\x72\x01\x6c\x01\x70\x01\uffff\x01\x21\x01\x70"+
+        "\x01\x00\x01\x6e\x01\x21\x01\uffff\x01\x21\x01\x69\x01\x64\x02\x21"+
+        "\x01\uffff\x01\x21\x01\x65\x01\x21\x01\x65\x01\x73\x01\x6c\x01\x65"+
+        "\x02\x21\x01\uffff\x01\x69\x01\x6f\x01\x65\x01\x73\x01\uffff\x01"+
+        "\x69\x01\x00\x01\x21\x01\x65\x02\uffff\x01\x78\x01\x69\x03\uffff"+
+        "\x02\x72\x01\uffff\x01\x21\x01\x62\x01\x65\x01\x6e\x02\uffff\x01"+
+        "\x6e\x01\x6c\x01\x21\x01\x65\x01\x63\x01\x00\x01\uffff\x01\x79\x01"+
+        "\x74\x01\x21\x02\x6e\x01\x61\x01\x72\x01\uffff\x01\x6f\x01\x41\x01"+
+        "\x64\x01\x61\x01\x73\x01\uffff\x01\x21\x01\x74\x01\x00\x01\x6c\x01"+
+        "\x21\x01\uffff\x01\x61\x01\x21\x01\x77\x01\x61\x01\x75\x01\uffff"+
+        "\x01\x41\x01\x74\x01\x21\x01\uffff\x01\x75\x01\x00\x01\x65\x01\uffff"+
+        "\x01\x74\x01\uffff\x01\x21\x01\x77\x01\x6e\x01\uffff\x01\x65\x01"+
+        "\uffff\x01\x72\x01\x00\x01\x21\x01\x65\x01\uffff\x01\x21\x01\x64"+
+        "\x01\x21\x01\x65\x01\x00\x01\uffff\x01\x21\x01\uffff\x01\x69\x01"+
+        "\uffff\x01\x21\x01\x0a\x01\uffff\x01\x00\x01\uffff\x01\x6e\x01\uffff"+
+        "\x01\x67\x01\x62\x01\x6f\x01\x78\x01\x21\x01\uffff";
+    const string DFA22_maxS =
+        "\x02\uffff\x03\uffff\x01\x3d\x02\uffff\x01\x2e\x02\x74\x05\uffff"+
+        "\x01\x6f\x01\x6e\x01\x78\x01\x6d\x01\x74\x01\x65\x01\x6f\x01\x7c"+
+        "\x01\x2d\x01\x39\x01\x69\x01\uffff\x01\x39\x01\uffff\x01\uffff\x01"+
+        "\uffff\x01\uffff\x01\x65\x01\x69\x01\x6e\x01\x6f\x01\x61\x01\x6f"+
+        "\x01\x72\x01\x61\x01\x69\x01\x68\x01\x73\x0a\uffff\x01\x73\x01\x79"+
+        "\x01\x6f\x01\uffff\x01\x67\x01\x64\x01\x7a\x05\uffff\x01\x7a\x01"+
+        "\x6f\x01\x72\x03\x7a\x01\x6c\x02\x7a\x01\x74\x01\x64\x03\uffff\x01"+
+        "\x39\x03\uffff\x01\x6b\x02\uffff\x01\uffff\x02\x21\x02\uffff\x01"+
+        "\x67\x01\uffff\x01\x6b\x02\x64\x01\x74\x01\x6f\x01\x69\x01\x61\x01"+
+        "\x66\x01\x74\x01\x6c\x01\x61\x01\x65\x01\x74\x01\x70\x01\uffff\x01"+
+        "\x6c\x01\x70\x01\x73\x02\x7a\x02\uffff\x01\x72\x01\x74\x01\x63\x03"+
+        "\uffff\x01\x69\x02\uffff\x01\x7a\x01\x65\x01\x7a\x01\uffff\x01\uffff"+
         "\x01\x69\x02\x7a\x01\x65\x02\x72\x01\x70\x01\x77\x01\x7a\x01\x74"+
-        "\x01\x6c\x01\x64\x01\x61\x01\x79\x01\x70\x02\x65\x01\x64\x01\x72"+
-        "\x01\x6c\x01\x70\x03\uffff\x01\x7a\x01\x70\x01\uffff\x01\x6e\x01"+
-        "\x7a\x01\uffff\x01\x7a\x01\x69\x01\x64\x02\x7a\x01\uffff\x01\x7a"+
-        "\x01\x65\x01\x7a\x01\x65\x01\x73\x01\x6c\x01\x65\x02\x7a\x01\x69"+
-        "\x01\x6f\x01\x65\x01\x73\x01\uffff\x01\x69\x01\uffff\x01\x7a\x01"+
-        "\x74\x02\uffff\x01\x78\x01\x69\x03\uffff\x02\x72\x01\uffff\x01\x7a"+
-        "\x01\x62\x01\x65\x01\x6e\x02\uffff\x01\x6e\x01\x6c\x01\x7a\x01\x65"+
-        "\x01\x63\x01\uffff\x01\uffff\x01\x79\x01\x74\x01\x7a\x02\x6e\x01"+
-        "\x61\x01\x72\x01\uffff\x01\x6f\x01\x7a\x01\x64\x01\x61\x01\x73\x01"+
-        "\uffff\x01\x7a\x01\x74\x01\uffff\x01\x6c\x01\x7a\x01\uffff\x01\x61"+
-        "\x01\x7a\x01\x77\x01\x61\x01\x75\x01\uffff\x01\x7a\x01\x74\x01\x7a"+
-        "\x01\uffff\x01\x75\x01\uffff\x01\x65\x01\uffff\x01\x74\x01\uffff"+
-        "\x01\x7a\x01\x77\x01\x6e\x01\uffff\x01\x65\x01\uffff\x01\x72\x01"+
-        "\uffff\x01\x7a\x01\x65\x01\uffff\x01\x7a\x01\x64\x01\x7a\x01\x65"+
-        "\x01\uffff\x01\uffff\x01\x7a\x01\uffff\x01\x69\x01\uffff\x01\x7a"+
-        "\x01\x0a\x01\uffff\x01\uffff\x01\uffff\x01\x6e\x01\uffff\x01\x67"+
-        "\x01\x62\x01\x6f\x01\x78\x01\x7a\x01\uffff";
+        "\x01\x6c\x01\x64\x01\x61\x01\x79\x01\x70\x02\x65\x01\x7a\x02\uffff"+
+        "\x01\x64\x01\x72\x01\x6c\x01\x70\x01\uffff\x01\x7a\x01\x70\x01\uffff"+
+        "\x01\x6e\x01\x7a\x01\uffff\x01\x7a\x01\x69\x01\x64\x02\x7a\x01\uffff"+
+        "\x01\x7a\x01\x65\x01\x7a\x01\x65\x01\x73\x01\x6c\x01\x65\x02\x7a"+
+        "\x01\uffff\x01\x69\x01\x6f\x01\x65\x01\x73\x01\uffff\x01\x69\x01"+
+        "\uffff\x01\x7a\x01\x74\x02\uffff\x01\x78\x01\x69\x03\uffff\x02\x72"+
+        "\x01\uffff\x01\x7a\x01\x62\x01\x65\x01\x6e\x02\uffff\x01\x6e\x01"+
+        "\x6c\x01\x7a\x01\x65\x01\x63\x01\uffff\x01\uffff\x01\x79\x01\x74"+
+        "\x01\x7a\x02\x6e\x01\x61\x01\x72\x01\uffff\x01\x6f\x01\x7a\x01\x64"+
+        "\x01\x61\x01\x73\x01\uffff\x01\x7a\x01\x74\x01\uffff\x01\x6c\x01"+
+        "\x7a\x01\uffff\x01\x61\x01\x7a\x01\x77\x01\x61\x01\x75\x01\uffff"+
+        "\x01\x7a\x01\x74\x01\x7a\x01\uffff\x01\x75\x01\uffff\x01\x65\x01"+
+        "\uffff\x01\x74\x01\uffff\x01\x7a\x01\x77\x01\x6e\x01\uffff\x01\x65"+
+        "\x01\uffff\x01\x72\x01\uffff\x01\x7a\x01\x65\x01\uffff\x01\x7a\x01"+
+        "\x64\x01\x7a\x01\x65\x01\uffff\x01\uffff\x01\x7a\x01\uffff\x01\x69"+
+        "\x01\uffff\x01\x7a\x01\x0a\x01\uffff\x01\uffff\x01\uffff\x01\x6e"+
+        "\x01\uffff\x01\x67\x01\x62\x01\x6f\x01\x78\x01\x7a\x01\uffff";
     const string DFA22_acceptS =
-        "\x02\uffff\x01\x05\x01\x06\x01\x07\x01\uffff\x01\x09\x01\x0a\x02"+
-        "\uffff\x01\x0e\x01\x0f\x01\x10\x01\x11\x01\x12\x0c\uffff\x01\x39"+
-        "\x02\uffff\x01\x3e\x01\uffff\x01\x42\x0b\uffff\x01\x40\x01\x41\x01"+
-        "\x05\x01\x06\x01\x07\x01\x08\x01\x34\x01\x33\x01\x09\x01\x0a\x03"+
-        "\uffff\x01\x39\x01\x0e\x01\x0f\x01\x10\x01\x11\x01\x12\x0e\uffff"+
-        "\x01\x2f\x01\x30\x01\x32\x01\x3b\x01\uffff\x01\x31\x01\x35\x01\uffff"+
-        "\x01\x3a\x01\x3d\x03\uffff\x01\x3e\x01\x3f\x01\uffff\x01\x40\x0e"+
-        "\uffff\x01\x43\x02\uffff\x01\x13\x03\uffff\x01\x14\x01\x15\x01\x18"+
-        "\x01\uffff\x01\x16\x01\x17\x02\uffff\x01\x2b\x04\uffff\x01\x3c\x15"+
-        "\uffff\x01\x27\x01\x28\x01\x2e\x05\uffff\x01\x19\x05\uffff\x01\x1f"+
-        "\x0d\uffff\x01\x2a\x04\uffff\x01\x04\x01\x1a\x02\uffff\x01\x26\x01"+
-        "\x1d\x01\x1e\x02\uffff\x01\x25\x04\uffff\x01\x0d\x01\x38\x06\uffff"+
-        "\x01\x01\x07\uffff\x01\x22\x05\uffff\x01\x2c\x05\uffff\x01\x1b\x05"+
-        "\uffff\x01\x0b\x03\uffff\x01\x2d\x03\uffff\x01\x03\x01\uffff\x01"+
-        "\x21\x03\uffff\x01\x0c\x01\uffff\x01\x36\x04\uffff\x01\x20\x05\uffff"+
-        "\x01\x02\x01\uffff\x01\x23\x01\uffff\x01\x29\x02\uffff\x01\x3c\x01"+
-        "\uffff\x01\x1c\x01\uffff\x01\x37\x05\uffff\x01\x24";
+        "\x02\uffff\x01\x05\x01\x06\x01\x07\x01\uffff\x01\x09\x01\x0a\x03"+
+        "\uffff\x01\x0f\x01\x10\x01\x11\x01\x12\x01\x13\x0b\uffff\x01\x3a"+
+        "\x02\uffff\x01\x3f\x01\uffff\x01\x43\x0b\uffff\x01\x41\x01\x42\x01"+
+        "\x05\x01\x06\x01\x07\x01\x08\x01\x35\x01\x34\x01\x09\x01\x0a\x03"+
+        "\uffff\x01\x3a\x03\uffff\x01\x0f\x01\x10\x01\x11\x01\x12\x01\x13"+
+        "\x0b\uffff\x01\x30\x01\x31\x01\x33\x01\uffff\x01\x3c\x01\x32\x01"+
+        "\x36\x01\uffff\x01\x3b\x01\x3e\x03\uffff\x01\x3f\x01\x40\x01\uffff"+
+        "\x01\x41\x0e\uffff\x01\x44\x05\uffff\x01\x2c\x01\x14\x03\uffff\x01"+
+        "\x15\x01\x16\x01\x19\x01\uffff\x01\x17\x01\x18\x04\uffff\x01\x3d"+
+        "\x12\uffff\x01\x2f\x01\x29\x04\uffff\x01\x28\x05\uffff\x01\x1a\x05"+
+        "\uffff\x01\x20\x09\uffff\x01\x0e\x04\uffff\x01\x2b\x04\uffff\x01"+
+        "\x04\x01\x1b\x02\uffff\x01\x27\x01\x1e\x01\x1f\x02\uffff\x01\x26"+
+        "\x04\uffff\x01\x0d\x01\x39\x06\uffff\x01\x01\x07\uffff\x01\x23\x05"+
+        "\uffff\x01\x2d\x05\uffff\x01\x1c\x05\uffff\x01\x0b\x03\uffff\x01"+
+        "\x2e\x03\uffff\x01\x03\x01\uffff\x01\x22\x03\uffff\x01\x0c\x01\uffff"+
+        "\x01\x37\x04\uffff\x01\x21\x05\uffff\x01\x02\x01\uffff\x01\x24\x01"+
+        "\uffff\x01\x2a\x02\uffff\x01\x3d\x01\uffff\x01\x1d\x01\uffff\x01"+
+        "\x38\x05\uffff\x01\x25";
     const string DFA22_specialS =
-        "\x01\x05\x01\x03\x1b\uffff\x01\x04\x01\uffff\x01\x00\x37\uffff"+
-        "\x01\x02\x27\uffff\x01\x06\x1b\uffff\x01\x07\x18\uffff\x01\x08\x17"+
-        "\uffff\x01\x09\x11\uffff\x01\x0a\x0e\uffff\x01\x0b\x0b\uffff\x01"+
-        "\x0c\x07\uffff\x01\x0d\x08\uffff\x01\x01\x09\uffff}>";
+        "\x01\x00\x01\x01\x1b\uffff\x01\x02\x01\uffff\x01\x04\x37\uffff"+
+        "\x01\x0c\x28\uffff\x01\x05\x1c\uffff\x01\x06\x19\uffff\x01\x07\x17"+
+        "\uffff\x01\x08\x11\uffff\x01\x09\x0e\uffff\x01\x0a\x0b\uffff\x01"+
+        "\x0b\x07\uffff\x01\x0d\x08\uffff\x01\x03\x09\uffff}>";
     static readonly string[] DFA22_transitionS = {
             "\x09\x20\x02\x1e\x02\x20\x01\x1e\x12\x20\x01\x1e\x03\x20\x01"+
-            "\x1f\x01\x1d\x02\x20\x01\x0a\x01\x0b\x01\x20\x01\x05\x01\x06"+
-            "\x01\x17\x01\x19\x01\x08\x0a\x1c\x01\x07\x01\x0e\x01\x20\x01"+
-            "\x04\x03\x20\x1a\x1b\x01\x0c\x01\x01\x01\x0d\x01\x20\x01\x1b"+
-            "\x01\x20\x01\x15\x01\x1b\x01\x0f\x01\x1b\x01\x11\x03\x1b\x01"+
-            "\x10\x02\x1b\x01\x14\x01\x12\x01\x16\x01\x1b\x01\x13\x02\x1b"+
+            "\x1f\x01\x1d\x02\x20\x01\x0b\x01\x0c\x01\x20\x01\x05\x01\x06"+
+            "\x01\x17\x01\x19\x01\x08\x0a\x1c\x01\x07\x01\x0f\x01\x20\x01"+
+            "\x04\x03\x20\x1a\x1b\x01\x0d\x01\x01\x01\x0e\x01\x20\x01\x1b"+
+            "\x01\x20\x01\x0a\x01\x1b\x01\x10\x01\x1b\x01\x12\x03\x1b\x01"+
+            "\x11\x02\x1b\x01\x15\x01\x13\x01\x16\x01\x1b\x01\x14\x02\x1b"+
             "\x01\x09\x01\x1a\x06\x1b\x01\x02\x01\x18\x01\x03\uff82\x20",
             "\x41\x2d\x1a\x2c\x04\x2d\x01\x2c\x01\x2d\x01\x2c\x01\x21\x01"+
             "\x26\x01\x27\x01\x23\x01\x29\x06\x2c\x01\x25\x01\x24\x01\x2c"+
@@ -3529,26 +3563,26 @@ public partial class simpletikzLexer : Lexer {
             "",
             "\x01\x36",
             "\x01\x38\x10\uffff\x01\x37",
+            "\x01\x3b\x03\uffff\x01\x3a\x01\uffff\x01\x3c",
             "",
             "",
             "",
             "",
             "",
-            "\x01\x41\x03\uffff\x01\x3f\x01\uffff\x01\x40",
-            "\x01\x42",
-            "\x01\x45\x01\x44\x0a\uffff\x01\x43",
-            "\x01\x46",
-            "\x01\x47",
-            "\x01\x48",
-            "\x01\x49\x03\uffff\x01\x4b\x01\uffff\x01\x4a",
+            "\x01\x44\x03\uffff\x01\x42\x01\uffff\x01\x43",
+            "\x01\x45",
+            "\x01\x48\x01\x47\x0a\uffff\x01\x46",
+            "\x01\x49",
+            "\x01\x4a",
+            "\x01\x4b",
             "\x01\x4c",
-            "\x01\x4d\x01\x50\x01\uffff\x0a\x51\x04\uffff\x01\x4e\x3d\uffff"+
+            "\x01\x4d\x01\x51\x01\uffff\x0a\x50\x04\uffff\x01\x4e\x3d\uffff"+
             "\x01\x4f",
             "\x01\x52",
-            "\x01\x53\x01\uffff\x0a\x50",
+            "\x01\x53\x01\uffff\x0a\x51",
             "\x01\x54",
             "",
-            "\x01\x50\x01\uffff\x0a\x51",
+            "\x01\x51\x01\uffff\x0a\x50",
             "\x09\x56\x01\x57\x01\x59\x02\x56\x01\x58\x12\x56\x01\x57\uffdf"+
             "\x56",
             "",
@@ -3579,6 +3613,10 @@ public partial class simpletikzLexer : Lexer {
             "\x01\x6d",
             "\x01\x6e",
             "",
+            "\x01\x70\x03\uffff\x01\x6f",
+            "\x01\x71",
+            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
+            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
             "",
             "",
             "",
@@ -3586,43 +3624,38 @@ public partial class simpletikzLexer : Lexer {
             "",
             "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
             "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x71\x01\x70",
-            "\x01\x72",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x01\x75\x01\x74",
             "\x01\x76",
             "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
             "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
             "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
             "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x79",
+            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
+            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
             "\x01\x7a",
             "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
             "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x7c",
+            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
+            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
             "\x01\x7d",
-            "",
-            "",
-            "",
-            "",
-            "\x01\x50\x01\uffff\x0a\x51",
-            "",
-            "",
             "\x01\x7e",
             "",
             "",
-            "\x21\x56\x01\x7f\uffde\x56",
-            "\x01\x56\x16\uffff\x01\u0080",
-            "\x01\u0080",
+            "",
+            "\x01\x51\x01\uffff\x0a\x50",
             "",
             "",
+            "",
+            "\x01\x7f",
+            "",
+            "",
+            "\x21\x56\x01\u0080\uffde\x56",
+            "\x01\x56\x16\uffff\x01\u0081",
             "\x01\u0081",
             "",
+            "",
             "\x01\u0082",
+            "",
             "\x01\u0083",
             "\x01\u0084",
             "\x01\u0085",
@@ -3636,44 +3669,44 @@ public partial class simpletikzLexer : Lexer {
             "\x01\u008d",
             "\x01\u008e",
             "\x01\u008f",
-            "",
             "\x01\u0090",
-            "\x01\u0091",
             "",
+            "\x01\u0091",
             "\x01\u0092",
             "\x01\u0093",
-            "\x01\u0094",
-            "",
-            "",
-            "",
-            "\x01\u0095",
-            "",
-            "",
             "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
             "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
             "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
             "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
             "",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "",
+            "\x01\u0096",
+            "\x01\u0097",
+            "\x01\u0098",
+            "",
+            "",
+            "",
             "\x01\u0099",
-            "\x01\u009a",
-            "\x54\x56\x01\u009b\uffab\x56",
             "",
+            "",
+            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
+            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x01\u009b",
             "\x01\u009c",
-            "\x01\u009d",
+            "\x54\x56\x01\u009d\uffab\x56",
+            "",
+            "\x01\u009e",
+            "\x01\u009f",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
             "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u009f",
-            "\x01\u00a0",
             "\x01\u00a1",
             "\x01\u00a2",
             "\x01\u00a3",
+            "\x01\u00a4",
+            "\x01\u00a5",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
             "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u00a5\x0b\uffff\x01\u00a6",
-            "\x01\u00a7",
-            "\x01\u00a8",
+            "\x01\u00a7\x0b\uffff\x01\u00a8",
             "\x01\u00a9",
             "\x01\u00aa",
             "\x01\u00ab",
@@ -3681,23 +3714,27 @@ public partial class simpletikzLexer : Lexer {
             "\x01\u00ad",
             "\x01\u00ae",
             "\x01\u00af",
-            "\x01\u00b0",
+            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
+            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "",
+            "",
             "\x01\u00b1",
-            "",
-            "",
-            "",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x01\u00b2",
             "\x01\u00b3",
-            "\x49\x56\x01\u00b4\uffb6\x56",
-            "\x01\u00b5",
+            "\x01\u00b4",
+            "",
+            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
+            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x01\u00b6",
+            "\x49\x56\x01\u00b7\uffb6\x56",
+            "\x01\u00b8",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x12\x5d\x01\u00b6\x07\x5d",
+            "\x5d\x04\uffff\x01\x5d\x01\uffff\x12\x5d\x01\u00b9\x07\x5d",
             "",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
             "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u00b9",
-            "\x01\u00ba",
+            "\x01\u00bc",
+            "\x01\u00bd",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
             "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
@@ -3705,131 +3742,132 @@ public partial class simpletikzLexer : Lexer {
             "",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
             "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u00be",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x03\x5d\x01\u00bf\x16\x5d",
             "\x01\u00c1",
-            "\x01\u00c2",
-            "\x01\u00c3",
+            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
+            "\x5d\x04\uffff\x01\x5d\x01\uffff\x03\x5d\x01\u00c2\x16\x5d",
             "\x01\u00c4",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x01\u00c5",
+            "\x01\u00c6",
             "\x01\u00c7",
-            "\x01\u00c8",
-            "\x01\u00c9",
-            "\x01\u00ca",
+            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
+            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
+            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
             "",
+            "\x01\u00ca",
             "\x01\u00cb",
-            "\x4b\x56\x01\u00cc\uffb4\x56",
+            "\x01\u00cc",
+            "\x01\u00cd",
+            "",
+            "\x01\u00ce",
+            "\x4b\x56\x01\u00cf\uffb4\x56",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
             "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u00cf\x0e\uffff\x01\u00ce",
+            "\x01\u00d2\x0e\uffff\x01\u00d1",
             "",
             "",
-            "\x01\u00d0",
-            "\x01\u00d1",
-            "",
-            "",
-            "",
-            "\x01\u00d2",
             "\x01\u00d3",
+            "\x01\u00d4",
+            "",
+            "",
+            "",
+            "\x01\u00d5",
+            "\x01\u00d6",
             "",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x03\x5d\x01\u00d4\x16\x5d",
-            "\x01\u00d6",
-            "\x01\u00d7",
-            "\x01\u00d8",
-            "",
-            "",
+            "\x5d\x04\uffff\x01\x5d\x01\uffff\x03\x5d\x01\u00d7\x16\x5d",
             "\x01\u00d9",
             "\x01\u00da",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x01\u00db",
+            "",
+            "",
             "\x01\u00dc",
             "\x01\u00dd",
-            "\x5a\x56\x01\u00de\uffa5\x56",
-            "",
+            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
+            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
             "\x01\u00df",
             "\x01\u00e0",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
+            "\x5a\x56\x01\u00e1\uffa5\x56",
+            "",
             "\x01\u00e2",
             "\x01\u00e3",
-            "\x01\u00e4",
+            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
+            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
             "\x01\u00e5",
-            "",
             "\x01\u00e6",
-            "\x1a\x6c\x06\uffff\x1a\x6c",
+            "\x01\u00e7",
             "\x01\u00e8",
+            "",
             "\x01\u00e9",
-            "\x01\u00ea",
+            "\x1a\x6c\x06\uffff\x1a\x6c",
+            "\x01\u00eb",
+            "\x01\u00ec",
+            "\x01\u00ed",
             "",
             "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
             "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\u00ec",
-            "\x45\x56\x01\u00ed\uffba\x56",
-            "\x01\u00ee",
+            "\x01\u00ef",
+            "\x45\x56\x01\u00f0\uffba\x56",
+            "\x01\u00f1",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
             "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
             "",
-            "\x01\u00f0",
+            "\x01\u00f3",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
             "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u00f2",
-            "\x01\u00f3",
-            "\x01\u00f4",
+            "\x01\u00f5",
+            "\x01\u00f6",
+            "\x01\u00f7",
             "",
             "\x1a\x6c\x06\uffff\x1a\x6c",
-            "\x01\u00f6",
+            "\x01\u00f9",
             "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
             "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "",
-            "\x01\u00f8",
-            "\x44\x56\x01\u00f9\uffbb\x56",
-            "\x01\u00fa",
             "",
             "\x01\u00fb",
-            "",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
+            "\x44\x56\x01\u00fc\uffbb\x56",
             "\x01\u00fd",
+            "",
             "\x01\u00fe",
             "",
-            "\x01\u00ff",
-            "",
+            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
+            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
             "\x01\u0100",
-            "\x54\x56\x01\u0101\uffab\x56",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
+            "\x01\u0101",
+            "",
+            "\x01\u0102",
+            "",
             "\x01\u0103",
+            "\x54\x56\x01\u0104\uffab\x56",
+            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
+            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
+            "\x01\u0106",
             "",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
             "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u0105",
+            "\x01\u0108",
             "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
             "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\u0107",
-            "\x0a\u010a\x01\u0109\x02\u010a\x01\u0108\ufff2\u010a",
+            "\x01\u010a",
+            "\x0a\u010d\x01\u010c\x02\u010d\x01\u010b\ufff2\u010d",
             "",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
             "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "",
-            "\x01\u010c",
-            "",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\u0109",
-            "",
-            "\x0a\u010a\x01\u0109\x02\u010a\x01\u0108\ufff2\u010a",
-            "",
-            "\x01\u010e",
             "",
             "\x01\u010f",
-            "\x01\u0110",
+            "",
+            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
+            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x01\u010c",
+            "",
+            "\x0a\u010d\x01\u010c\x02\u010d\x01\u010b\ufff2\u010d",
+            "",
             "\x01\u0111",
+            "",
             "\x01\u0112",
+            "\x01\u0113",
+            "\x01\u0114",
+            "\x01\u0115",
             "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
             "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
             ""
@@ -3861,7 +3899,7 @@ public partial class simpletikzLexer : Lexer {
 
         override public string Description
         {
-            get { return "1:1: Tokens : ( T__39 | T__40 | T__41 | T__42 | T__43 | T__44 | T__45 | T__46 | T__47 | T__48 | T__49 | T__50 | T__51 | T__52 | T__53 | T__54 | T__55 | T__56 | T__57 | T__58 | T__59 | T__60 | T__61 | T__62 | T__63 | T__64 | T__65 | T__66 | T__67 | T__68 | T__69 | T__70 | T__71 | T__72 | T__73 | T__74 | T__75 | T__76 | T__77 | T__78 | T__79 | T__80 | T__81 | T__82 | T__83 | T__84 | T__85 | T__86 | T__87 | T__88 | T__89 | T__90 | T__91 | T__92 | T__93 | T__94 | ID | INT | FLOAT_WO_EXP | TIKZEDT_CMD_COMMENT | COMMENT | WS | MATHSTRING | COMMAND | ESC_SEQ | SOMETHING | SOMETHING1 );"; }
+            get { return "1:1: Tokens : ( T__39 | T__40 | T__41 | T__42 | T__43 | T__44 | T__45 | T__46 | T__47 | T__48 | T__49 | T__50 | T__51 | T__52 | T__53 | T__54 | T__55 | T__56 | T__57 | T__58 | T__59 | T__60 | T__61 | T__62 | T__63 | T__64 | T__65 | T__66 | T__67 | T__68 | T__69 | T__70 | T__71 | T__72 | T__73 | T__74 | T__75 | T__76 | T__77 | T__78 | T__79 | T__80 | T__81 | T__82 | T__83 | T__84 | T__85 | T__86 | T__87 | T__88 | T__89 | T__90 | T__91 | T__92 | T__93 | T__94 | T__95 | ID | INT | FLOAT_WO_EXP | TIKZEDT_CMD_COMMENT | COMMENT | WS | MATHSTRING | COMMAND | ESC_SEQ | SOMETHING | SOMETHING1 );"; }
         }
 
     }
@@ -3874,38 +3912,76 @@ public partial class simpletikzLexer : Lexer {
         switch ( s )
         {
                	case 0 : 
-                   	int LA22_31 = input.LA(1);
+                   	int LA22_0 = input.LA(1);
 
                    	s = -1;
-                   	if ( ((LA22_31 >= '\u0000' && LA22_31 <= '\uFFFF')) ) { s = 91; }
+                   	if ( (LA22_0 == '\\') ) { s = 1; }
 
-                   	else s = 32;
+                   	else if ( (LA22_0 == '{') ) { s = 2; }
+
+                   	else if ( (LA22_0 == '}') ) { s = 3; }
+
+                   	else if ( (LA22_0 == '=') ) { s = 4; }
+
+                   	else if ( (LA22_0 == '+') ) { s = 5; }
+
+                   	else if ( (LA22_0 == ',') ) { s = 6; }
+
+                   	else if ( (LA22_0 == ':') ) { s = 7; }
+
+                   	else if ( (LA22_0 == '/') ) { s = 8; }
+
+                   	else if ( (LA22_0 == 's') ) { s = 9; }
+
+                   	else if ( (LA22_0 == 'a') ) { s = 10; }
+
+                   	else if ( (LA22_0 == '(') ) { s = 11; }
+
+                   	else if ( (LA22_0 == ')') ) { s = 12; }
+
+                   	else if ( (LA22_0 == '[') ) { s = 13; }
+
+                   	else if ( (LA22_0 == ']') ) { s = 14; }
+
+                   	else if ( (LA22_0 == ';') ) { s = 15; }
+
+                   	else if ( (LA22_0 == 'c') ) { s = 16; }
+
+                   	else if ( (LA22_0 == 'i') ) { s = 17; }
+
+                   	else if ( (LA22_0 == 'e') ) { s = 18; }
+
+                   	else if ( (LA22_0 == 'm') ) { s = 19; }
+
+                   	else if ( (LA22_0 == 'p') ) { s = 20; }
+
+                   	else if ( (LA22_0 == 'l') ) { s = 21; }
+
+                   	else if ( (LA22_0 == 'n') ) { s = 22; }
+
+                   	else if ( (LA22_0 == '-') ) { s = 23; }
+
+                   	else if ( (LA22_0 == '|') ) { s = 24; }
+
+                   	else if ( (LA22_0 == '.') ) { s = 25; }
+
+                   	else if ( (LA22_0 == 't') ) { s = 26; }
+
+                   	else if ( ((LA22_0 >= 'A' && LA22_0 <= 'Z') || LA22_0 == '_' || LA22_0 == 'b' || LA22_0 == 'd' || (LA22_0 >= 'f' && LA22_0 <= 'h') || (LA22_0 >= 'j' && LA22_0 <= 'k') || LA22_0 == 'o' || (LA22_0 >= 'q' && LA22_0 <= 'r') || (LA22_0 >= 'u' && LA22_0 <= 'z')) ) { s = 27; }
+
+                   	else if ( ((LA22_0 >= '0' && LA22_0 <= '9')) ) { s = 28; }
+
+                   	else if ( (LA22_0 == '%') ) { s = 29; }
+
+                   	else if ( ((LA22_0 >= '\t' && LA22_0 <= '\n') || LA22_0 == '\r' || LA22_0 == ' ') ) { s = 30; }
+
+                   	else if ( (LA22_0 == '$') ) { s = 31; }
+
+                   	else if ( ((LA22_0 >= '\u0000' && LA22_0 <= '\b') || (LA22_0 >= '\u000B' && LA22_0 <= '\f') || (LA22_0 >= '\u000E' && LA22_0 <= '\u001F') || (LA22_0 >= '!' && LA22_0 <= '#') || (LA22_0 >= '&' && LA22_0 <= '\'') || LA22_0 == '*' || LA22_0 == '<' || (LA22_0 >= '>' && LA22_0 <= '@') || LA22_0 == '^' || LA22_0 == '`' || (LA22_0 >= '~' && LA22_0 <= '\uFFFF')) ) { s = 32; }
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 1 : 
-                   	int LA22_266 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA22_266 == '\r') ) { s = 264; }
-
-                   	else if ( (LA22_266 == '\n') ) { s = 265; }
-
-                   	else if ( ((LA22_266 >= '\u0000' && LA22_266 <= '\t') || (LA22_266 >= '\u000B' && LA22_266 <= '\f') || (LA22_266 >= '\u000E' && LA22_266 <= '\uFFFF')) ) { s = 266; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 2 : 
-                   	int LA22_87 = input.LA(1);
-
-                   	s = -1;
-                   	if ( ((LA22_87 >= '\u0000' && LA22_87 <= ' ') || (LA22_87 >= '\"' && LA22_87 <= '\uFFFF')) ) { s = 86; }
-
-                   	else if ( (LA22_87 == '!') ) { s = 127; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 3 : 
                    	int LA22_1 = input.LA(1);
 
                    	s = -1;
@@ -3939,7 +4015,7 @@ public partial class simpletikzLexer : Lexer {
 
                    	if ( s >= 0 ) return s;
                    	break;
-               	case 4 : 
+               	case 2 : 
                    	int LA22_29 = input.LA(1);
 
                    	s = -1;
@@ -3955,155 +4031,117 @@ public partial class simpletikzLexer : Lexer {
 
                    	if ( s >= 0 ) return s;
                    	break;
-               	case 5 : 
-                   	int LA22_0 = input.LA(1);
+               	case 3 : 
+                   	int LA22_269 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA22_0 == '\\') ) { s = 1; }
+                   	if ( (LA22_269 == '\r') ) { s = 267; }
 
-                   	else if ( (LA22_0 == '{') ) { s = 2; }
+                   	else if ( (LA22_269 == '\n') ) { s = 268; }
 
-                   	else if ( (LA22_0 == '}') ) { s = 3; }
+                   	else if ( ((LA22_269 >= '\u0000' && LA22_269 <= '\t') || (LA22_269 >= '\u000B' && LA22_269 <= '\f') || (LA22_269 >= '\u000E' && LA22_269 <= '\uFFFF')) ) { s = 269; }
 
-                   	else if ( (LA22_0 == '=') ) { s = 4; }
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 4 : 
+                   	int LA22_31 = input.LA(1);
 
-                   	else if ( (LA22_0 == '+') ) { s = 5; }
+                   	s = -1;
+                   	if ( ((LA22_31 >= '\u0000' && LA22_31 <= '\uFFFF')) ) { s = 91; }
 
-                   	else if ( (LA22_0 == ',') ) { s = 6; }
+                   	else s = 32;
 
-                   	else if ( (LA22_0 == ':') ) { s = 7; }
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 5 : 
+                   	int LA22_128 = input.LA(1);
 
-                   	else if ( (LA22_0 == '/') ) { s = 8; }
+                   	s = -1;
+                   	if ( (LA22_128 == 'T') ) { s = 157; }
 
-                   	else if ( (LA22_0 == 's') ) { s = 9; }
-
-                   	else if ( (LA22_0 == '(') ) { s = 10; }
-
-                   	else if ( (LA22_0 == ')') ) { s = 11; }
-
-                   	else if ( (LA22_0 == '[') ) { s = 12; }
-
-                   	else if ( (LA22_0 == ']') ) { s = 13; }
-
-                   	else if ( (LA22_0 == ';') ) { s = 14; }
-
-                   	else if ( (LA22_0 == 'c') ) { s = 15; }
-
-                   	else if ( (LA22_0 == 'i') ) { s = 16; }
-
-                   	else if ( (LA22_0 == 'e') ) { s = 17; }
-
-                   	else if ( (LA22_0 == 'm') ) { s = 18; }
-
-                   	else if ( (LA22_0 == 'p') ) { s = 19; }
-
-                   	else if ( (LA22_0 == 'l') ) { s = 20; }
-
-                   	else if ( (LA22_0 == 'a') ) { s = 21; }
-
-                   	else if ( (LA22_0 == 'n') ) { s = 22; }
-
-                   	else if ( (LA22_0 == '-') ) { s = 23; }
-
-                   	else if ( (LA22_0 == '|') ) { s = 24; }
-
-                   	else if ( (LA22_0 == '.') ) { s = 25; }
-
-                   	else if ( (LA22_0 == 't') ) { s = 26; }
-
-                   	else if ( ((LA22_0 >= 'A' && LA22_0 <= 'Z') || LA22_0 == '_' || LA22_0 == 'b' || LA22_0 == 'd' || (LA22_0 >= 'f' && LA22_0 <= 'h') || (LA22_0 >= 'j' && LA22_0 <= 'k') || LA22_0 == 'o' || (LA22_0 >= 'q' && LA22_0 <= 'r') || (LA22_0 >= 'u' && LA22_0 <= 'z')) ) { s = 27; }
-
-                   	else if ( ((LA22_0 >= '0' && LA22_0 <= '9')) ) { s = 28; }
-
-                   	else if ( (LA22_0 == '%') ) { s = 29; }
-
-                   	else if ( ((LA22_0 >= '\t' && LA22_0 <= '\n') || LA22_0 == '\r' || LA22_0 == ' ') ) { s = 30; }
-
-                   	else if ( (LA22_0 == '$') ) { s = 31; }
-
-                   	else if ( ((LA22_0 >= '\u0000' && LA22_0 <= '\b') || (LA22_0 >= '\u000B' && LA22_0 <= '\f') || (LA22_0 >= '\u000E' && LA22_0 <= '\u001F') || (LA22_0 >= '!' && LA22_0 <= '#') || (LA22_0 >= '&' && LA22_0 <= '\'') || LA22_0 == '*' || LA22_0 == '<' || (LA22_0 >= '>' && LA22_0 <= '@') || LA22_0 == '^' || LA22_0 == '`' || (LA22_0 >= '~' && LA22_0 <= '\uFFFF')) ) { s = 32; }
+                   	else if ( ((LA22_128 >= '\u0000' && LA22_128 <= 'S') || (LA22_128 >= 'U' && LA22_128 <= '\uFFFF')) ) { s = 86; }
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 6 : 
-                   	int LA22_127 = input.LA(1);
+                   	int LA22_157 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA22_127 == 'T') ) { s = 155; }
+                   	if ( (LA22_157 == 'I') ) { s = 183; }
 
-                   	else if ( ((LA22_127 >= '\u0000' && LA22_127 <= 'S') || (LA22_127 >= 'U' && LA22_127 <= '\uFFFF')) ) { s = 86; }
+                   	else if ( ((LA22_157 >= '\u0000' && LA22_157 <= 'H') || (LA22_157 >= 'J' && LA22_157 <= '\uFFFF')) ) { s = 86; }
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 7 : 
-                   	int LA22_155 = input.LA(1);
+                   	int LA22_183 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA22_155 == 'I') ) { s = 180; }
+                   	if ( (LA22_183 == 'K') ) { s = 207; }
 
-                   	else if ( ((LA22_155 >= '\u0000' && LA22_155 <= 'H') || (LA22_155 >= 'J' && LA22_155 <= '\uFFFF')) ) { s = 86; }
+                   	else if ( ((LA22_183 >= '\u0000' && LA22_183 <= 'J') || (LA22_183 >= 'L' && LA22_183 <= '\uFFFF')) ) { s = 86; }
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 8 : 
-                   	int LA22_180 = input.LA(1);
+                   	int LA22_207 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA22_180 == 'K') ) { s = 204; }
+                   	if ( (LA22_207 == 'Z') ) { s = 225; }
 
-                   	else if ( ((LA22_180 >= '\u0000' && LA22_180 <= 'J') || (LA22_180 >= 'L' && LA22_180 <= '\uFFFF')) ) { s = 86; }
+                   	else if ( ((LA22_207 >= '\u0000' && LA22_207 <= 'Y') || (LA22_207 >= '[' && LA22_207 <= '\uFFFF')) ) { s = 86; }
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 9 : 
-                   	int LA22_204 = input.LA(1);
+                   	int LA22_225 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA22_204 == 'Z') ) { s = 222; }
+                   	if ( (LA22_225 == 'E') ) { s = 240; }
 
-                   	else if ( ((LA22_204 >= '\u0000' && LA22_204 <= 'Y') || (LA22_204 >= '[' && LA22_204 <= '\uFFFF')) ) { s = 86; }
+                   	else if ( ((LA22_225 >= '\u0000' && LA22_225 <= 'D') || (LA22_225 >= 'F' && LA22_225 <= '\uFFFF')) ) { s = 86; }
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 10 : 
-                   	int LA22_222 = input.LA(1);
+                   	int LA22_240 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA22_222 == 'E') ) { s = 237; }
+                   	if ( (LA22_240 == 'D') ) { s = 252; }
 
-                   	else if ( ((LA22_222 >= '\u0000' && LA22_222 <= 'D') || (LA22_222 >= 'F' && LA22_222 <= '\uFFFF')) ) { s = 86; }
+                   	else if ( ((LA22_240 >= '\u0000' && LA22_240 <= 'C') || (LA22_240 >= 'E' && LA22_240 <= '\uFFFF')) ) { s = 86; }
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 11 : 
-                   	int LA22_237 = input.LA(1);
+                   	int LA22_252 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA22_237 == 'D') ) { s = 249; }
+                   	if ( (LA22_252 == 'T') ) { s = 260; }
 
-                   	else if ( ((LA22_237 >= '\u0000' && LA22_237 <= 'C') || (LA22_237 >= 'E' && LA22_237 <= '\uFFFF')) ) { s = 86; }
+                   	else if ( ((LA22_252 >= '\u0000' && LA22_252 <= 'S') || (LA22_252 >= 'U' && LA22_252 <= '\uFFFF')) ) { s = 86; }
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 12 : 
-                   	int LA22_249 = input.LA(1);
+                   	int LA22_87 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA22_249 == 'T') ) { s = 257; }
+                   	if ( (LA22_87 == '!') ) { s = 128; }
 
-                   	else if ( ((LA22_249 >= '\u0000' && LA22_249 <= 'S') || (LA22_249 >= 'U' && LA22_249 <= '\uFFFF')) ) { s = 86; }
+                   	else if ( ((LA22_87 >= '\u0000' && LA22_87 <= ' ') || (LA22_87 >= '\"' && LA22_87 <= '\uFFFF')) ) { s = 86; }
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 13 : 
-                   	int LA22_257 = input.LA(1);
+                   	int LA22_260 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA22_257 == '\r') ) { s = 264; }
+                   	if ( (LA22_260 == '\r') ) { s = 267; }
 
-                   	else if ( (LA22_257 == '\n') ) { s = 265; }
+                   	else if ( (LA22_260 == '\n') ) { s = 268; }
 
-                   	else if ( ((LA22_257 >= '\u0000' && LA22_257 <= '\t') || (LA22_257 >= '\u000B' && LA22_257 <= '\f') || (LA22_257 >= '\u000E' && LA22_257 <= '\uFFFF')) ) { s = 266; }
+                   	else if ( ((LA22_260 >= '\u0000' && LA22_260 <= '\t') || (LA22_260 >= '\u000B' && LA22_260 <= '\f') || (LA22_260 >= '\u000E' && LA22_260 <= '\uFFFF')) ) { s = 269; }
 
                    	if ( s >= 0 ) return s;
                    	break;

--- a/TikzParser/output/simpletikzLexer.cs
+++ b/TikzParser/output/simpletikzLexer.cs
@@ -1,4 +1,4 @@
-// $ANTLR 3.1.1 E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g 2016-09-21 11:07:05
+// $ANTLR 3.1.1 E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g 2016-09-21 15:48:42
 
 using System;
 using Antlr.Runtime;
@@ -67,7 +67,9 @@ public partial class simpletikzLexer : Lexer {
     public const int IM_STRING = 21;
     public const int MATHSTRING = 36;
     public const int T__95 = 95;
+    public const int T__96 = 96;
     public const int IM_COORD = 6;
+    public const int T__97 = 97;
     public const int IM_USETIKZLIB = 20;
     public const int FLOAT_WO_EXP = 30;
     public const int IM_PICTURE = 10;
@@ -457,11 +459,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__52;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:41:7: ( 'args' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:41:9: 'args'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:41:7: ( 'n' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:41:9: 'n'
             {
-            	Match("args"); 
-
+            	Match('n'); 
 
             }
 
@@ -481,10 +482,11 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__53;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:42:7: ( '(' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:42:9: '('
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:42:7: ( 'args' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:42:9: 'args'
             {
-            	Match('('); 
+            	Match("args"); 
+
 
             }
 
@@ -504,10 +506,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__54;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:43:7: ( ')' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:43:9: ')'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:43:7: ( '2' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:43:9: '2'
             {
-            	Match(')'); 
+            	Match('2'); 
 
             }
 
@@ -527,10 +529,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__55;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:44:7: ( '[' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:44:9: '['
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:44:7: ( '(' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:44:9: '('
             {
-            	Match('['); 
+            	Match('('); 
 
             }
 
@@ -550,10 +552,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__56;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:45:7: ( ']' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:45:9: ']'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:45:7: ( ')' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:45:9: ')'
             {
-            	Match(']'); 
+            	Match(')'); 
 
             }
 
@@ -573,10 +575,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__57;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:46:7: ( ';' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:46:9: ';'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:46:7: ( '[' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:46:9: '['
             {
-            	Match(';'); 
+            	Match('['); 
 
             }
 
@@ -596,11 +598,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__58;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:47:7: ( 'cm' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:47:9: 'cm'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:47:7: ( ']' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:47:9: ']'
             {
-            	Match("cm"); 
-
+            	Match(']'); 
 
             }
 
@@ -620,11 +621,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__59;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:48:7: ( 'in' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:48:9: 'in'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:48:7: ( ';' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:48:9: ';'
             {
-            	Match("in"); 
-
+            	Match(';'); 
 
             }
 
@@ -644,10 +644,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__60;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:49:7: ( 'ex' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:49:9: 'ex'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:49:7: ( 'cm' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:49:9: 'cm'
             {
-            	Match("ex"); 
+            	Match("cm"); 
 
 
             }
@@ -668,10 +668,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__61;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:50:7: ( 'mm' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:50:9: 'mm'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:50:7: ( 'in' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:50:9: 'in'
             {
-            	Match("mm"); 
+            	Match("in"); 
 
 
             }
@@ -692,10 +692,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__62;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:51:7: ( 'pt' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:51:9: 'pt'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:51:7: ( 'ex' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:51:9: 'ex'
             {
-            	Match("pt"); 
+            	Match("ex"); 
 
 
             }
@@ -716,10 +716,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__63;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:52:7: ( 'em' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:52:9: 'em'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:52:7: ( 'mm' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:52:9: 'mm'
             {
-            	Match("em"); 
+            	Match("mm"); 
 
 
             }
@@ -740,10 +740,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__64;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:53:7: ( '\\\\end' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:53:9: '\\\\end'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:53:7: ( 'pt' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:53:9: 'pt'
             {
-            	Match("\\end"); 
+            	Match("pt"); 
 
 
             }
@@ -764,10 +764,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__65;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:54:7: ( '\\\\node' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:54:9: '\\\\node'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:54:7: ( 'em' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:54:9: 'em'
             {
-            	Match("\\node"); 
+            	Match("em"); 
 
 
             }
@@ -788,10 +788,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__66;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:55:7: ( '\\\\matrix' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:55:9: '\\\\matrix'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:55:7: ( '\\\\end' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:55:9: '\\\\end'
             {
-            	Match("\\matrix"); 
+            	Match("\\end"); 
 
 
             }
@@ -812,10 +812,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__67;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:56:7: ( '\\\\coordinate' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:56:9: '\\\\coordinate'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:56:7: ( '\\\\node' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:56:9: '\\\\node'
             {
-            	Match("\\coordinate"); 
+            	Match("\\node"); 
 
 
             }
@@ -836,10 +836,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__68;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:57:7: ( '\\\\draw' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:57:9: '\\\\draw'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:57:7: ( '\\\\matrix' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:57:9: '\\\\matrix'
             {
-            	Match("\\draw"); 
+            	Match("\\matrix"); 
 
 
             }
@@ -860,10 +860,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__69;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:58:7: ( '\\\\path' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:58:9: '\\\\path'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:58:7: ( '\\\\coordinate' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:58:9: '\\\\coordinate'
             {
-            	Match("\\path"); 
+            	Match("\\coordinate"); 
 
 
             }
@@ -884,10 +884,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__70;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:59:7: ( '\\\\def' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:59:9: '\\\\def'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:59:7: ( '\\\\draw' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:59:9: '\\\\draw'
             {
-            	Match("\\def"); 
+            	Match("\\draw"); 
 
 
             }
@@ -908,10 +908,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__71;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:60:7: ( '\\\\filldraw' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:60:9: '\\\\filldraw'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:60:7: ( '\\\\path' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:60:9: '\\\\path'
             {
-            	Match("\\filldraw"); 
+            	Match("\\path"); 
 
 
             }
@@ -932,10 +932,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__72;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:61:7: ( '\\\\pattern' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:61:9: '\\\\pattern'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:61:7: ( '\\\\def' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:61:9: '\\\\def'
             {
-            	Match("\\pattern"); 
+            	Match("\\def"); 
 
 
             }
@@ -956,10 +956,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__73;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:62:7: ( '\\\\shade' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:62:9: '\\\\shade'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:62:7: ( '\\\\filldraw' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:62:9: '\\\\filldraw'
             {
-            	Match("\\shade"); 
+            	Match("\\filldraw"); 
 
 
             }
@@ -980,10 +980,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__74;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:63:7: ( '\\\\shadedraw' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:63:9: '\\\\shadedraw'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:63:7: ( '\\\\pattern' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:63:9: '\\\\pattern'
             {
-            	Match("\\shadedraw"); 
+            	Match("\\pattern"); 
 
 
             }
@@ -1004,10 +1004,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__75;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:64:7: ( '\\\\useasboundingbox' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:64:9: '\\\\useasboundingbox'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:64:7: ( '\\\\shade' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:64:9: '\\\\shade'
             {
-            	Match("\\useasboundingbox"); 
+            	Match("\\shade"); 
 
 
             }
@@ -1028,10 +1028,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__76;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:65:7: ( '\\\\fill' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:65:9: '\\\\fill'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:65:7: ( '\\\\shadedraw' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:65:9: '\\\\shadedraw'
             {
-            	Match("\\fill"); 
+            	Match("\\shadedraw"); 
 
 
             }
@@ -1052,10 +1052,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__77;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:66:7: ( '\\\\clip' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:66:9: '\\\\clip'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:66:7: ( '\\\\useasboundingbox' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:66:9: '\\\\useasboundingbox'
             {
-            	Match("\\clip"); 
+            	Match("\\useasboundingbox"); 
 
 
             }
@@ -1076,10 +1076,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__78;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:67:7: ( 'let' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:67:9: 'let'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:67:7: ( '\\\\fill' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:67:9: '\\\\fill'
             {
-            	Match("let"); 
+            	Match("\\fill"); 
 
 
             }
@@ -1100,10 +1100,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__79;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:68:7: ( 'and' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:68:9: 'and'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:68:7: ( '\\\\clip' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:68:9: '\\\\clip'
             {
-            	Match("and"); 
+            	Match("\\clip"); 
 
 
             }
@@ -1124,10 +1124,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__80;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:69:7: ( 'coordinate' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:69:9: 'coordinate'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:69:7: ( 'let' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:69:9: 'let'
             {
-            	Match("coordinate"); 
+            	Match("let"); 
 
 
             }
@@ -1148,10 +1148,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__81;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:70:7: ( 'node' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:70:9: 'node'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:70:7: ( 'and' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:70:9: 'and'
             {
-            	Match("node"); 
+            	Match("and"); 
 
 
             }
@@ -1172,10 +1172,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__82;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:71:7: ( 'at' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:71:9: 'at'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:71:7: ( 'coordinate' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:71:9: 'coordinate'
             {
-            	Match("at"); 
+            	Match("coordinate"); 
 
 
             }
@@ -1196,10 +1196,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__83;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:72:7: ( 'circle' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:72:9: 'circle'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:72:7: ( 'node' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:72:9: 'node'
             {
-            	Match("circle"); 
+            	Match("node"); 
 
 
             }
@@ -1220,10 +1220,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__84;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:73:7: ( 'ellipse' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:73:9: 'ellipse'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:73:7: ( 'at' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:73:9: 'at'
             {
-            	Match("ellipse"); 
+            	Match("at"); 
 
 
             }
@@ -1244,10 +1244,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__85;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:74:7: ( 'arc' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:74:9: 'arc'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:74:7: ( 'circle' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:74:9: 'circle'
             {
-            	Match("arc"); 
+            	Match("circle"); 
 
 
             }
@@ -1268,10 +1268,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__86;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:75:7: ( '--' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:75:9: '--'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:75:7: ( 'ellipse' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:75:9: 'ellipse'
             {
-            	Match("--"); 
+            	Match("ellipse"); 
 
 
             }
@@ -1292,10 +1292,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__87;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:76:7: ( '->' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:76:9: '->'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:76:7: ( 'arc' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:76:9: 'arc'
             {
-            	Match("->"); 
+            	Match("arc"); 
 
 
             }
@@ -1316,10 +1316,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__88;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:77:7: ( '|-' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:77:9: '|-'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:77:7: ( '--' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:77:9: '--'
             {
-            	Match("|-"); 
+            	Match("--"); 
 
 
             }
@@ -1340,10 +1340,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__89;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:78:7: ( '-|' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:78:9: '-|'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:78:7: ( '->' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:78:9: '->'
             {
-            	Match("-|"); 
+            	Match("->"); 
 
 
             }
@@ -1364,10 +1364,11 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__90;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:79:7: ( '+' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:79:9: '+'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:79:7: ( '|-' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:79:9: '|-'
             {
-            	Match('+'); 
+            	Match("|-"); 
+
 
             }
 
@@ -1387,10 +1388,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__91;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:80:7: ( '++' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:80:9: '++'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:80:7: ( '-|' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:80:9: '-|'
             {
-            	Match("++"); 
+            	Match("-|"); 
 
 
             }
@@ -1411,11 +1412,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__92;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:81:7: ( '..' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:81:9: '..'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:81:7: ( '+' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:81:9: '+'
             {
-            	Match(".."); 
-
+            	Match('+'); 
 
             }
 
@@ -1435,10 +1435,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__93;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:82:7: ( 'controls' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:82:9: 'controls'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:82:7: ( '++' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:82:9: '++'
             {
-            	Match("controls"); 
+            	Match("++"); 
 
 
             }
@@ -1459,10 +1459,10 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__94;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:83:7: ( 'tikzpicture' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:83:9: 'tikzpicture'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:83:7: ( '..' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:83:9: '..'
             {
-            	Match("tikzpicture"); 
+            	Match(".."); 
 
 
             }
@@ -1483,8 +1483,56 @@ public partial class simpletikzLexer : Lexer {
     		{
             int _type = T__95;
     	int _channel = DEFAULT_TOKEN_CHANNEL;
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:84:7: ( 'scope' )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:84:9: 'scope'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:84:7: ( 'controls' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:84:9: 'controls'
+            {
+            	Match("controls"); 
+
+
+            }
+
+            state.type = _type;
+            state.channel = _channel;
+        }
+        finally 
+    	{
+        }
+    }
+    // $ANTLR end "T__95"
+
+    // $ANTLR start "T__96"
+    public void mT__96() // throws RecognitionException [2]
+    {
+    		try
+    		{
+            int _type = T__96;
+    	int _channel = DEFAULT_TOKEN_CHANNEL;
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:85:7: ( 'tikzpicture' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:85:9: 'tikzpicture'
+            {
+            	Match("tikzpicture"); 
+
+
+            }
+
+            state.type = _type;
+            state.channel = _channel;
+        }
+        finally 
+    	{
+        }
+    }
+    // $ANTLR end "T__96"
+
+    // $ANTLR start "T__97"
+    public void mT__97() // throws RecognitionException [2]
+    {
+    		try
+    		{
+            int _type = T__97;
+    	int _channel = DEFAULT_TOKEN_CHANNEL;
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:86:7: ( 'scope' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:86:9: 'scope'
             {
             	Match("scope"); 
 
@@ -1498,7 +1546,7 @@ public partial class simpletikzLexer : Lexer {
     	{
         }
     }
-    // $ANTLR end "T__95"
+    // $ANTLR end "T__97"
 
     // $ANTLR start "ID"
     public void mID() // throws RecognitionException [2]
@@ -2489,8 +2537,8 @@ public partial class simpletikzLexer : Lexer {
 
     override public void mTokens() // throws RecognitionException 
     {
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:8: ( T__39 | T__40 | T__41 | T__42 | T__43 | T__44 | T__45 | T__46 | T__47 | T__48 | T__49 | T__50 | T__51 | T__52 | T__53 | T__54 | T__55 | T__56 | T__57 | T__58 | T__59 | T__60 | T__61 | T__62 | T__63 | T__64 | T__65 | T__66 | T__67 | T__68 | T__69 | T__70 | T__71 | T__72 | T__73 | T__74 | T__75 | T__76 | T__77 | T__78 | T__79 | T__80 | T__81 | T__82 | T__83 | T__84 | T__85 | T__86 | T__87 | T__88 | T__89 | T__90 | T__91 | T__92 | T__93 | T__94 | T__95 | ID | INT | FLOAT_WO_EXP | TIKZEDT_CMD_COMMENT | COMMENT | WS | MATHSTRING | COMMAND | ESC_SEQ | SOMETHING | SOMETHING1 )
-        int alt22 = 68;
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:8: ( T__39 | T__40 | T__41 | T__42 | T__43 | T__44 | T__45 | T__46 | T__47 | T__48 | T__49 | T__50 | T__51 | T__52 | T__53 | T__54 | T__55 | T__56 | T__57 | T__58 | T__59 | T__60 | T__61 | T__62 | T__63 | T__64 | T__65 | T__66 | T__67 | T__68 | T__69 | T__70 | T__71 | T__72 | T__73 | T__74 | T__75 | T__76 | T__77 | T__78 | T__79 | T__80 | T__81 | T__82 | T__83 | T__84 | T__85 | T__86 | T__87 | T__88 | T__89 | T__90 | T__91 | T__92 | T__93 | T__94 | T__95 | T__96 | T__97 | ID | INT | FLOAT_WO_EXP | TIKZEDT_CMD_COMMENT | COMMENT | WS | MATHSTRING | COMMAND | ESC_SEQ | SOMETHING | SOMETHING1 )
+        int alt22 = 70;
         alt22 = dfa22.Predict(input);
         switch (alt22) 
         {
@@ -2894,77 +2942,91 @@ public partial class simpletikzLexer : Lexer {
                 }
                 break;
             case 58 :
-                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:352: ID
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:352: T__96
+                {
+                	mT__96(); 
+
+                }
+                break;
+            case 59 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:358: T__97
+                {
+                	mT__97(); 
+
+                }
+                break;
+            case 60 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:364: ID
                 {
                 	mID(); 
 
                 }
                 break;
-            case 59 :
-                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:355: INT
+            case 61 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:367: INT
                 {
                 	mINT(); 
 
                 }
                 break;
-            case 60 :
-                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:359: FLOAT_WO_EXP
+            case 62 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:371: FLOAT_WO_EXP
                 {
                 	mFLOAT_WO_EXP(); 
 
                 }
                 break;
-            case 61 :
-                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:372: TIKZEDT_CMD_COMMENT
+            case 63 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:384: TIKZEDT_CMD_COMMENT
                 {
                 	mTIKZEDT_CMD_COMMENT(); 
 
                 }
                 break;
-            case 62 :
-                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:392: COMMENT
+            case 64 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:404: COMMENT
                 {
                 	mCOMMENT(); 
 
                 }
                 break;
-            case 63 :
-                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:400: WS
+            case 65 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:412: WS
                 {
                 	mWS(); 
 
                 }
                 break;
-            case 64 :
-                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:403: MATHSTRING
+            case 66 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:415: MATHSTRING
                 {
                 	mMATHSTRING(); 
 
                 }
                 break;
-            case 65 :
-                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:414: COMMAND
+            case 67 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:426: COMMAND
                 {
                 	mCOMMAND(); 
 
                 }
                 break;
-            case 66 :
-                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:422: ESC_SEQ
+            case 68 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:434: ESC_SEQ
                 {
                 	mESC_SEQ(); 
 
                 }
                 break;
-            case 67 :
-                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:430: SOMETHING
+            case 69 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:442: SOMETHING
                 {
                 	mSOMETHING(); 
 
                 }
                 break;
-            case 68 :
-                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:440: SOMETHING1
+            case 70 :
+                // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:1:452: SOMETHING1
                 {
                 	mSOMETHING1(); 
 
@@ -2994,17 +3056,17 @@ public partial class simpletikzLexer : Lexer {
     const string DFA17_eofS =
         "\x12\uffff";
     const string DFA17_minS =
-        "\x01\x25\x02\x00\x01\uffff\x05\x00\x01\uffff\x03\x00\x01\uffff"+
-        "\x04\x00";
+        "\x01\x25\x02\x00\x01\uffff\x05\x00\x01\uffff\x05\x00\x01\uffff"+
+        "\x02\x00";
     const string DFA17_maxS =
-        "\x01\x25\x02\uffff\x01\uffff\x05\uffff\x01\uffff\x03\uffff\x01"+
-        "\uffff\x04\uffff";
+        "\x01\x25\x02\uffff\x01\uffff\x05\uffff\x01\uffff\x05\uffff\x01"+
+        "\uffff\x02\uffff";
     const string DFA17_acceptS =
-        "\x03\uffff\x01\x01\x05\uffff\x01\x02\x03\uffff\x01\x01\x04\uffff";
+        "\x03\uffff\x01\x01\x05\uffff\x01\x02\x05\uffff\x01\x01\x02\uffff";
     const string DFA17_specialS =
-        "\x01\uffff\x01\x01\x01\x0c\x01\uffff\x01\x04\x01\x08\x01\x0b\x01"+
-        "\x02\x01\x09\x01\uffff\x01\x03\x01\x0a\x01\x05\x01\uffff\x01\x0d"+
-        "\x01\x07\x01\x00\x01\x06}>";
+        "\x01\uffff\x01\x03\x01\x0b\x01\uffff\x01\x0a\x01\x04\x01\x00\x01"+
+        "\x01\x01\x05\x01\uffff\x01\x02\x01\x09\x01\x06\x01\x0c\x01\x0d\x01"+
+        "\uffff\x01\x07\x01\x08}>";
     static readonly string[] DFA17_transitionS = {
             "\x01\x01",
             "\x2f\x03\x01\x02\uffd0\x03",
@@ -3019,15 +3081,15 @@ public partial class simpletikzLexer : Lexer {
             "",
             "\x0a\x08\x01\x06\x02\x08\x01\x05\x17\x08\x01\x07\x09\x08\x01"+
             "\x0b\uffd0\x08",
-            "\x0a\x0f\x01\x0d\x02\x0f\x01\x0c\x17\x0f\x01\x0e\uffda\x0f",
-            "\x0a\x09\x01\x0d\ufff5\x09",
+            "\x0a\x0d\x01\x0f\x02\x0d\x01\x0e\x17\x0d\x01\x0c\uffda\x0d",
+            "\x0a\x0d\x01\x0f\x02\x0d\x01\x0e\x17\x0d\x01\x0c\x04\x0d\x01"+
+            "\x10\uffd5\x0d",
+            "\x0a\x0d\x01\x0f\x02\x0d\x01\x0e\x17\x0d\x01\x0c\uffda\x0d",
+            "\x0a\x09\x01\x0f\ufff5\x09",
             "",
-            "\x0a\x0f\x01\x0d\x02\x0f\x01\x0c\x17\x0f\x01\x0e\x04\x0f\x01"+
-            "\x10\uffd5\x0f",
-            "\x0a\x0f\x01\x0d\x02\x0f\x01\x0c\x17\x0f\x01\x0e\uffda\x0f",
-            "\x0a\x0f\x01\x0d\x02\x0f\x01\x0c\x17\x0f\x01\x0e\x09\x0f\x01"+
-            "\x11\uffd0\x0f",
-            "\x0a\x0f\x01\x0d\x02\x0f\x01\x0c\x17\x0f\x01\x0e\uffda\x0f"
+            "\x0a\x0d\x01\x0f\x02\x0d\x01\x0e\x17\x0d\x01\x0c\x09\x0d\x01"+
+            "\x11\uffd0\x0d",
+            "\x0a\x0d\x01\x0f\x02\x0d\x01\x0e\x17\x0d\x01\x0c\uffda\x0d"
     };
 
     static readonly short[] DFA17_eot = DFA.UnpackEncodedString(DFA17_eotS);
@@ -3069,22 +3131,48 @@ public partial class simpletikzLexer : Lexer {
         switch ( s )
         {
                	case 0 : 
-                   	int LA17_16 = input.LA(1);
+                   	int LA17_6 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA17_16 == '/') ) { s = 17; }
+                   	if ( ((LA17_6 >= '\u0000' && LA17_6 <= '\uFFFF')) ) { s = 9; }
 
-                   	else if ( (LA17_16 == '\r') ) { s = 12; }
-
-                   	else if ( (LA17_16 == '\n') ) { s = 13; }
-
-                   	else if ( (LA17_16 == '%') ) { s = 14; }
-
-                   	else if ( ((LA17_16 >= '\u0000' && LA17_16 <= '\t') || (LA17_16 >= '\u000B' && LA17_16 <= '\f') || (LA17_16 >= '\u000E' && LA17_16 <= '$') || (LA17_16 >= '&' && LA17_16 <= '.') || (LA17_16 >= '0' && LA17_16 <= '\uFFFF')) ) { s = 15; }
+                   	else s = 3;
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 1 : 
+                   	int LA17_7 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_7 == '*') ) { s = 10; }
+
+                   	else if ( (LA17_7 == '%') ) { s = 7; }
+
+                   	else if ( (LA17_7 == '\r') ) { s = 5; }
+
+                   	else if ( (LA17_7 == '\n') ) { s = 6; }
+
+                   	else if ( ((LA17_7 >= '\u0000' && LA17_7 <= '\t') || (LA17_7 >= '\u000B' && LA17_7 <= '\f') || (LA17_7 >= '\u000E' && LA17_7 <= '$') || (LA17_7 >= '&' && LA17_7 <= ')') || (LA17_7 >= '+' && LA17_7 <= '\uFFFF')) ) { s = 8; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 2 : 
+                   	int LA17_10 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_10 == '/') ) { s = 11; }
+
+                   	else if ( (LA17_10 == '%') ) { s = 7; }
+
+                   	else if ( (LA17_10 == '\r') ) { s = 5; }
+
+                   	else if ( (LA17_10 == '\n') ) { s = 6; }
+
+                   	else if ( ((LA17_10 >= '\u0000' && LA17_10 <= '\t') || (LA17_10 >= '\u000B' && LA17_10 <= '\f') || (LA17_10 >= '\u000E' && LA17_10 <= '$') || (LA17_10 >= '&' && LA17_10 <= '.') || (LA17_10 >= '0' && LA17_10 <= '\uFFFF')) ) { s = 8; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 3 : 
                    	int LA17_1 = input.LA(1);
 
                    	s = -1;
@@ -3094,39 +3182,91 @@ public partial class simpletikzLexer : Lexer {
 
                    	if ( s >= 0 ) return s;
                    	break;
-               	case 2 : 
-                   	int LA17_7 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA17_7 == '*') ) { s = 10; }
-
-                   	else if ( (LA17_7 == '\r') ) { s = 5; }
-
-                   	else if ( (LA17_7 == '\n') ) { s = 6; }
-
-                   	else if ( (LA17_7 == '%') ) { s = 7; }
-
-                   	else if ( ((LA17_7 >= '\u0000' && LA17_7 <= '\t') || (LA17_7 >= '\u000B' && LA17_7 <= '\f') || (LA17_7 >= '\u000E' && LA17_7 <= '$') || (LA17_7 >= '&' && LA17_7 <= ')') || (LA17_7 >= '+' && LA17_7 <= '\uFFFF')) ) { s = 8; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 3 : 
-                   	int LA17_10 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA17_10 == '/') ) { s = 11; }
-
-                   	else if ( (LA17_10 == '\r') ) { s = 5; }
-
-                   	else if ( (LA17_10 == '\n') ) { s = 6; }
-
-                   	else if ( (LA17_10 == '%') ) { s = 7; }
-
-                   	else if ( ((LA17_10 >= '\u0000' && LA17_10 <= '\t') || (LA17_10 >= '\u000B' && LA17_10 <= '\f') || (LA17_10 >= '\u000E' && LA17_10 <= '$') || (LA17_10 >= '&' && LA17_10 <= '.') || (LA17_10 >= '0' && LA17_10 <= '\uFFFF')) ) { s = 8; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
                	case 4 : 
+                   	int LA17_5 = input.LA(1);
+
+                   	s = -1;
+                   	if ( ((LA17_5 >= '\u0000' && LA17_5 <= '\t') || (LA17_5 >= '\u000B' && LA17_5 <= '\uFFFF')) ) { s = 9; }
+
+                   	else if ( (LA17_5 == '\n') ) { s = 6; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 5 : 
+                   	int LA17_8 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_8 == '%') ) { s = 7; }
+
+                   	else if ( (LA17_8 == '\r') ) { s = 5; }
+
+                   	else if ( (LA17_8 == '\n') ) { s = 6; }
+
+                   	else if ( ((LA17_8 >= '\u0000' && LA17_8 <= '\t') || (LA17_8 >= '\u000B' && LA17_8 <= '\f') || (LA17_8 >= '\u000E' && LA17_8 <= '$') || (LA17_8 >= '&' && LA17_8 <= '\uFFFF')) ) { s = 8; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 6 : 
+                   	int LA17_12 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_12 == '*') ) { s = 16; }
+
+                   	else if ( (LA17_12 == '%') ) { s = 12; }
+
+                   	else if ( (LA17_12 == '\r') ) { s = 14; }
+
+                   	else if ( (LA17_12 == '\n') ) { s = 15; }
+
+                   	else if ( ((LA17_12 >= '\u0000' && LA17_12 <= '\t') || (LA17_12 >= '\u000B' && LA17_12 <= '\f') || (LA17_12 >= '\u000E' && LA17_12 <= '$') || (LA17_12 >= '&' && LA17_12 <= ')') || (LA17_12 >= '+' && LA17_12 <= '\uFFFF')) ) { s = 13; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 7 : 
+                   	int LA17_16 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_16 == '/') ) { s = 17; }
+
+                   	else if ( (LA17_16 == '%') ) { s = 12; }
+
+                   	else if ( (LA17_16 == '\r') ) { s = 14; }
+
+                   	else if ( (LA17_16 == '\n') ) { s = 15; }
+
+                   	else if ( ((LA17_16 >= '\u0000' && LA17_16 <= '\t') || (LA17_16 >= '\u000B' && LA17_16 <= '\f') || (LA17_16 >= '\u000E' && LA17_16 <= '$') || (LA17_16 >= '&' && LA17_16 <= '.') || (LA17_16 >= '0' && LA17_16 <= '\uFFFF')) ) { s = 13; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 8 : 
+                   	int LA17_17 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_17 == '%') ) { s = 12; }
+
+                   	else if ( ((LA17_17 >= '\u0000' && LA17_17 <= '\t') || (LA17_17 >= '\u000B' && LA17_17 <= '\f') || (LA17_17 >= '\u000E' && LA17_17 <= '$') || (LA17_17 >= '&' && LA17_17 <= '\uFFFF')) ) { s = 13; }
+
+                   	else if ( (LA17_17 == '\r') ) { s = 14; }
+
+                   	else if ( (LA17_17 == '\n') ) { s = 15; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 9 : 
+                   	int LA17_11 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_11 == '%') ) { s = 12; }
+
+                   	else if ( ((LA17_11 >= '\u0000' && LA17_11 <= '\t') || (LA17_11 >= '\u000B' && LA17_11 <= '\f') || (LA17_11 >= '\u000E' && LA17_11 <= '$') || (LA17_11 >= '&' && LA17_11 <= '\uFFFF')) ) { s = 13; }
+
+                   	else if ( (LA17_11 == '\r') ) { s = 14; }
+
+                   	else if ( (LA17_11 == '\n') ) { s = 15; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 10 : 
                    	int LA17_4 = input.LA(1);
 
                    	s = -1;
@@ -3140,93 +3280,7 @@ public partial class simpletikzLexer : Lexer {
 
                    	if ( s >= 0 ) return s;
                    	break;
-               	case 5 : 
-                   	int LA17_12 = input.LA(1);
-
-                   	s = -1;
-                   	if ( ((LA17_12 >= '\u0000' && LA17_12 <= '\t') || (LA17_12 >= '\u000B' && LA17_12 <= '\uFFFF')) ) { s = 9; }
-
-                   	else if ( (LA17_12 == '\n') ) { s = 13; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 6 : 
-                   	int LA17_17 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA17_17 == '\r') ) { s = 12; }
-
-                   	else if ( (LA17_17 == '\n') ) { s = 13; }
-
-                   	else if ( (LA17_17 == '%') ) { s = 14; }
-
-                   	else if ( ((LA17_17 >= '\u0000' && LA17_17 <= '\t') || (LA17_17 >= '\u000B' && LA17_17 <= '\f') || (LA17_17 >= '\u000E' && LA17_17 <= '$') || (LA17_17 >= '&' && LA17_17 <= '\uFFFF')) ) { s = 15; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 7 : 
-                   	int LA17_15 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA17_15 == '\r') ) { s = 12; }
-
-                   	else if ( (LA17_15 == '\n') ) { s = 13; }
-
-                   	else if ( (LA17_15 == '%') ) { s = 14; }
-
-                   	else if ( ((LA17_15 >= '\u0000' && LA17_15 <= '\t') || (LA17_15 >= '\u000B' && LA17_15 <= '\f') || (LA17_15 >= '\u000E' && LA17_15 <= '$') || (LA17_15 >= '&' && LA17_15 <= '\uFFFF')) ) { s = 15; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 8 : 
-                   	int LA17_5 = input.LA(1);
-
-                   	s = -1;
-                   	if ( ((LA17_5 >= '\u0000' && LA17_5 <= '\t') || (LA17_5 >= '\u000B' && LA17_5 <= '\uFFFF')) ) { s = 9; }
-
-                   	else if ( (LA17_5 == '\n') ) { s = 6; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 9 : 
-                   	int LA17_8 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA17_8 == '\r') ) { s = 5; }
-
-                   	else if ( (LA17_8 == '\n') ) { s = 6; }
-
-                   	else if ( (LA17_8 == '%') ) { s = 7; }
-
-                   	else if ( ((LA17_8 >= '\u0000' && LA17_8 <= '\t') || (LA17_8 >= '\u000B' && LA17_8 <= '\f') || (LA17_8 >= '\u000E' && LA17_8 <= '$') || (LA17_8 >= '&' && LA17_8 <= '\uFFFF')) ) { s = 8; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 10 : 
-                   	int LA17_11 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA17_11 == '\r') ) { s = 12; }
-
-                   	else if ( (LA17_11 == '\n') ) { s = 13; }
-
-                   	else if ( (LA17_11 == '%') ) { s = 14; }
-
-                   	else if ( ((LA17_11 >= '\u0000' && LA17_11 <= '\t') || (LA17_11 >= '\u000B' && LA17_11 <= '\f') || (LA17_11 >= '\u000E' && LA17_11 <= '$') || (LA17_11 >= '&' && LA17_11 <= '\uFFFF')) ) { s = 15; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
                	case 11 : 
-                   	int LA17_6 = input.LA(1);
-
-                   	s = -1;
-                   	if ( ((LA17_6 >= '\u0000' && LA17_6 <= '\uFFFF')) ) { s = 9; }
-
-                   	else s = 3;
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 12 : 
                    	int LA17_2 = input.LA(1);
 
                    	s = -1;
@@ -3236,19 +3290,27 @@ public partial class simpletikzLexer : Lexer {
 
                    	if ( s >= 0 ) return s;
                    	break;
+               	case 12 : 
+                   	int LA17_13 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA17_13 == '%') ) { s = 12; }
+
+                   	else if ( (LA17_13 == '\r') ) { s = 14; }
+
+                   	else if ( (LA17_13 == '\n') ) { s = 15; }
+
+                   	else if ( ((LA17_13 >= '\u0000' && LA17_13 <= '\t') || (LA17_13 >= '\u000B' && LA17_13 <= '\f') || (LA17_13 >= '\u000E' && LA17_13 <= '$') || (LA17_13 >= '&' && LA17_13 <= '\uFFFF')) ) { s = 13; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
                	case 13 : 
                    	int LA17_14 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA17_14 == '*') ) { s = 16; }
+                   	if ( ((LA17_14 >= '\u0000' && LA17_14 <= '\t') || (LA17_14 >= '\u000B' && LA17_14 <= '\uFFFF')) ) { s = 9; }
 
-                   	else if ( (LA17_14 == '\r') ) { s = 12; }
-
-                   	else if ( (LA17_14 == '\n') ) { s = 13; }
-
-                   	else if ( (LA17_14 == '%') ) { s = 14; }
-
-                   	else if ( ((LA17_14 >= '\u0000' && LA17_14 <= '\t') || (LA17_14 >= '\u000B' && LA17_14 <= '\f') || (LA17_14 >= '\u000E' && LA17_14 <= '$') || (LA17_14 >= '&' && LA17_14 <= ')') || (LA17_14 >= '+' && LA17_14 <= '\uFFFF')) ) { s = 15; }
+                   	else if ( (LA17_14 == '\n') ) { s = 15; }
 
                    	if ( s >= 0 ) return s;
                    	break;
@@ -3269,8 +3331,8 @@ public partial class simpletikzLexer : Lexer {
     const string DFA14_acceptS =
         "\x02\uffff\x01\x01\x05\uffff\x01\x02\x01\uffff\x02\x02";
     const string DFA14_specialS =
-        "\x01\x00\x01\x05\x01\uffff\x01\x06\x01\x07\x01\x01\x01\x04\x01"+
-        "\x02\x01\uffff\x01\x03\x02\uffff}>";
+        "\x01\x01\x01\x04\x01\uffff\x01\x05\x01\x03\x01\x00\x01\x06\x01"+
+        "\x07\x01\uffff\x01\x02\x02\uffff}>";
     static readonly string[] DFA14_transitionS = {
             "\x25\x02\x01\x01\uffda\x02",
             "\x2a\x02\x01\x03\uffd5\x02",
@@ -3327,6 +3389,22 @@ public partial class simpletikzLexer : Lexer {
         switch ( s )
         {
                	case 0 : 
+                   	int LA14_5 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA14_5 == '*') ) { s = 9; }
+
+                   	else if ( (LA14_5 == '%') ) { s = 5; }
+
+                   	else if ( (LA14_5 == '\r') ) { s = 7; }
+
+                   	else if ( (LA14_5 == '\n') ) { s = 8; }
+
+                   	else if ( ((LA14_5 >= '\u0000' && LA14_5 <= '\t') || (LA14_5 >= '\u000B' && LA14_5 <= '\f') || (LA14_5 >= '\u000E' && LA14_5 <= '$') || (LA14_5 >= '&' && LA14_5 <= ')') || (LA14_5 >= '+' && LA14_5 <= '\uFFFF')) ) { s = 6; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 1 : 
                    	int LA14_0 = input.LA(1);
 
                    	s = -1;
@@ -3336,83 +3414,23 @@ public partial class simpletikzLexer : Lexer {
 
                    	if ( s >= 0 ) return s;
                    	break;
-               	case 1 : 
-                   	int LA14_5 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA14_5 == '*') ) { s = 9; }
-
-                   	else if ( (LA14_5 == '\r') ) { s = 7; }
-
-                   	else if ( (LA14_5 == '\n') ) { s = 8; }
-
-                   	else if ( (LA14_5 == '%') ) { s = 5; }
-
-                   	else if ( ((LA14_5 >= '\u0000' && LA14_5 <= '\t') || (LA14_5 >= '\u000B' && LA14_5 <= '\f') || (LA14_5 >= '\u000E' && LA14_5 <= '$') || (LA14_5 >= '&' && LA14_5 <= ')') || (LA14_5 >= '+' && LA14_5 <= '\uFFFF')) ) { s = 6; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
                	case 2 : 
-                   	int LA14_7 = input.LA(1);
-
-                   	s = -1;
-                   	if ( ((LA14_7 >= '\u0000' && LA14_7 <= '\t') || (LA14_7 >= '\u000B' && LA14_7 <= '\uFFFF')) ) { s = 2; }
-
-                   	else if ( (LA14_7 == '\n') ) { s = 8; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 3 : 
                    	int LA14_9 = input.LA(1);
 
                    	s = -1;
                    	if ( (LA14_9 == '/') ) { s = 10; }
 
+                   	else if ( (LA14_9 == '%') ) { s = 5; }
+
                    	else if ( (LA14_9 == '\r') ) { s = 7; }
 
                    	else if ( (LA14_9 == '\n') ) { s = 11; }
-
-                   	else if ( (LA14_9 == '%') ) { s = 5; }
 
                    	else if ( ((LA14_9 >= '\u0000' && LA14_9 <= '\t') || (LA14_9 >= '\u000B' && LA14_9 <= '\f') || (LA14_9 >= '\u000E' && LA14_9 <= '$') || (LA14_9 >= '&' && LA14_9 <= '.') || (LA14_9 >= '0' && LA14_9 <= '\uFFFF')) ) { s = 6; }
 
                    	if ( s >= 0 ) return s;
                    	break;
-               	case 4 : 
-                   	int LA14_6 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA14_6 == '\r') ) { s = 7; }
-
-                   	else if ( (LA14_6 == '\n') ) { s = 8; }
-
-                   	else if ( (LA14_6 == '%') ) { s = 5; }
-
-                   	else if ( ((LA14_6 >= '\u0000' && LA14_6 <= '\t') || (LA14_6 >= '\u000B' && LA14_6 <= '\f') || (LA14_6 >= '\u000E' && LA14_6 <= '$') || (LA14_6 >= '&' && LA14_6 <= '\uFFFF')) ) { s = 6; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 5 : 
-                   	int LA14_1 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA14_1 == '*') ) { s = 3; }
-
-                   	else if ( ((LA14_1 >= '\u0000' && LA14_1 <= ')') || (LA14_1 >= '+' && LA14_1 <= '\uFFFF')) ) { s = 2; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 6 : 
-                   	int LA14_3 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA14_3 == '/') ) { s = 4; }
-
-                   	else if ( ((LA14_3 >= '\u0000' && LA14_3 <= '.') || (LA14_3 >= '0' && LA14_3 <= '\uFFFF')) ) { s = 2; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 7 : 
+               	case 3 : 
                    	int LA14_4 = input.LA(1);
 
                    	s = -1;
@@ -3426,6 +3444,50 @@ public partial class simpletikzLexer : Lexer {
 
                    	if ( s >= 0 ) return s;
                    	break;
+               	case 4 : 
+                   	int LA14_1 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA14_1 == '*') ) { s = 3; }
+
+                   	else if ( ((LA14_1 >= '\u0000' && LA14_1 <= ')') || (LA14_1 >= '+' && LA14_1 <= '\uFFFF')) ) { s = 2; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 5 : 
+                   	int LA14_3 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA14_3 == '/') ) { s = 4; }
+
+                   	else if ( ((LA14_3 >= '\u0000' && LA14_3 <= '.') || (LA14_3 >= '0' && LA14_3 <= '\uFFFF')) ) { s = 2; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 6 : 
+                   	int LA14_6 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA14_6 == '%') ) { s = 5; }
+
+                   	else if ( (LA14_6 == '\r') ) { s = 7; }
+
+                   	else if ( (LA14_6 == '\n') ) { s = 8; }
+
+                   	else if ( ((LA14_6 >= '\u0000' && LA14_6 <= '\t') || (LA14_6 >= '\u000B' && LA14_6 <= '\f') || (LA14_6 >= '\u000E' && LA14_6 <= '$') || (LA14_6 >= '&' && LA14_6 <= '\uFFFF')) ) { s = 6; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 7 : 
+                   	int LA14_7 = input.LA(1);
+
+                   	s = -1;
+                   	if ( ((LA14_7 >= '\u0000' && LA14_7 <= '\t') || (LA14_7 >= '\u000B' && LA14_7 <= '\uFFFF')) ) { s = 2; }
+
+                   	else if ( (LA14_7 == '\n') ) { s = 8; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
         }
         NoViableAltException nvae =
             new NoViableAltException(dfa.Description, 14, _s, input);
@@ -3433,51 +3495,51 @@ public partial class simpletikzLexer : Lexer {
         throw nvae;
     }
     const string DFA22_eotS =
-        "\x01\uffff\x01\x20\x03\uffff\x01\x33\x02\uffff\x01\x20\x02\x39"+
-        "\x05\uffff\x07\x39\x03\x20\x01\x39\x01\uffff\x01\x55\x01\x20\x01"+
-        "\uffff\x01\x20\x01\uffff\x0b\x5d\x0a\uffff\x01\x6c\x02\x39\x01\uffff"+
-        "\x02\x39\x01\x72\x05\uffff\x01\x73\x02\x39\x01\x77\x01\x78\x01\x79"+
-        "\x01\x39\x01\x7b\x01\x7c\x02\x39\x03\uffff\x01\x55\x03\uffff\x01"+
-        "\x39\x04\uffff\x01\x56\x02\uffff\x01\x5d\x01\uffff\x0c\x5d\x02\x6c"+
-        "\x01\uffff\x03\x39\x01\u0094\x01\u0095\x02\uffff\x03\x39\x03\uffff"+
-        "\x01\x39\x02\uffff\x01\u009a\x02\x39\x02\uffff\x02\x5d\x01\u00a0"+
-        "\x05\x5d\x01\u00a6\x04\x5d\x02\x6c\x02\x39\x01\u00b0\x02\uffff\x04"+
-        "\x39\x01\uffff\x01\u00b5\x01\x39\x01\uffff\x01\x5d\x01\u00ba\x01"+
-        "\uffff\x01\u00bb\x02\x5d\x01\u00be\x01\u00bf\x01\uffff\x01\u00c0"+
-        "\x01\x5d\x01\u00c3\x02\x5d\x02\x6c\x01\u00c8\x01\u00c9\x01\uffff"+
-        "\x04\x39\x01\uffff\x01\x39\x01\uffff\x01\u00d0\x01\x5d\x02\uffff"+
-        "\x02\x5d\x03\uffff\x02\x5d\x01\uffff\x01\u00d8\x01\x5d\x02\x6c\x02"+
-        "\uffff\x02\x39\x01\u00de\x02\x39\x02\uffff\x02\x5d\x01\u00e4\x04"+
-        "\x5d\x01\uffff\x01\x5d\x01\u00ea\x01\x6c\x02\x39\x01\uffff\x01\u00ee"+
-        "\x01\x39\x01\uffff\x01\x5d\x01\u00f2\x01\uffff\x01\x5d\x01\u00f4"+
-        "\x03\x5d\x01\uffff\x01\u00f8\x01\x39\x01\u00fa\x01\uffff\x01\x39"+
-        "\x01\uffff\x01\x5d\x01\uffff\x01\x5d\x01\uffff\x01\u00ff\x02\x5d"+
-        "\x01\uffff\x01\x39\x01\uffff\x01\x39\x01\uffff\x01\u0105\x01\x5d"+
-        "\x01\uffff\x01\u0107\x01\x5d\x01\u0109\x01\x39\x02\uffff\x01\u010e"+
-        "\x01\uffff\x01\x5d\x01\uffff\x01\u0110\x04\uffff\x01\x5d\x01\uffff"+
-        "\x04\x5d\x01\u0116\x01\uffff";
+        "\x01\uffff\x01\x21\x03\uffff\x01\x34\x02\uffff\x01\x21\x01\x3a"+
+        "\x01\x3c\x01\x3a\x01\x40\x05\uffff\x06\x3a\x03\x21\x01\x3a\x01\uffff"+
+        "\x01\x58\x01\x21\x01\uffff\x01\x21\x01\uffff\x0b\x60\x0a\uffff\x01"+
+        "\x6f\x02\x3a\x01\uffff\x01\x3a\x01\uffff\x02\x3a\x01\x76\x02\uffff"+
+        "\x01\x58\x05\uffff\x01\x77\x02\x3a\x01\x7b\x01\x7c\x01\x7d\x01\x3a"+
+        "\x01\x7f\x01\u0080\x01\x3a\x05\uffff\x01\x3a\x04\uffff\x01\x59\x02"+
+        "\uffff\x01\x60\x01\uffff\x0c\x60\x02\x6f\x01\uffff\x04\x3a\x01\u0098"+
+        "\x01\u0099\x02\uffff\x03\x3a\x03\uffff\x01\x3a\x02\uffff\x01\u009e"+
+        "\x01\x3a\x02\uffff\x02\x60\x01\u00a3\x05\x60\x01\u00a9\x04\x60\x02"+
+        "\x6f\x02\x3a\x01\u00b3\x01\u00b4\x02\uffff\x04\x3a\x01\uffff\x01"+
+        "\x3a\x01\uffff\x01\x60\x01\u00bd\x01\uffff\x01\u00be\x02\x60\x01"+
+        "\u00c1\x01\u00c2\x01\uffff\x01\u00c3\x01\x60\x01\u00c6\x02\x60\x02"+
+        "\x6f\x01\u00cb\x01\u00cc\x02\uffff\x05\x3a\x01\uffff\x01\u00d3\x01"+
+        "\x60\x02\uffff\x02\x60\x03\uffff\x02\x60\x01\uffff\x01\u00db\x01"+
+        "\x60\x02\x6f\x02\uffff\x02\x3a\x01\u00e1\x02\x3a\x02\uffff\x02\x60"+
+        "\x01\u00e7\x04\x60\x01\uffff\x01\x60\x01\u00ed\x01\x6f\x02\x3a\x01"+
+        "\uffff\x01\u00f1\x01\x3a\x01\uffff\x01\x60\x01\u00f5\x01\uffff\x01"+
+        "\x60\x01\u00f7\x03\x60\x01\uffff\x01\u00fb\x01\x3a\x01\u00fd\x01"+
+        "\uffff\x01\x3a\x01\uffff\x01\x60\x01\uffff\x01\x60\x01\uffff\x01"+
+        "\u0102\x02\x60\x01\uffff\x01\x3a\x01\uffff\x01\x3a\x01\uffff\x01"+
+        "\u0108\x01\x60\x01\uffff\x01\u010a\x01\x60\x01\u010c\x01\x3a\x02"+
+        "\uffff\x01\u0111\x01\uffff\x01\x60\x01\uffff\x01\u0113\x04\uffff"+
+        "\x01\x60\x01\uffff\x04\x60\x01\u0119\x01\uffff";
     const string DFA22_eofS =
-        "\u0117\uffff";
+        "\u011a\uffff";
     const string DFA22_minS =
-        "\x02\x00\x03\uffff\x01\x2b\x02\uffff\x01\x2e\x01\x63\x01\x6e\x05"+
-        "\uffff\x01\x69\x01\x6e\x01\x6c\x01\x6d\x01\x74\x01\x65\x01\x6f\x02"+
-        "\x2d\x01\x2e\x01\x69\x01\uffff\x01\x2e\x01\x00\x01\uffff\x01\x00"+
-        "\x01\uffff\x01\x65\x01\x69\x01\x6e\x01\x6f\x01\x61\x01\x6c\x01\x65"+
-        "\x01\x61\x01\x69\x01\x68\x01\x73\x0a\uffff\x01\x61\x01\x79\x01\x6f"+
-        "\x01\uffff\x01\x63\x01\x64\x01\x21\x05\uffff\x01\x21\x01\x6e\x01"+
-        "\x72\x03\x21\x01\x6c\x02\x21\x01\x74\x01\x64\x03\uffff\x01\x2e\x03"+
-        "\uffff\x01\x6b\x02\uffff\x01\x00\x01\x0a\x01\x21\x02\uffff\x01\x67"+
-        "\x01\uffff\x01\x6b\x02\x64\x01\x74\x01\x6f\x01\x69\x01\x61\x01\x66"+
-        "\x01\x74\x01\x6c\x01\x61\x01\x65\x01\x74\x01\x70\x01\uffff\x01\x6c"+
-        "\x01\x70\x01\x73\x02\x21\x02\uffff\x01\x72\x01\x74\x01\x63\x03\uffff"+
-        "\x01\x69\x02\uffff\x01\x21\x01\x65\x01\x7a\x01\x00\x01\uffff\x01"+
-        "\x69\x01\x7a\x01\x21\x01\x65\x02\x72\x01\x70\x01\x77\x01\x21\x01"+
-        "\x68\x01\x6c\x01\x64\x01\x61\x01\x79\x01\x70\x02\x65\x01\x21\x02"+
-        "\uffff\x01\x64\x01\x72\x01\x6c\x01\x70\x01\uffff\x01\x21\x01\x70"+
-        "\x01\x00\x01\x6e\x01\x21\x01\uffff\x01\x21\x01\x69\x01\x64\x02\x21"+
-        "\x01\uffff\x01\x21\x01\x65\x01\x21\x01\x65\x01\x73\x01\x6c\x01\x65"+
-        "\x02\x21\x01\uffff\x01\x69\x01\x6f\x01\x65\x01\x73\x01\uffff\x01"+
-        "\x69\x01\x00\x01\x21\x01\x65\x02\uffff\x01\x78\x01\x69\x03\uffff"+
+        "\x02\x00\x03\uffff\x01\x2b\x02\uffff\x01\x2e\x01\x63\x01\x21\x01"+
+        "\x6e\x01\x2e\x05\uffff\x01\x69\x01\x6e\x01\x6c\x01\x6d\x01\x74\x01"+
+        "\x65\x02\x2d\x01\x2e\x01\x69\x01\uffff\x01\x2e\x01\x00\x01\uffff"+
+        "\x01\x00\x01\uffff\x01\x65\x01\x69\x01\x6e\x01\x6f\x01\x61\x01\x6c"+
+        "\x01\x65\x01\x61\x01\x69\x01\x68\x01\x73\x0a\uffff\x01\x61\x01\x79"+
+        "\x01\x6f\x01\uffff\x01\x64\x01\uffff\x01\x63\x01\x64\x01\x21\x02"+
+        "\uffff\x01\x2e\x05\uffff\x01\x21\x01\x6e\x01\x72\x03\x21\x01\x6c"+
+        "\x02\x21\x01\x74\x05\uffff\x01\x6b\x02\uffff\x01\x00\x01\x0a\x01"+
+        "\x21\x02\uffff\x01\x67\x01\uffff\x01\x6b\x02\x64\x01\x74\x01\x6f"+
+        "\x01\x69\x01\x61\x01\x66\x01\x74\x01\x6c\x01\x61\x01\x65\x01\x74"+
+        "\x01\x70\x01\uffff\x01\x6c\x01\x70\x01\x65\x01\x73\x02\x21\x02\uffff"+
+        "\x01\x72\x01\x74\x01\x63\x03\uffff\x01\x69\x02\uffff\x01\x21\x01"+
+        "\x7a\x01\x00\x01\uffff\x01\x69\x01\x7a\x01\x21\x01\x65\x02\x72\x01"+
+        "\x70\x01\x77\x01\x21\x01\x68\x01\x6c\x01\x64\x01\x61\x01\x79\x01"+
+        "\x70\x02\x65\x02\x21\x02\uffff\x01\x64\x01\x72\x01\x6c\x01\x70\x01"+
+        "\uffff\x01\x70\x01\x00\x01\x6e\x01\x21\x01\uffff\x01\x21\x01\x69"+
+        "\x01\x64\x02\x21\x01\uffff\x01\x21\x01\x65\x01\x21\x01\x65\x01\x73"+
+        "\x01\x6c\x01\x65\x02\x21\x02\uffff\x01\x69\x01\x6f\x01\x65\x01\x73"+
+        "\x01\x69\x01\x00\x01\x21\x01\x65\x02\uffff\x01\x78\x01\x69\x03\uffff"+
         "\x02\x72\x01\uffff\x01\x21\x01\x62\x01\x65\x01\x6e\x02\uffff\x01"+
         "\x6e\x01\x6c\x01\x21\x01\x65\x01\x63\x01\x00\x01\uffff\x01\x79\x01"+
         "\x74\x01\x21\x02\x6e\x01\x61\x01\x72\x01\uffff\x01\x6f\x01\x41\x01"+
@@ -3490,115 +3552,118 @@ public partial class simpletikzLexer : Lexer {
         "\uffff\x01\x21\x01\x0a\x01\uffff\x01\x00\x01\uffff\x01\x6e\x01\uffff"+
         "\x01\x67\x01\x62\x01\x6f\x01\x78\x01\x21\x01\uffff";
     const string DFA22_maxS =
-        "\x02\uffff\x03\uffff\x01\x3d\x02\uffff\x01\x2e\x02\x74\x05\uffff"+
-        "\x01\x6f\x01\x6e\x01\x78\x01\x6d\x01\x74\x01\x65\x01\x6f\x01\x7c"+
-        "\x01\x2d\x01\x39\x01\x69\x01\uffff\x01\x39\x01\uffff\x01\uffff\x01"+
-        "\uffff\x01\uffff\x01\x65\x01\x69\x01\x6e\x01\x6f\x01\x61\x01\x6f"+
-        "\x01\x72\x01\x61\x01\x69\x01\x68\x01\x73\x0a\uffff\x01\x73\x01\x79"+
-        "\x01\x6f\x01\uffff\x01\x67\x01\x64\x01\x7a\x05\uffff\x01\x7a\x01"+
-        "\x6f\x01\x72\x03\x7a\x01\x6c\x02\x7a\x01\x74\x01\x64\x03\uffff\x01"+
-        "\x39\x03\uffff\x01\x6b\x02\uffff\x01\uffff\x02\x21\x02\uffff\x01"+
-        "\x67\x01\uffff\x01\x6b\x02\x64\x01\x74\x01\x6f\x01\x69\x01\x61\x01"+
-        "\x66\x01\x74\x01\x6c\x01\x61\x01\x65\x01\x74\x01\x70\x01\uffff\x01"+
-        "\x6c\x01\x70\x01\x73\x02\x7a\x02\uffff\x01\x72\x01\x74\x01\x63\x03"+
-        "\uffff\x01\x69\x02\uffff\x01\x7a\x01\x65\x01\x7a\x01\uffff\x01\uffff"+
-        "\x01\x69\x02\x7a\x01\x65\x02\x72\x01\x70\x01\x77\x01\x7a\x01\x74"+
-        "\x01\x6c\x01\x64\x01\x61\x01\x79\x01\x70\x02\x65\x01\x7a\x02\uffff"+
-        "\x01\x64\x01\x72\x01\x6c\x01\x70\x01\uffff\x01\x7a\x01\x70\x01\uffff"+
-        "\x01\x6e\x01\x7a\x01\uffff\x01\x7a\x01\x69\x01\x64\x02\x7a\x01\uffff"+
-        "\x01\x7a\x01\x65\x01\x7a\x01\x65\x01\x73\x01\x6c\x01\x65\x02\x7a"+
-        "\x01\uffff\x01\x69\x01\x6f\x01\x65\x01\x73\x01\uffff\x01\x69\x01"+
-        "\uffff\x01\x7a\x01\x74\x02\uffff\x01\x78\x01\x69\x03\uffff\x02\x72"+
-        "\x01\uffff\x01\x7a\x01\x62\x01\x65\x01\x6e\x02\uffff\x01\x6e\x01"+
-        "\x6c\x01\x7a\x01\x65\x01\x63\x01\uffff\x01\uffff\x01\x79\x01\x74"+
-        "\x01\x7a\x02\x6e\x01\x61\x01\x72\x01\uffff\x01\x6f\x01\x7a\x01\x64"+
-        "\x01\x61\x01\x73\x01\uffff\x01\x7a\x01\x74\x01\uffff\x01\x6c\x01"+
-        "\x7a\x01\uffff\x01\x61\x01\x7a\x01\x77\x01\x61\x01\x75\x01\uffff"+
-        "\x01\x7a\x01\x74\x01\x7a\x01\uffff\x01\x75\x01\uffff\x01\x65\x01"+
-        "\uffff\x01\x74\x01\uffff\x01\x7a\x01\x77\x01\x6e\x01\uffff\x01\x65"+
-        "\x01\uffff\x01\x72\x01\uffff\x01\x7a\x01\x65\x01\uffff\x01\x7a\x01"+
-        "\x64\x01\x7a\x01\x65\x01\uffff\x01\uffff\x01\x7a\x01\uffff\x01\x69"+
-        "\x01\uffff\x01\x7a\x01\x0a\x01\uffff\x01\uffff\x01\uffff\x01\x6e"+
-        "\x01\uffff\x01\x67\x01\x62\x01\x6f\x01\x78\x01\x7a\x01\uffff";
+        "\x02\uffff\x03\uffff\x01\x3d\x02\uffff\x01\x2e\x01\x74\x01\x7a"+
+        "\x01\x74\x01\x39\x05\uffff\x01\x6f\x01\x6e\x01\x78\x01\x6d\x01\x74"+
+        "\x01\x65\x01\x7c\x01\x2d\x01\x39\x01\x69\x01\uffff\x01\x39\x01\uffff"+
+        "\x01\uffff\x01\uffff\x01\uffff\x01\x65\x01\x69\x01\x6e\x01\x6f\x01"+
+        "\x61\x01\x6f\x01\x72\x01\x61\x01\x69\x01\x68\x01\x73\x0a\uffff\x01"+
+        "\x73\x01\x79\x01\x6f\x01\uffff\x01\x64\x01\uffff\x01\x67\x01\x64"+
+        "\x01\x7a\x02\uffff\x01\x39\x05\uffff\x01\x7a\x01\x6f\x01\x72\x03"+
+        "\x7a\x01\x6c\x02\x7a\x01\x74\x05\uffff\x01\x6b\x02\uffff\x01\uffff"+
+        "\x02\x21\x02\uffff\x01\x67\x01\uffff\x01\x6b\x02\x64\x01\x74\x01"+
+        "\x6f\x01\x69\x01\x61\x01\x66\x01\x74\x01\x6c\x01\x61\x01\x65\x01"+
+        "\x74\x01\x70\x01\uffff\x01\x6c\x01\x70\x01\x65\x01\x73\x02\x7a\x02"+
+        "\uffff\x01\x72\x01\x74\x01\x63\x03\uffff\x01\x69\x02\uffff\x02\x7a"+
+        "\x01\uffff\x01\uffff\x01\x69\x02\x7a\x01\x65\x02\x72\x01\x70\x01"+
+        "\x77\x01\x7a\x01\x74\x01\x6c\x01\x64\x01\x61\x01\x79\x01\x70\x02"+
+        "\x65\x02\x7a\x02\uffff\x01\x64\x01\x72\x01\x6c\x01\x70\x01\uffff"+
+        "\x01\x70\x01\uffff\x01\x6e\x01\x7a\x01\uffff\x01\x7a\x01\x69\x01"+
+        "\x64\x02\x7a\x01\uffff\x01\x7a\x01\x65\x01\x7a\x01\x65\x01\x73\x01"+
+        "\x6c\x01\x65\x02\x7a\x02\uffff\x01\x69\x01\x6f\x01\x65\x01\x73\x01"+
+        "\x69\x01\uffff\x01\x7a\x01\x74\x02\uffff\x01\x78\x01\x69\x03\uffff"+
+        "\x02\x72\x01\uffff\x01\x7a\x01\x62\x01\x65\x01\x6e\x02\uffff\x01"+
+        "\x6e\x01\x6c\x01\x7a\x01\x65\x01\x63\x01\uffff\x01\uffff\x01\x79"+
+        "\x01\x74\x01\x7a\x02\x6e\x01\x61\x01\x72\x01\uffff\x01\x6f\x01\x7a"+
+        "\x01\x64\x01\x61\x01\x73\x01\uffff\x01\x7a\x01\x74\x01\uffff\x01"+
+        "\x6c\x01\x7a\x01\uffff\x01\x61\x01\x7a\x01\x77\x01\x61\x01\x75\x01"+
+        "\uffff\x01\x7a\x01\x74\x01\x7a\x01\uffff\x01\x75\x01\uffff\x01\x65"+
+        "\x01\uffff\x01\x74\x01\uffff\x01\x7a\x01\x77\x01\x6e\x01\uffff\x01"+
+        "\x65\x01\uffff\x01\x72\x01\uffff\x01\x7a\x01\x65\x01\uffff\x01\x7a"+
+        "\x01\x64\x01\x7a\x01\x65\x01\uffff\x01\uffff\x01\x7a\x01\uffff\x01"+
+        "\x69\x01\uffff\x01\x7a\x01\x0a\x01\uffff\x01\uffff\x01\uffff\x01"+
+        "\x6e\x01\uffff\x01\x67\x01\x62\x01\x6f\x01\x78\x01\x7a\x01\uffff";
     const string DFA22_acceptS =
-        "\x02\uffff\x01\x05\x01\x06\x01\x07\x01\uffff\x01\x09\x01\x0a\x03"+
-        "\uffff\x01\x0f\x01\x10\x01\x11\x01\x12\x01\x13\x0b\uffff\x01\x3a"+
-        "\x02\uffff\x01\x3f\x01\uffff\x01\x43\x0b\uffff\x01\x41\x01\x42\x01"+
-        "\x05\x01\x06\x01\x07\x01\x08\x01\x35\x01\x34\x01\x09\x01\x0a\x03"+
-        "\uffff\x01\x3a\x03\uffff\x01\x0f\x01\x10\x01\x11\x01\x12\x01\x13"+
-        "\x0b\uffff\x01\x30\x01\x31\x01\x33\x01\uffff\x01\x3c\x01\x32\x01"+
-        "\x36\x01\uffff\x01\x3b\x01\x3e\x03\uffff\x01\x3f\x01\x40\x01\uffff"+
-        "\x01\x41\x0e\uffff\x01\x44\x05\uffff\x01\x2c\x01\x14\x03\uffff\x01"+
-        "\x15\x01\x16\x01\x19\x01\uffff\x01\x17\x01\x18\x04\uffff\x01\x3d"+
-        "\x12\uffff\x01\x2f\x01\x29\x04\uffff\x01\x28\x05\uffff\x01\x1a\x05"+
-        "\uffff\x01\x20\x09\uffff\x01\x0e\x04\uffff\x01\x2b\x04\uffff\x01"+
-        "\x04\x01\x1b\x02\uffff\x01\x27\x01\x1e\x01\x1f\x02\uffff\x01\x26"+
-        "\x04\uffff\x01\x0d\x01\x39\x06\uffff\x01\x01\x07\uffff\x01\x23\x05"+
-        "\uffff\x01\x2d\x05\uffff\x01\x1c\x05\uffff\x01\x0b\x03\uffff\x01"+
-        "\x2e\x03\uffff\x01\x03\x01\uffff\x01\x22\x03\uffff\x01\x0c\x01\uffff"+
-        "\x01\x37\x04\uffff\x01\x21\x05\uffff\x01\x02\x01\uffff\x01\x24\x01"+
-        "\uffff\x01\x2a\x02\uffff\x01\x3d\x01\uffff\x01\x1d\x01\uffff\x01"+
-        "\x38\x05\uffff\x01\x25";
+        "\x02\uffff\x01\x05\x01\x06\x01\x07\x01\uffff\x01\x09\x01\x0a\x05"+
+        "\uffff\x01\x11\x01\x12\x01\x13\x01\x14\x01\x15\x0a\uffff\x01\x3c"+
+        "\x02\uffff\x01\x41\x01\uffff\x01\x45\x0b\uffff\x01\x43\x01\x44\x01"+
+        "\x05\x01\x06\x01\x07\x01\x08\x01\x37\x01\x36\x01\x09\x01\x0a\x03"+
+        "\uffff\x01\x3c\x01\uffff\x01\x0e\x03\uffff\x01\x10\x01\x3e\x01\uffff"+
+        "\x01\x11\x01\x12\x01\x13\x01\x14\x01\x15\x0a\uffff\x01\x32\x01\x33"+
+        "\x01\x35\x01\x34\x01\x38\x01\uffff\x01\x3d\x01\x40\x03\uffff\x01"+
+        "\x41\x01\x42\x01\uffff\x01\x43\x0e\uffff\x01\x46\x06\uffff\x01\x2e"+
+        "\x01\x16\x03\uffff\x01\x17\x01\x18\x01\x1b\x01\uffff\x01\x19\x01"+
+        "\x1a\x03\uffff\x01\x3f\x13\uffff\x01\x31\x01\x2b\x04\uffff\x01\x2a"+
+        "\x04\uffff\x01\x1c\x05\uffff\x01\x22\x09\uffff\x01\x2d\x01\x0f\x08"+
+        "\uffff\x01\x04\x01\x1d\x02\uffff\x01\x29\x01\x20\x01\x21\x02\uffff"+
+        "\x01\x28\x04\uffff\x01\x0d\x01\x3b\x06\uffff\x01\x01\x07\uffff\x01"+
+        "\x25\x05\uffff\x01\x2f\x05\uffff\x01\x1e\x05\uffff\x01\x0b\x03\uffff"+
+        "\x01\x30\x03\uffff\x01\x03\x01\uffff\x01\x24\x03\uffff\x01\x0c\x01"+
+        "\uffff\x01\x39\x04\uffff\x01\x23\x05\uffff\x01\x02\x01\uffff\x01"+
+        "\x26\x01\uffff\x01\x2c\x02\uffff\x01\x3f\x01\uffff\x01\x1f\x01\uffff"+
+        "\x01\x3a\x05\uffff\x01\x27";
     const string DFA22_specialS =
-        "\x01\x00\x01\x01\x1b\uffff\x01\x02\x01\uffff\x01\x04\x37\uffff"+
-        "\x01\x0c\x28\uffff\x01\x05\x1c\uffff\x01\x06\x19\uffff\x01\x07\x17"+
-        "\uffff\x01\x08\x11\uffff\x01\x09\x0e\uffff\x01\x0a\x0b\uffff\x01"+
-        "\x0b\x07\uffff\x01\x0d\x08\uffff\x01\x03\x09\uffff}>";
+        "\x01\x0a\x01\x0b\x1c\uffff\x01\x09\x01\uffff\x01\x0c\x39\uffff"+
+        "\x01\x0d\x28\uffff\x01\x02\x1c\uffff\x01\x03\x19\uffff\x01\x04\x17"+
+        "\uffff\x01\x05\x11\uffff\x01\x06\x0e\uffff\x01\x07\x0b\uffff\x01"+
+        "\x08\x07\uffff\x01\x00\x08\uffff\x01\x01\x09\uffff}>";
     static readonly string[] DFA22_transitionS = {
-            "\x09\x20\x02\x1e\x02\x20\x01\x1e\x12\x20\x01\x1e\x03\x20\x01"+
-            "\x1f\x01\x1d\x02\x20\x01\x0b\x01\x0c\x01\x20\x01\x05\x01\x06"+
-            "\x01\x17\x01\x19\x01\x08\x0a\x1c\x01\x07\x01\x0f\x01\x20\x01"+
-            "\x04\x03\x20\x1a\x1b\x01\x0d\x01\x01\x01\x0e\x01\x20\x01\x1b"+
-            "\x01\x20\x01\x0a\x01\x1b\x01\x10\x01\x1b\x01\x12\x03\x1b\x01"+
-            "\x11\x02\x1b\x01\x15\x01\x13\x01\x16\x01\x1b\x01\x14\x02\x1b"+
-            "\x01\x09\x01\x1a\x06\x1b\x01\x02\x01\x18\x01\x03\uff82\x20",
-            "\x41\x2d\x1a\x2c\x04\x2d\x01\x2c\x01\x2d\x01\x2c\x01\x21\x01"+
-            "\x26\x01\x27\x01\x23\x01\x29\x06\x2c\x01\x25\x01\x24\x01\x2c"+
-            "\x01\x28\x02\x2c\x01\x2a\x01\x22\x01\x2b\x05\x2c\uff85\x2d",
+            "\x09\x21\x02\x1f\x02\x21\x01\x1f\x12\x21\x01\x1f\x03\x21\x01"+
+            "\x20\x01\x1e\x02\x21\x01\x0d\x01\x0e\x01\x21\x01\x05\x01\x06"+
+            "\x01\x18\x01\x1a\x01\x08\x02\x1d\x01\x0c\x07\x1d\x01\x07\x01"+
+            "\x11\x01\x21\x01\x04\x03\x21\x1a\x1c\x01\x0f\x01\x01\x01\x10"+
+            "\x01\x21\x01\x1c\x01\x21\x01\x0b\x01\x1c\x01\x12\x01\x1c\x01"+
+            "\x14\x03\x1c\x01\x13\x02\x1c\x01\x17\x01\x15\x01\x0a\x01\x1c"+
+            "\x01\x16\x02\x1c\x01\x09\x01\x1b\x06\x1c\x01\x02\x01\x19\x01"+
+            "\x03\uff82\x21",
+            "\x41\x2e\x1a\x2d\x04\x2e\x01\x2d\x01\x2e\x01\x2d\x01\x22\x01"+
+            "\x27\x01\x28\x01\x24\x01\x2a\x06\x2d\x01\x26\x01\x25\x01\x2d"+
+            "\x01\x29\x02\x2d\x01\x2b\x01\x23\x01\x2c\x05\x2d\uff85\x2e",
             "",
             "",
             "",
-            "\x01\x32\x11\uffff\x01\x31",
+            "\x01\x33\x11\uffff\x01\x32",
             "",
             "",
-            "\x01\x36",
-            "\x01\x38\x10\uffff\x01\x37",
-            "\x01\x3b\x03\uffff\x01\x3a\x01\uffff\x01\x3c",
+            "\x01\x37",
+            "\x01\x39\x10\uffff\x01\x38",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x0e\x3a\x01\x3b\x0b\x3a",
+            "\x01\x3e\x03\uffff\x01\x3d\x01\uffff\x01\x3f",
+            "\x01\x41\x01\uffff\x0a\x42",
             "",
             "",
             "",
             "",
             "",
-            "\x01\x44\x03\uffff\x01\x42\x01\uffff\x01\x43",
-            "\x01\x45",
-            "\x01\x48\x01\x47\x0a\uffff\x01\x46",
-            "\x01\x49",
-            "\x01\x4a",
+            "\x01\x4a\x03\uffff\x01\x48\x01\uffff\x01\x49",
             "\x01\x4b",
-            "\x01\x4c",
-            "\x01\x4d\x01\x51\x01\uffff\x0a\x50\x04\uffff\x01\x4e\x3d\uffff"+
+            "\x01\x4e\x01\x4d\x0a\uffff\x01\x4c",
             "\x01\x4f",
-            "\x01\x52",
-            "\x01\x53\x01\uffff\x0a\x51",
+            "\x01\x50",
+            "\x01\x51",
+            "\x01\x52\x01\x41\x01\uffff\x0a\x42\x04\uffff\x01\x53\x3d\uffff"+
             "\x01\x54",
+            "\x01\x55",
+            "\x01\x56\x01\uffff\x0a\x41",
+            "\x01\x57",
             "",
-            "\x01\x51\x01\uffff\x0a\x50",
-            "\x09\x56\x01\x57\x01\x59\x02\x56\x01\x58\x12\x56\x01\x57\uffdf"+
-            "\x56",
+            "\x01\x41\x01\uffff\x0a\x42",
+            "\x09\x59\x01\x5a\x01\x5c\x02\x59\x01\x5b\x12\x59\x01\x5a\uffdf"+
+            "\x59",
             "",
-            "\x00\x5b",
+            "\x00\x5e",
             "",
-            "\x01\x5c",
-            "\x01\x5e",
             "\x01\x5f",
-            "\x01\x60",
             "\x01\x61",
-            "\x01\x63\x02\uffff\x01\x62",
-            "\x01\x65\x0c\uffff\x01\x64",
-            "\x01\x66",
-            "\x01\x67",
-            "\x01\x68",
+            "\x01\x62",
+            "\x01\x63",
+            "\x01\x64",
+            "\x01\x66\x02\uffff\x01\x65",
+            "\x01\x68\x0c\uffff\x01\x67",
             "\x01\x69",
+            "\x01\x6a",
+            "\x01\x6b",
+            "\x01\x6c",
             "",
             "",
             "",
@@ -3609,56 +3674,55 @@ public partial class simpletikzLexer : Lexer {
             "",
             "",
             "",
-            "\x01\x6b\x11\uffff\x01\x6a",
-            "\x01\x6d",
-            "\x01\x6e",
-            "",
-            "\x01\x70\x03\uffff\x01\x6f",
+            "\x01\x6e\x11\uffff\x01\x6d",
+            "\x01\x70",
             "\x01\x71",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "",
+            "\x01\x72",
+            "",
+            "\x01\x74\x03\uffff\x01\x73",
+            "\x01\x75",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
+            "",
+            "",
+            "\x01\x41\x01\uffff\x0a\x42",
             "",
             "",
             "",
             "",
             "",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x75\x01\x74",
-            "\x01\x76",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
+            "\x01\x79\x01\x78",
             "\x01\x7a",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x7d",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
             "\x01\x7e",
-            "",
-            "",
-            "",
-            "\x01\x51\x01\uffff\x0a\x50",
-            "",
-            "",
-            "",
-            "\x01\x7f",
-            "",
-            "",
-            "\x21\x56\x01\u0080\uffde\x56",
-            "\x01\x56\x16\uffff\x01\u0081",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
             "\x01\u0081",
+            "",
+            "",
+            "",
             "",
             "",
             "\x01\u0082",
             "",
-            "\x01\u0083",
+            "",
+            "\x21\x59\x01\u0083\uffde\x59",
+            "\x01\x59\x16\uffff\x01\u0084",
             "\x01\u0084",
+            "",
+            "",
             "\x01\u0085",
+            "",
             "\x01\u0086",
             "\x01\u0087",
             "\x01\u0088",
@@ -3670,206 +3734,209 @@ public partial class simpletikzLexer : Lexer {
             "\x01\u008e",
             "\x01\u008f",
             "\x01\u0090",
-            "",
             "\x01\u0091",
             "\x01\u0092",
             "\x01\u0093",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
             "",
-            "",
+            "\x01\u0094",
+            "\x01\u0095",
             "\x01\u0096",
             "\x01\u0097",
-            "\x01\u0098",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
             "",
             "",
-            "",
-            "\x01\u0099",
-            "",
-            "",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x01\u009a",
             "\x01\u009b",
             "\x01\u009c",
-            "\x54\x56\x01\u009d\uffab\x56",
             "",
-            "\x01\u009e",
+            "",
+            "",
+            "\x01\u009d",
+            "",
+            "",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
             "\x01\u009f",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
+            "\x54\x59\x01\u00a0\uffab\x59",
+            "",
             "\x01\u00a1",
             "\x01\u00a2",
-            "\x01\u00a3",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
             "\x01\u00a4",
             "\x01\u00a5",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u00a7\x0b\uffff\x01\u00a8",
-            "\x01\u00a9",
-            "\x01\u00aa",
-            "\x01\u00ab",
+            "\x01\u00a6",
+            "\x01\u00a7",
+            "\x01\u00a8",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
+            "\x01\u00aa\x0b\uffff\x01\u00ab",
             "\x01\u00ac",
             "\x01\u00ad",
             "\x01\u00ae",
             "\x01\u00af",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "",
-            "",
+            "\x01\u00b0",
             "\x01\u00b1",
             "\x01\u00b2",
-            "\x01\u00b3",
-            "\x01\u00b4",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
             "",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "",
+            "\x01\u00b5",
             "\x01\u00b6",
-            "\x49\x56\x01\u00b7\uffb6\x56",
+            "\x01\u00b7",
             "\x01\u00b8",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x12\x5d\x01\u00b9\x07\x5d",
             "",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u00bc",
-            "\x01\u00bd",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
+            "\x01\u00b9",
+            "\x49\x59\x01\u00ba\uffb6\x59",
+            "\x01\u00bb",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x12\x60\x01\u00bc\x07\x60",
             "",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u00c1",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x03\x5d\x01\u00c2\x16\x5d",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
+            "\x01\u00bf",
+            "\x01\u00c0",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
+            "",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
             "\x01\u00c4",
-            "\x01\u00c5",
-            "\x01\u00c6",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x03\x60\x01\u00c5\x16\x60",
             "\x01\u00c7",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "",
+            "\x01\u00c8",
+            "\x01\u00c9",
             "\x01\u00ca",
-            "\x01\u00cb",
-            "\x01\u00cc",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
+            "",
+            "",
             "\x01\u00cd",
-            "",
             "\x01\u00ce",
-            "\x4b\x56\x01\u00cf\uffb4\x56",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u00d2\x0e\uffff\x01\u00d1",
+            "\x01\u00cf",
+            "\x01\u00d0",
+            "\x01\u00d1",
+            "\x4b\x59\x01\u00d2\uffb4\x59",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
+            "\x01\u00d5\x0e\uffff\x01\u00d4",
             "",
             "",
-            "\x01\u00d3",
-            "\x01\u00d4",
-            "",
-            "",
-            "",
-            "\x01\u00d5",
             "\x01\u00d6",
+            "\x01\u00d7",
             "",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x03\x5d\x01\u00d7\x16\x5d",
+            "",
+            "",
+            "\x01\u00d8",
             "\x01\u00d9",
-            "\x01\u00da",
-            "\x01\u00db",
             "",
-            "",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x03\x60\x01\u00da\x16\x60",
             "\x01\u00dc",
             "\x01\u00dd",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x01\u00de",
+            "",
+            "",
             "\x01\u00df",
             "\x01\u00e0",
-            "\x5a\x56\x01\u00e1\uffa5\x56",
-            "",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
             "\x01\u00e2",
             "\x01\u00e3",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
+            "\x5a\x59\x01\u00e4\uffa5\x59",
+            "",
             "\x01\u00e5",
             "\x01\u00e6",
-            "\x01\u00e7",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
             "\x01\u00e8",
-            "",
             "\x01\u00e9",
-            "\x1a\x6c\x06\uffff\x1a\x6c",
+            "\x01\u00ea",
             "\x01\u00eb",
+            "",
             "\x01\u00ec",
-            "\x01\u00ed",
-            "",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x1a\x6f\x06\uffff\x1a\x6f",
+            "\x01\u00ee",
             "\x01\u00ef",
-            "\x45\x56\x01\u00f0\uffba\x56",
-            "\x01\u00f1",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
+            "\x01\u00f0",
             "",
-            "\x01\u00f3",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u00f5",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
+            "\x01\u00f2",
+            "\x45\x59\x01\u00f3\uffba\x59",
+            "\x01\u00f4",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
+            "",
             "\x01\u00f6",
-            "\x01\u00f7",
-            "",
-            "\x1a\x6c\x06\uffff\x1a\x6c",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
+            "\x01\u00f8",
             "\x01\u00f9",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
+            "\x01\u00fa",
             "",
-            "\x01\u00fb",
-            "\x44\x56\x01\u00fc\uffbb\x56",
-            "\x01\u00fd",
+            "\x1a\x6f\x06\uffff\x1a\x6f",
+            "\x01\u00fc",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
             "",
             "\x01\u00fe",
-            "",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
+            "\x44\x59\x01\u00ff\uffbb\x59",
             "\x01\u0100",
+            "",
             "\x01\u0101",
             "",
-            "\x01\u0102",
-            "",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
             "\x01\u0103",
-            "\x54\x56\x01\u0104\uffab\x56",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
+            "\x01\u0104",
+            "",
+            "\x01\u0105",
+            "",
             "\x01\u0106",
+            "\x54\x59\x01\u0107\uffab\x59",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
+            "\x01\u0109",
             "",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "\x01\u0108",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\u010a",
-            "\x0a\u010d\x01\u010c\x02\u010d\x01\u010b\ufff2\u010d",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
+            "\x01\u010b",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
+            "\x01\u010d",
+            "\x0a\u0110\x01\u010f\x02\u0110\x01\u010e\ufff2\u0110",
             "",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
-            "",
-            "\x01\u010f",
-            "",
-            "\x01\x39\x0c\uffff\x01\x39\x01\uffff\x0a\x39\x07\uffff\x1a"+
-            "\x39\x04\uffff\x01\x39\x01\uffff\x1a\x39",
-            "\x01\u010c",
-            "",
-            "\x0a\u010d\x01\u010c\x02\u010d\x01\u010b\ufff2\u010d",
-            "",
-            "\x01\u0111",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
             "",
             "\x01\u0112",
-            "\x01\u0113",
+            "",
+            "\x01\x3a\x0c\uffff\x01\x3a\x01\uffff\x0a\x3a\x07\uffff\x1a"+
+            "\x3a\x04\uffff\x01\x3a\x01\uffff\x1a\x3a",
+            "\x01\u010f",
+            "",
+            "\x0a\u0110\x01\u010f\x02\u0110\x01\u010e\ufff2\u0110",
+            "",
             "\x01\u0114",
+            "",
             "\x01\u0115",
-            "\x01\x5d\x0c\uffff\x01\x5d\x01\uffff\x0a\x5d\x07\uffff\x1a"+
-            "\x5d\x04\uffff\x01\x5d\x01\uffff\x1a\x5d",
+            "\x01\u0116",
+            "\x01\u0117",
+            "\x01\u0118",
+            "\x01\x60\x0c\uffff\x01\x60\x01\uffff\x0a\x60\x07\uffff\x1a"+
+            "\x60\x04\uffff\x01\x60\x01\uffff\x1a\x60",
             ""
     };
 
@@ -3899,7 +3966,7 @@ public partial class simpletikzLexer : Lexer {
 
         override public string Description
         {
-            get { return "1:1: Tokens : ( T__39 | T__40 | T__41 | T__42 | T__43 | T__44 | T__45 | T__46 | T__47 | T__48 | T__49 | T__50 | T__51 | T__52 | T__53 | T__54 | T__55 | T__56 | T__57 | T__58 | T__59 | T__60 | T__61 | T__62 | T__63 | T__64 | T__65 | T__66 | T__67 | T__68 | T__69 | T__70 | T__71 | T__72 | T__73 | T__74 | T__75 | T__76 | T__77 | T__78 | T__79 | T__80 | T__81 | T__82 | T__83 | T__84 | T__85 | T__86 | T__87 | T__88 | T__89 | T__90 | T__91 | T__92 | T__93 | T__94 | T__95 | ID | INT | FLOAT_WO_EXP | TIKZEDT_CMD_COMMENT | COMMENT | WS | MATHSTRING | COMMAND | ESC_SEQ | SOMETHING | SOMETHING1 );"; }
+            get { return "1:1: Tokens : ( T__39 | T__40 | T__41 | T__42 | T__43 | T__44 | T__45 | T__46 | T__47 | T__48 | T__49 | T__50 | T__51 | T__52 | T__53 | T__54 | T__55 | T__56 | T__57 | T__58 | T__59 | T__60 | T__61 | T__62 | T__63 | T__64 | T__65 | T__66 | T__67 | T__68 | T__69 | T__70 | T__71 | T__72 | T__73 | T__74 | T__75 | T__76 | T__77 | T__78 | T__79 | T__80 | T__81 | T__82 | T__83 | T__84 | T__85 | T__86 | T__87 | T__88 | T__89 | T__90 | T__91 | T__92 | T__93 | T__94 | T__95 | T__96 | T__97 | ID | INT | FLOAT_WO_EXP | TIKZEDT_CMD_COMMENT | COMMENT | WS | MATHSTRING | COMMAND | ESC_SEQ | SOMETHING | SOMETHING1 );"; }
         }
 
     }
@@ -3912,6 +3979,116 @@ public partial class simpletikzLexer : Lexer {
         switch ( s )
         {
                	case 0 : 
+                   	int LA22_263 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA22_263 == '\r') ) { s = 270; }
+
+                   	else if ( (LA22_263 == '\n') ) { s = 271; }
+
+                   	else if ( ((LA22_263 >= '\u0000' && LA22_263 <= '\t') || (LA22_263 >= '\u000B' && LA22_263 <= '\f') || (LA22_263 >= '\u000E' && LA22_263 <= '\uFFFF')) ) { s = 272; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 1 : 
+                   	int LA22_272 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA22_272 == '\r') ) { s = 270; }
+
+                   	else if ( (LA22_272 == '\n') ) { s = 271; }
+
+                   	else if ( ((LA22_272 >= '\u0000' && LA22_272 <= '\t') || (LA22_272 >= '\u000B' && LA22_272 <= '\f') || (LA22_272 >= '\u000E' && LA22_272 <= '\uFFFF')) ) { s = 272; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 2 : 
+                   	int LA22_131 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA22_131 == 'T') ) { s = 160; }
+
+                   	else if ( ((LA22_131 >= '\u0000' && LA22_131 <= 'S') || (LA22_131 >= 'U' && LA22_131 <= '\uFFFF')) ) { s = 89; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 3 : 
+                   	int LA22_160 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA22_160 == 'I') ) { s = 186; }
+
+                   	else if ( ((LA22_160 >= '\u0000' && LA22_160 <= 'H') || (LA22_160 >= 'J' && LA22_160 <= '\uFFFF')) ) { s = 89; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 4 : 
+                   	int LA22_186 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA22_186 == 'K') ) { s = 210; }
+
+                   	else if ( ((LA22_186 >= '\u0000' && LA22_186 <= 'J') || (LA22_186 >= 'L' && LA22_186 <= '\uFFFF')) ) { s = 89; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 5 : 
+                   	int LA22_210 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA22_210 == 'Z') ) { s = 228; }
+
+                   	else if ( ((LA22_210 >= '\u0000' && LA22_210 <= 'Y') || (LA22_210 >= '[' && LA22_210 <= '\uFFFF')) ) { s = 89; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 6 : 
+                   	int LA22_228 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA22_228 == 'E') ) { s = 243; }
+
+                   	else if ( ((LA22_228 >= '\u0000' && LA22_228 <= 'D') || (LA22_228 >= 'F' && LA22_228 <= '\uFFFF')) ) { s = 89; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 7 : 
+                   	int LA22_243 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA22_243 == 'D') ) { s = 255; }
+
+                   	else if ( ((LA22_243 >= '\u0000' && LA22_243 <= 'C') || (LA22_243 >= 'E' && LA22_243 <= '\uFFFF')) ) { s = 89; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 8 : 
+                   	int LA22_255 = input.LA(1);
+
+                   	s = -1;
+                   	if ( (LA22_255 == 'T') ) { s = 263; }
+
+                   	else if ( ((LA22_255 >= '\u0000' && LA22_255 <= 'S') || (LA22_255 >= 'U' && LA22_255 <= '\uFFFF')) ) { s = 89; }
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 9 : 
+                   	int LA22_30 = input.LA(1);
+
+                   	s = -1;
+                   	if ( ((LA22_30 >= '\u0000' && LA22_30 <= '\b') || (LA22_30 >= '\u000B' && LA22_30 <= '\f') || (LA22_30 >= '\u000E' && LA22_30 <= '\u001F') || (LA22_30 >= '!' && LA22_30 <= '\uFFFF')) ) { s = 89; }
+
+                   	else if ( (LA22_30 == '\t' || LA22_30 == ' ') ) { s = 90; }
+
+                   	else if ( (LA22_30 == '\r') ) { s = 91; }
+
+                   	else if ( (LA22_30 == '\n') ) { s = 92; }
+
+                   	else s = 33;
+
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 10 : 
                    	int LA22_0 = input.LA(1);
 
                    	s = -1;
@@ -3933,215 +4110,107 @@ public partial class simpletikzLexer : Lexer {
 
                    	else if ( (LA22_0 == 's') ) { s = 9; }
 
-                   	else if ( (LA22_0 == 'a') ) { s = 10; }
+                   	else if ( (LA22_0 == 'n') ) { s = 10; }
 
-                   	else if ( (LA22_0 == '(') ) { s = 11; }
+                   	else if ( (LA22_0 == 'a') ) { s = 11; }
 
-                   	else if ( (LA22_0 == ')') ) { s = 12; }
+                   	else if ( (LA22_0 == '2') ) { s = 12; }
 
-                   	else if ( (LA22_0 == '[') ) { s = 13; }
+                   	else if ( (LA22_0 == '(') ) { s = 13; }
 
-                   	else if ( (LA22_0 == ']') ) { s = 14; }
+                   	else if ( (LA22_0 == ')') ) { s = 14; }
 
-                   	else if ( (LA22_0 == ';') ) { s = 15; }
+                   	else if ( (LA22_0 == '[') ) { s = 15; }
 
-                   	else if ( (LA22_0 == 'c') ) { s = 16; }
+                   	else if ( (LA22_0 == ']') ) { s = 16; }
 
-                   	else if ( (LA22_0 == 'i') ) { s = 17; }
+                   	else if ( (LA22_0 == ';') ) { s = 17; }
 
-                   	else if ( (LA22_0 == 'e') ) { s = 18; }
+                   	else if ( (LA22_0 == 'c') ) { s = 18; }
 
-                   	else if ( (LA22_0 == 'm') ) { s = 19; }
+                   	else if ( (LA22_0 == 'i') ) { s = 19; }
 
-                   	else if ( (LA22_0 == 'p') ) { s = 20; }
+                   	else if ( (LA22_0 == 'e') ) { s = 20; }
 
-                   	else if ( (LA22_0 == 'l') ) { s = 21; }
+                   	else if ( (LA22_0 == 'm') ) { s = 21; }
 
-                   	else if ( (LA22_0 == 'n') ) { s = 22; }
+                   	else if ( (LA22_0 == 'p') ) { s = 22; }
 
-                   	else if ( (LA22_0 == '-') ) { s = 23; }
+                   	else if ( (LA22_0 == 'l') ) { s = 23; }
 
-                   	else if ( (LA22_0 == '|') ) { s = 24; }
+                   	else if ( (LA22_0 == '-') ) { s = 24; }
 
-                   	else if ( (LA22_0 == '.') ) { s = 25; }
+                   	else if ( (LA22_0 == '|') ) { s = 25; }
 
-                   	else if ( (LA22_0 == 't') ) { s = 26; }
+                   	else if ( (LA22_0 == '.') ) { s = 26; }
 
-                   	else if ( ((LA22_0 >= 'A' && LA22_0 <= 'Z') || LA22_0 == '_' || LA22_0 == 'b' || LA22_0 == 'd' || (LA22_0 >= 'f' && LA22_0 <= 'h') || (LA22_0 >= 'j' && LA22_0 <= 'k') || LA22_0 == 'o' || (LA22_0 >= 'q' && LA22_0 <= 'r') || (LA22_0 >= 'u' && LA22_0 <= 'z')) ) { s = 27; }
+                   	else if ( (LA22_0 == 't') ) { s = 27; }
 
-                   	else if ( ((LA22_0 >= '0' && LA22_0 <= '9')) ) { s = 28; }
+                   	else if ( ((LA22_0 >= 'A' && LA22_0 <= 'Z') || LA22_0 == '_' || LA22_0 == 'b' || LA22_0 == 'd' || (LA22_0 >= 'f' && LA22_0 <= 'h') || (LA22_0 >= 'j' && LA22_0 <= 'k') || LA22_0 == 'o' || (LA22_0 >= 'q' && LA22_0 <= 'r') || (LA22_0 >= 'u' && LA22_0 <= 'z')) ) { s = 28; }
 
-                   	else if ( (LA22_0 == '%') ) { s = 29; }
+                   	else if ( ((LA22_0 >= '0' && LA22_0 <= '1') || (LA22_0 >= '3' && LA22_0 <= '9')) ) { s = 29; }
 
-                   	else if ( ((LA22_0 >= '\t' && LA22_0 <= '\n') || LA22_0 == '\r' || LA22_0 == ' ') ) { s = 30; }
+                   	else if ( (LA22_0 == '%') ) { s = 30; }
 
-                   	else if ( (LA22_0 == '$') ) { s = 31; }
+                   	else if ( ((LA22_0 >= '\t' && LA22_0 <= '\n') || LA22_0 == '\r' || LA22_0 == ' ') ) { s = 31; }
 
-                   	else if ( ((LA22_0 >= '\u0000' && LA22_0 <= '\b') || (LA22_0 >= '\u000B' && LA22_0 <= '\f') || (LA22_0 >= '\u000E' && LA22_0 <= '\u001F') || (LA22_0 >= '!' && LA22_0 <= '#') || (LA22_0 >= '&' && LA22_0 <= '\'') || LA22_0 == '*' || LA22_0 == '<' || (LA22_0 >= '>' && LA22_0 <= '@') || LA22_0 == '^' || LA22_0 == '`' || (LA22_0 >= '~' && LA22_0 <= '\uFFFF')) ) { s = 32; }
+                   	else if ( (LA22_0 == '$') ) { s = 32; }
 
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 1 : 
-                   	int LA22_1 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA22_1 == 'b') ) { s = 33; }
-
-                   	else if ( (LA22_1 == 't') ) { s = 34; }
-
-                   	else if ( (LA22_1 == 'e') ) { s = 35; }
-
-                   	else if ( (LA22_1 == 'n') ) { s = 36; }
-
-                   	else if ( (LA22_1 == 'm') ) { s = 37; }
-
-                   	else if ( (LA22_1 == 'c') ) { s = 38; }
-
-                   	else if ( (LA22_1 == 'd') ) { s = 39; }
-
-                   	else if ( (LA22_1 == 'p') ) { s = 40; }
-
-                   	else if ( (LA22_1 == 'f') ) { s = 41; }
-
-                   	else if ( (LA22_1 == 's') ) { s = 42; }
-
-                   	else if ( (LA22_1 == 'u') ) { s = 43; }
-
-                   	else if ( ((LA22_1 >= 'A' && LA22_1 <= 'Z') || LA22_1 == '_' || LA22_1 == 'a' || (LA22_1 >= 'g' && LA22_1 <= 'l') || LA22_1 == 'o' || (LA22_1 >= 'q' && LA22_1 <= 'r') || (LA22_1 >= 'v' && LA22_1 <= 'z')) ) { s = 44; }
-
-                   	else if ( ((LA22_1 >= '\u0000' && LA22_1 <= '@') || (LA22_1 >= '[' && LA22_1 <= '^') || LA22_1 == '`' || (LA22_1 >= '{' && LA22_1 <= '\uFFFF')) ) { s = 45; }
-
-                   	else s = 32;
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 2 : 
-                   	int LA22_29 = input.LA(1);
-
-                   	s = -1;
-                   	if ( ((LA22_29 >= '\u0000' && LA22_29 <= '\b') || (LA22_29 >= '\u000B' && LA22_29 <= '\f') || (LA22_29 >= '\u000E' && LA22_29 <= '\u001F') || (LA22_29 >= '!' && LA22_29 <= '\uFFFF')) ) { s = 86; }
-
-                   	else if ( (LA22_29 == '\t' || LA22_29 == ' ') ) { s = 87; }
-
-                   	else if ( (LA22_29 == '\r') ) { s = 88; }
-
-                   	else if ( (LA22_29 == '\n') ) { s = 89; }
-
-                   	else s = 32;
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 3 : 
-                   	int LA22_269 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA22_269 == '\r') ) { s = 267; }
-
-                   	else if ( (LA22_269 == '\n') ) { s = 268; }
-
-                   	else if ( ((LA22_269 >= '\u0000' && LA22_269 <= '\t') || (LA22_269 >= '\u000B' && LA22_269 <= '\f') || (LA22_269 >= '\u000E' && LA22_269 <= '\uFFFF')) ) { s = 269; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 4 : 
-                   	int LA22_31 = input.LA(1);
-
-                   	s = -1;
-                   	if ( ((LA22_31 >= '\u0000' && LA22_31 <= '\uFFFF')) ) { s = 91; }
-
-                   	else s = 32;
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 5 : 
-                   	int LA22_128 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA22_128 == 'T') ) { s = 157; }
-
-                   	else if ( ((LA22_128 >= '\u0000' && LA22_128 <= 'S') || (LA22_128 >= 'U' && LA22_128 <= '\uFFFF')) ) { s = 86; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 6 : 
-                   	int LA22_157 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA22_157 == 'I') ) { s = 183; }
-
-                   	else if ( ((LA22_157 >= '\u0000' && LA22_157 <= 'H') || (LA22_157 >= 'J' && LA22_157 <= '\uFFFF')) ) { s = 86; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 7 : 
-                   	int LA22_183 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA22_183 == 'K') ) { s = 207; }
-
-                   	else if ( ((LA22_183 >= '\u0000' && LA22_183 <= 'J') || (LA22_183 >= 'L' && LA22_183 <= '\uFFFF')) ) { s = 86; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 8 : 
-                   	int LA22_207 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA22_207 == 'Z') ) { s = 225; }
-
-                   	else if ( ((LA22_207 >= '\u0000' && LA22_207 <= 'Y') || (LA22_207 >= '[' && LA22_207 <= '\uFFFF')) ) { s = 86; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 9 : 
-                   	int LA22_225 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA22_225 == 'E') ) { s = 240; }
-
-                   	else if ( ((LA22_225 >= '\u0000' && LA22_225 <= 'D') || (LA22_225 >= 'F' && LA22_225 <= '\uFFFF')) ) { s = 86; }
-
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 10 : 
-                   	int LA22_240 = input.LA(1);
-
-                   	s = -1;
-                   	if ( (LA22_240 == 'D') ) { s = 252; }
-
-                   	else if ( ((LA22_240 >= '\u0000' && LA22_240 <= 'C') || (LA22_240 >= 'E' && LA22_240 <= '\uFFFF')) ) { s = 86; }
+                   	else if ( ((LA22_0 >= '\u0000' && LA22_0 <= '\b') || (LA22_0 >= '\u000B' && LA22_0 <= '\f') || (LA22_0 >= '\u000E' && LA22_0 <= '\u001F') || (LA22_0 >= '!' && LA22_0 <= '#') || (LA22_0 >= '&' && LA22_0 <= '\'') || LA22_0 == '*' || LA22_0 == '<' || (LA22_0 >= '>' && LA22_0 <= '@') || LA22_0 == '^' || LA22_0 == '`' || (LA22_0 >= '~' && LA22_0 <= '\uFFFF')) ) { s = 33; }
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 11 : 
-                   	int LA22_252 = input.LA(1);
+                   	int LA22_1 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA22_252 == 'T') ) { s = 260; }
+                   	if ( (LA22_1 == 'b') ) { s = 34; }
 
-                   	else if ( ((LA22_252 >= '\u0000' && LA22_252 <= 'S') || (LA22_252 >= 'U' && LA22_252 <= '\uFFFF')) ) { s = 86; }
+                   	else if ( (LA22_1 == 't') ) { s = 35; }
+
+                   	else if ( (LA22_1 == 'e') ) { s = 36; }
+
+                   	else if ( (LA22_1 == 'n') ) { s = 37; }
+
+                   	else if ( (LA22_1 == 'm') ) { s = 38; }
+
+                   	else if ( (LA22_1 == 'c') ) { s = 39; }
+
+                   	else if ( (LA22_1 == 'd') ) { s = 40; }
+
+                   	else if ( (LA22_1 == 'p') ) { s = 41; }
+
+                   	else if ( (LA22_1 == 'f') ) { s = 42; }
+
+                   	else if ( (LA22_1 == 's') ) { s = 43; }
+
+                   	else if ( (LA22_1 == 'u') ) { s = 44; }
+
+                   	else if ( ((LA22_1 >= 'A' && LA22_1 <= 'Z') || LA22_1 == '_' || LA22_1 == 'a' || (LA22_1 >= 'g' && LA22_1 <= 'l') || LA22_1 == 'o' || (LA22_1 >= 'q' && LA22_1 <= 'r') || (LA22_1 >= 'v' && LA22_1 <= 'z')) ) { s = 45; }
+
+                   	else if ( ((LA22_1 >= '\u0000' && LA22_1 <= '@') || (LA22_1 >= '[' && LA22_1 <= '^') || LA22_1 == '`' || (LA22_1 >= '{' && LA22_1 <= '\uFFFF')) ) { s = 46; }
+
+                   	else s = 33;
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 12 : 
-                   	int LA22_87 = input.LA(1);
+                   	int LA22_32 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA22_87 == '!') ) { s = 128; }
+                   	if ( ((LA22_32 >= '\u0000' && LA22_32 <= '\uFFFF')) ) { s = 94; }
 
-                   	else if ( ((LA22_87 >= '\u0000' && LA22_87 <= ' ') || (LA22_87 >= '\"' && LA22_87 <= '\uFFFF')) ) { s = 86; }
+                   	else s = 33;
 
                    	if ( s >= 0 ) return s;
                    	break;
                	case 13 : 
-                   	int LA22_260 = input.LA(1);
+                   	int LA22_90 = input.LA(1);
 
                    	s = -1;
-                   	if ( (LA22_260 == '\r') ) { s = 267; }
+                   	if ( ((LA22_90 >= '\u0000' && LA22_90 <= ' ') || (LA22_90 >= '\"' && LA22_90 <= '\uFFFF')) ) { s = 89; }
 
-                   	else if ( (LA22_260 == '\n') ) { s = 268; }
-
-                   	else if ( ((LA22_260 >= '\u0000' && LA22_260 <= '\t') || (LA22_260 >= '\u000B' && LA22_260 <= '\f') || (LA22_260 >= '\u000E' && LA22_260 <= '\uFFFF')) ) { s = 269; }
+                   	else if ( (LA22_90 == '!') ) { s = 131; }
 
                    	if ( s >= 0 ) return s;
                    	break;

--- a/TikzParser/output/simpletikzParser.cs
+++ b/TikzParser/output/simpletikzParser.cs
@@ -1,4 +1,4 @@
-// $ANTLR 3.1.1 E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g 2016-09-21 11:07:05
+// $ANTLR 3.1.1 E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g 2016-09-21 15:48:41
 
 using System;
 using Antlr.Runtime;
@@ -68,7 +68,9 @@ public partial class simpletikzParser : Parser
 		"'/.style'", 
 		"'/.append'", 
 		"'style'", 
+		"'n'", 
 		"'args'", 
+		"'2'", 
 		"'('", 
 		"')'", 
 		"'['", 
@@ -173,7 +175,9 @@ public partial class simpletikzParser : Parser
     public const int IM_STRING = 21;
     public const int MATHSTRING = 36;
     public const int T__95 = 95;
+    public const int T__96 = 96;
     public const int IM_COORD = 6;
+    public const int T__97 = 97;
     public const int IM_USETIKZLIB = 20;
     public const int FLOAT_WO_EXP = 30;
     public const int IM_PICTURE = 10;
@@ -408,6 +412,8 @@ public partial class simpletikzParser : Parser
             	    case 93:
             	    case 94:
             	    case 95:
+            	    case 96:
+            	    case 97:
             	    	{
             	        alt1 = 1;
             	        }
@@ -477,7 +483,7 @@ public partial class simpletikzParser : Parser
             	    int alt2 = 2;
             	    int LA2_0 = input.LA(1);
 
-            	    if ( ((LA2_0 >= IM_PATH && LA2_0 <= 95)) )
+            	    if ( ((LA2_0 >= IM_PATH && LA2_0 <= 97)) )
             	    {
             	        alt2 = 1;
             	    }
@@ -690,6 +696,8 @@ public partial class simpletikzParser : Parser
             	    case 93:
             	    case 94:
             	    case 95:
+            	    case 96:
+            	    case 97:
             	    	{
             	        alt3 = 1;
             	        }
@@ -1035,7 +1043,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
 
             	set14 = (IToken)input.LT(1);
-            	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= IM_ARC) || (input.LA(1) >= ID && input.LA(1) <= SOMETHING1) || (input.LA(1) >= 43 && input.LA(1) <= 95) ) 
+            	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= IM_ARC) || (input.LA(1) >= ID && input.LA(1) <= SOMETHING1) || (input.LA(1) >= 43 && input.LA(1) <= 97) ) 
             	{
             	    input.Consume();
             	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set14));
@@ -1353,7 +1361,7 @@ public partial class simpletikzParser : Parser
             	int alt8 = 2;
             	int LA8_0 = input.LA(1);
 
-            	if ( ((LA8_0 >= IM_PATH && LA8_0 <= 42) || LA8_0 == 46 || (LA8_0 >= 51 && LA8_0 <= 52) || (LA8_0 >= 58 && LA8_0 <= 95)) )
+            	if ( ((LA8_0 >= IM_PATH && LA8_0 <= 42) || LA8_0 == 46 || (LA8_0 >= 51 && LA8_0 <= 54) || (LA8_0 >= 60 && LA8_0 <= 97)) )
             	{
             	    alt8 = 1;
             	}
@@ -1377,7 +1385,7 @@ public partial class simpletikzParser : Parser
             	        	    {
             	        	        int LA6_1 = input.LA(2);
 
-            	        	        if ( ((LA6_1 >= IM_PATH && LA6_1 <= 42) || LA6_1 == 46 || (LA6_1 >= 51 && LA6_1 <= 52) || (LA6_1 >= 58 && LA6_1 <= 95)) )
+            	        	        if ( ((LA6_1 >= IM_PATH && LA6_1 <= 42) || LA6_1 == 46 || (LA6_1 >= 51 && LA6_1 <= 54) || (LA6_1 >= 60 && LA6_1 <= 97)) )
             	        	        {
             	        	            alt6 = 1;
             	        	        }
@@ -1471,7 +1479,7 @@ public partial class simpletikzParser : Parser
 
 
             	// AST REWRITE
-            	// elements:          option, squarebr_end, squarebr_start
+            	// elements:          squarebr_start, option, squarebr_end
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -1669,7 +1677,7 @@ public partial class simpletikzParser : Parser
 
 
             	// AST REWRITE
-            	// elements:          iddornumberunitorstringorrange, idd
+            	// elements:          idd, iddornumberunitorstringorrange
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -1768,7 +1776,7 @@ public partial class simpletikzParser : Parser
             	    int alt12 = 2;
             	    int LA12_0 = input.LA(1);
 
-            	    if ( ((LA12_0 >= IM_PATH && LA12_0 <= 42) || (LA12_0 >= 45 && LA12_0 <= 95)) )
+            	    if ( ((LA12_0 >= IM_PATH && LA12_0 <= 42) || (LA12_0 >= 45 && LA12_0 <= 97)) )
             	    {
             	        alt12 = 1;
             	    }
@@ -1824,7 +1832,7 @@ public partial class simpletikzParser : Parser
             			    	    int alt13 = 2;
             			    	    int LA13_0 = input.LA(1);
 
-            			    	    if ( ((LA13_0 >= IM_PATH && LA13_0 <= 42) || (LA13_0 >= 45 && LA13_0 <= 95)) )
+            			    	    if ( ((LA13_0 >= IM_PATH && LA13_0 <= 42) || (LA13_0 >= 45 && LA13_0 <= 97)) )
             			    	    {
             			    	        alt13 = 1;
             			    	    }
@@ -1870,7 +1878,7 @@ public partial class simpletikzParser : Parser
 
 
             	// AST REWRITE
-            	// elements:          44, 43
+            	// elements:          43, 44
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -1946,7 +1954,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
 
             	set43 = (IToken)input.LT(1);
-            	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= 42) || (input.LA(1) >= 45 && input.LA(1) <= 95) ) 
+            	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= 42) || (input.LA(1) >= 45 && input.LA(1) <= 97) ) 
             	{
             	    input.Consume();
             	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set43));
@@ -2245,7 +2253,7 @@ public partial class simpletikzParser : Parser
 
 
             	// AST REWRITE
-            	// elements:          48, numberunit, numberunit
+            	// elements:          numberunit, numberunit, 48
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -2302,7 +2310,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "option_style"
-    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:196:1: option_style : idd ( '/.style' | ( '/.append' 'style' ) | ( '/.style' number 'args' ) ) '=' '{' ( option_kv ( ',' option_kv )* )? ( ',' )? '}' -> ^( IM_OPTION_STYLE idd ( option_kv )* ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:196:1: option_style : idd ( '/.style' | ( '/.append' 'style' ) ) ( ( ( 'n' 'args' )=> ( 'n' 'args' ) '=' '{' number '}' ) | ( '2' 'args' )? '=' ) '{' ( option_kv ( ',' option_kv )* )? ( ',' )? '}' -> ^( IM_OPTION_STYLE idd ( option_kv )* ) ;
     public simpletikzParser.option_style_return option_style() // throws RecognitionException [1]
     {   
         simpletikzParser.option_style_return retval = new simpletikzParser.option_style_return();
@@ -2313,32 +2321,42 @@ public partial class simpletikzParser : Parser
         IToken string_literal58 = null;
         IToken string_literal59 = null;
         IToken string_literal60 = null;
-        IToken string_literal61 = null;
-        IToken string_literal63 = null;
+        IToken char_literal61 = null;
+        IToken string_literal62 = null;
+        IToken char_literal63 = null;
         IToken char_literal64 = null;
-        IToken char_literal65 = null;
+        IToken char_literal66 = null;
         IToken char_literal67 = null;
+        IToken string_literal68 = null;
         IToken char_literal69 = null;
         IToken char_literal70 = null;
+        IToken char_literal72 = null;
+        IToken char_literal74 = null;
+        IToken char_literal75 = null;
         simpletikzParser.idd_return idd57 = default(simpletikzParser.idd_return);
 
-        simpletikzParser.number_return number62 = default(simpletikzParser.number_return);
+        simpletikzParser.number_return number65 = default(simpletikzParser.number_return);
 
-        simpletikzParser.option_kv_return option_kv66 = default(simpletikzParser.option_kv_return);
+        simpletikzParser.option_kv_return option_kv71 = default(simpletikzParser.option_kv_return);
 
-        simpletikzParser.option_kv_return option_kv68 = default(simpletikzParser.option_kv_return);
+        simpletikzParser.option_kv_return option_kv73 = default(simpletikzParser.option_kv_return);
 
 
         object string_literal58_tree=null;
         object string_literal59_tree=null;
         object string_literal60_tree=null;
-        object string_literal61_tree=null;
-        object string_literal63_tree=null;
+        object char_literal61_tree=null;
+        object string_literal62_tree=null;
+        object char_literal63_tree=null;
         object char_literal64_tree=null;
-        object char_literal65_tree=null;
+        object char_literal66_tree=null;
         object char_literal67_tree=null;
+        object string_literal68_tree=null;
         object char_literal69_tree=null;
         object char_literal70_tree=null;
+        object char_literal72_tree=null;
+        object char_literal74_tree=null;
+        object char_literal75_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
         RewriteRuleTokenStream stream_45 = new RewriteRuleTokenStream(adaptor,"token 45");
         RewriteRuleTokenStream stream_47 = new RewriteRuleTokenStream(adaptor,"token 47");
@@ -2346,44 +2364,29 @@ public partial class simpletikzParser : Parser
         RewriteRuleTokenStream stream_50 = new RewriteRuleTokenStream(adaptor,"token 50");
         RewriteRuleTokenStream stream_51 = new RewriteRuleTokenStream(adaptor,"token 51");
         RewriteRuleTokenStream stream_52 = new RewriteRuleTokenStream(adaptor,"token 52");
+        RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
         RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
+        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
         RewriteRuleSubtreeStream stream_number = new RewriteRuleSubtreeStream(adaptor,"rule number");
         RewriteRuleSubtreeStream stream_idd = new RewriteRuleSubtreeStream(adaptor,"rule idd");
         RewriteRuleSubtreeStream stream_option_kv = new RewriteRuleSubtreeStream(adaptor,"rule option_kv");
         try 
     	{
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:2: ( idd ( '/.style' | ( '/.append' 'style' ) | ( '/.style' number 'args' ) ) '=' '{' ( option_kv ( ',' option_kv )* )? ( ',' )? '}' -> ^( IM_OPTION_STYLE idd ( option_kv )* ) )
-            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:4: idd ( '/.style' | ( '/.append' 'style' ) | ( '/.style' number 'args' ) ) '=' '{' ( option_kv ( ',' option_kv )* )? ( ',' )? '}'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:2: ( idd ( '/.style' | ( '/.append' 'style' ) ) ( ( ( 'n' 'args' )=> ( 'n' 'args' ) '=' '{' number '}' ) | ( '2' 'args' )? '=' ) '{' ( option_kv ( ',' option_kv )* )? ( ',' )? '}' -> ^( IM_OPTION_STYLE idd ( option_kv )* ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:4: idd ( '/.style' | ( '/.append' 'style' ) ) ( ( ( 'n' 'args' )=> ( 'n' 'args' ) '=' '{' number '}' ) | ( '2' 'args' )? '=' ) '{' ( option_kv ( ',' option_kv )* )? ( ',' )? '}'
             {
             	PushFollow(FOLLOW_idd_in_option_style697);
             	idd57 = idd();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
             	if ( state.backtracking==0 ) stream_idd.Add(idd57.Tree);
-            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:8: ( '/.style' | ( '/.append' 'style' ) | ( '/.style' number 'args' ) )
-            	int alt17 = 3;
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:8: ( '/.style' | ( '/.append' 'style' ) )
+            	int alt17 = 2;
             	int LA17_0 = input.LA(1);
 
             	if ( (LA17_0 == 49) )
             	{
-            	    int LA17_1 = input.LA(2);
-
-            	    if ( ((LA17_1 >= FLOAT_WO_EXP && LA17_1 <= INT)) )
-            	    {
-            	        alt17 = 3;
-            	    }
-            	    else if ( (LA17_1 == 45) )
-            	    {
-            	        alt17 = 1;
-            	    }
-            	    else 
-            	    {
-            	        if ( state.backtracking > 0 ) {state.failed = true; return retval;}
-            	        NoViableAltException nvae_d17s1 =
-            	            new NoViableAltException("", 17, 1, input);
-
-            	        throw nvae_d17s1;
-            	    }
+            	    alt17 = 1;
             	}
             	else if ( (LA17_0 == 50) )
             	{
@@ -2426,22 +2429,62 @@ public partial class simpletikzParser : Parser
 
             	        }
             	        break;
-            	    case 3 :
-            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:45: ( '/.style' number 'args' )
-            	        {
-            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:45: ( '/.style' number 'args' )
-            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:46: '/.style' number 'args'
-            	        	{
-            	        		string_literal61=(IToken)Match(input,49,FOLLOW_49_in_option_style714); if (state.failed) return retval; 
-            	        		if ( state.backtracking==0 ) stream_49.Add(string_literal61);
 
-            	        		PushFollow(FOLLOW_number_in_option_style716);
-            	        		number62 = number();
+            	}
+
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:44: ( ( ( 'n' 'args' )=> ( 'n' 'args' ) '=' '{' number '}' ) | ( '2' 'args' )? '=' )
+            	int alt19 = 2;
+            	int LA19_0 = input.LA(1);
+
+            	if ( (LA19_0 == 52) && (synpred1_simpletikz()) )
+            	{
+            	    alt19 = 1;
+            	}
+            	else if ( (LA19_0 == 45 || LA19_0 == 54) )
+            	{
+            	    alt19 = 2;
+            	}
+            	else 
+            	{
+            	    if ( state.backtracking > 0 ) {state.failed = true; return retval;}
+            	    NoViableAltException nvae_d19s0 =
+            	        new NoViableAltException("", 19, 0, input);
+
+            	    throw nvae_d19s0;
+            	}
+            	switch (alt19) 
+            	{
+            	    case 1 :
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:45: ( ( 'n' 'args' )=> ( 'n' 'args' ) '=' '{' number '}' )
+            	        {
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:45: ( ( 'n' 'args' )=> ( 'n' 'args' ) '=' '{' number '}' )
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:46: ( 'n' 'args' )=> ( 'n' 'args' ) '=' '{' number '}'
+            	        	{
+            	        		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:61: ( 'n' 'args' )
+            	        		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:62: 'n' 'args'
+            	        		{
+            	        			char_literal61=(IToken)Match(input,52,FOLLOW_52_in_option_style722); if (state.failed) return retval; 
+            	        			if ( state.backtracking==0 ) stream_52.Add(char_literal61);
+
+            	        			string_literal62=(IToken)Match(input,53,FOLLOW_53_in_option_style724); if (state.failed) return retval; 
+            	        			if ( state.backtracking==0 ) stream_53.Add(string_literal62);
+
+
+            	        		}
+
+            	        		char_literal63=(IToken)Match(input,45,FOLLOW_45_in_option_style727); if (state.failed) return retval; 
+            	        		if ( state.backtracking==0 ) stream_45.Add(char_literal63);
+
+            	        		char_literal64=(IToken)Match(input,43,FOLLOW_43_in_option_style729); if (state.failed) return retval; 
+            	        		if ( state.backtracking==0 ) stream_43.Add(char_literal64);
+
+            	        		PushFollow(FOLLOW_number_in_option_style731);
+            	        		number65 = number();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking==0 ) stream_number.Add(number62.Tree);
-            	        		string_literal63=(IToken)Match(input,52,FOLLOW_52_in_option_style718); if (state.failed) return retval; 
-            	        		if ( state.backtracking==0 ) stream_52.Add(string_literal63);
+            	        		if ( state.backtracking==0 ) stream_number.Add(number65.Tree);
+            	        		char_literal66=(IToken)Match(input,44,FOLLOW_44_in_option_style733); if (state.failed) return retval; 
+            	        		if ( state.backtracking==0 ) stream_44.Add(char_literal66);
 
 
             	        	}
@@ -2449,76 +2492,107 @@ public partial class simpletikzParser : Parser
 
             	        }
             	        break;
+            	    case 2 :
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:97: ( '2' 'args' )? '='
+            	        {
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:97: ( '2' 'args' )?
+            	        	int alt18 = 2;
+            	        	int LA18_0 = input.LA(1);
+
+            	        	if ( (LA18_0 == 54) )
+            	        	{
+            	        	    alt18 = 1;
+            	        	}
+            	        	switch (alt18) 
+            	        	{
+            	        	    case 1 :
+            	        	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:98: '2' 'args'
+            	        	        {
+            	        	        	char_literal67=(IToken)Match(input,54,FOLLOW_54_in_option_style740); if (state.failed) return retval; 
+            	        	        	if ( state.backtracking==0 ) stream_54.Add(char_literal67);
+
+            	        	        	string_literal68=(IToken)Match(input,53,FOLLOW_53_in_option_style742); if (state.failed) return retval; 
+            	        	        	if ( state.backtracking==0 ) stream_53.Add(string_literal68);
+
+
+            	        	        }
+            	        	        break;
+
+            	        	}
+
+            	        	char_literal69=(IToken)Match(input,45,FOLLOW_45_in_option_style746); if (state.failed) return retval; 
+            	        	if ( state.backtracking==0 ) stream_45.Add(char_literal69);
+
+
+            	        }
+            	        break;
 
             	}
 
-            	char_literal64=(IToken)Match(input,45,FOLLOW_45_in_option_style722); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_45.Add(char_literal64);
+            	char_literal70=(IToken)Match(input,43,FOLLOW_43_in_option_style749); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal70);
 
-            	char_literal65=(IToken)Match(input,43,FOLLOW_43_in_option_style724); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal65);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:120: ( option_kv ( ',' option_kv )* )?
+            	int alt21 = 2;
+            	int LA21_0 = input.LA(1);
 
-            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:80: ( option_kv ( ',' option_kv )* )?
-            	int alt19 = 2;
-            	int LA19_0 = input.LA(1);
-
-            	if ( ((LA19_0 >= IM_PATH && LA19_0 <= 42) || LA19_0 == 46 || (LA19_0 >= 51 && LA19_0 <= 52) || (LA19_0 >= 58 && LA19_0 <= 95)) )
+            	if ( ((LA21_0 >= IM_PATH && LA21_0 <= 42) || LA21_0 == 46 || (LA21_0 >= 51 && LA21_0 <= 54) || (LA21_0 >= 60 && LA21_0 <= 97)) )
             	{
-            	    alt19 = 1;
+            	    alt21 = 1;
             	}
-            	switch (alt19) 
+            	switch (alt21) 
             	{
             	    case 1 :
-            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:81: option_kv ( ',' option_kv )*
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:121: option_kv ( ',' option_kv )*
             	        {
-            	        	PushFollow(FOLLOW_option_kv_in_option_style727);
-            	        	option_kv66 = option_kv();
+            	        	PushFollow(FOLLOW_option_kv_in_option_style752);
+            	        	option_kv71 = option_kv();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_option_kv.Add(option_kv66.Tree);
-            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:91: ( ',' option_kv )*
+            	        	if ( state.backtracking==0 ) stream_option_kv.Add(option_kv71.Tree);
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:131: ( ',' option_kv )*
             	        	do 
             	        	{
-            	        	    int alt18 = 2;
-            	        	    int LA18_0 = input.LA(1);
+            	        	    int alt20 = 2;
+            	        	    int LA20_0 = input.LA(1);
 
-            	        	    if ( (LA18_0 == 47) )
+            	        	    if ( (LA20_0 == 47) )
             	        	    {
-            	        	        int LA18_1 = input.LA(2);
+            	        	        int LA20_1 = input.LA(2);
 
-            	        	        if ( ((LA18_1 >= IM_PATH && LA18_1 <= 42) || LA18_1 == 46 || (LA18_1 >= 51 && LA18_1 <= 52) || (LA18_1 >= 58 && LA18_1 <= 95)) )
+            	        	        if ( ((LA20_1 >= IM_PATH && LA20_1 <= 42) || LA20_1 == 46 || (LA20_1 >= 51 && LA20_1 <= 54) || (LA20_1 >= 60 && LA20_1 <= 97)) )
             	        	        {
-            	        	            alt18 = 1;
+            	        	            alt20 = 1;
             	        	        }
 
 
             	        	    }
 
 
-            	        	    switch (alt18) 
+            	        	    switch (alt20) 
             	        		{
             	        			case 1 :
-            	        			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:92: ',' option_kv
+            	        			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:132: ',' option_kv
             	        			    {
-            	        			    	char_literal67=(IToken)Match(input,47,FOLLOW_47_in_option_style730); if (state.failed) return retval; 
-            	        			    	if ( state.backtracking==0 ) stream_47.Add(char_literal67);
+            	        			    	char_literal72=(IToken)Match(input,47,FOLLOW_47_in_option_style755); if (state.failed) return retval; 
+            	        			    	if ( state.backtracking==0 ) stream_47.Add(char_literal72);
 
-            	        			    	PushFollow(FOLLOW_option_kv_in_option_style732);
-            	        			    	option_kv68 = option_kv();
+            	        			    	PushFollow(FOLLOW_option_kv_in_option_style757);
+            	        			    	option_kv73 = option_kv();
             	        			    	state.followingStackPointer--;
             	        			    	if (state.failed) return retval;
-            	        			    	if ( state.backtracking==0 ) stream_option_kv.Add(option_kv68.Tree);
+            	        			    	if ( state.backtracking==0 ) stream_option_kv.Add(option_kv73.Tree);
 
             	        			    }
             	        			    break;
 
             	        			default:
-            	        			    goto loop18;
+            	        			    goto loop20;
             	        	    }
             	        	} while (true);
 
-            	        	loop18:
-            	        		;	// Stops C# compiler whining that label 'loop18' has no statements
+            	        	loop20:
+            	        		;	// Stops C# compiler whining that label 'loop20' has no statements
 
 
             	        }
@@ -2526,21 +2600,21 @@ public partial class simpletikzParser : Parser
 
             	}
 
-            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:111: ( ',' )?
-            	int alt20 = 2;
-            	int LA20_0 = input.LA(1);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:151: ( ',' )?
+            	int alt22 = 2;
+            	int LA22_0 = input.LA(1);
 
-            	if ( (LA20_0 == 47) )
+            	if ( (LA22_0 == 47) )
             	{
-            	    alt20 = 1;
+            	    alt22 = 1;
             	}
-            	switch (alt20) 
+            	switch (alt22) 
             	{
             	    case 1 :
-            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:111: ','
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:151: ','
             	        {
-            	        	char_literal69=(IToken)Match(input,47,FOLLOW_47_in_option_style739); if (state.failed) return retval; 
-            	        	if ( state.backtracking==0 ) stream_47.Add(char_literal69);
+            	        	char_literal74=(IToken)Match(input,47,FOLLOW_47_in_option_style764); if (state.failed) return retval; 
+            	        	if ( state.backtracking==0 ) stream_47.Add(char_literal74);
 
 
             	        }
@@ -2548,13 +2622,13 @@ public partial class simpletikzParser : Parser
 
             	}
 
-            	char_literal70=(IToken)Match(input,44,FOLLOW_44_in_option_style742); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_44.Add(char_literal70);
+            	char_literal75=(IToken)Match(input,44,FOLLOW_44_in_option_style767); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_44.Add(char_literal75);
 
 
 
             	// AST REWRITE
-            	// elements:          option_kv, idd
+            	// elements:          idd, option_kv
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -2564,15 +2638,15 @@ public partial class simpletikzParser : Parser
             	RewriteRuleSubtreeStream stream_retval = new RewriteRuleSubtreeStream(adaptor, "token retval", (retval!=null ? retval.Tree : null));
 
             	root_0 = (object)adaptor.GetNilNode();
-            	// 197:121: -> ^( IM_OPTION_STYLE idd ( option_kv )* )
+            	// 197:161: -> ^( IM_OPTION_STYLE idd ( option_kv )* )
             	{
-            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:124: ^( IM_OPTION_STYLE idd ( option_kv )* )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:164: ^( IM_OPTION_STYLE idd ( option_kv )* )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_OPTION_STYLE, "IM_OPTION_STYLE"), root_1);
 
             	    adaptor.AddChild(root_1, stream_idd.NextTree());
-            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:146: ( option_kv )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:186: ( option_kv )*
             	    while ( stream_option_kv.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_option_kv.NextTree());
@@ -2624,7 +2698,7 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.idd_heavenknowswhythisisnecessary_return idd_heavenknowswhythisisnecessary71 = default(simpletikzParser.idd_heavenknowswhythisisnecessary_return);
+        simpletikzParser.idd_heavenknowswhythisisnecessary_return idd_heavenknowswhythisisnecessary76 = default(simpletikzParser.idd_heavenknowswhythisisnecessary_return);
 
 
         RewriteRuleSubtreeStream stream_idd_heavenknowswhythisisnecessary = new RewriteRuleSubtreeStream(adaptor,"rule idd_heavenknowswhythisisnecessary");
@@ -2633,11 +2707,11 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:210:2: ( idd_heavenknowswhythisisnecessary -> ^( IM_ID ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:210:4: idd_heavenknowswhythisisnecessary
             {
-            	PushFollow(FOLLOW_idd_heavenknowswhythisisnecessary_in_idd777);
-            	idd_heavenknowswhythisisnecessary71 = idd_heavenknowswhythisisnecessary();
+            	PushFollow(FOLLOW_idd_heavenknowswhythisisnecessary_in_idd802);
+            	idd_heavenknowswhythisisnecessary76 = idd_heavenknowswhythisisnecessary();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_idd_heavenknowswhythisisnecessary.Add(idd_heavenknowswhythisisnecessary71.Tree);
+            	if ( state.backtracking==0 ) stream_idd_heavenknowswhythisisnecessary.Add(idd_heavenknowswhythisisnecessary76.Tree);
 
 
             	// AST REWRITE
@@ -2702,9 +2776,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set72 = null;
+        IToken set77 = null;
 
-        object set72_tree=null;
+        object set77_tree=null;
 
         try 
     	{
@@ -2714,43 +2788,43 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
 
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:213:6: (~ ( '(' | ')' | '[' | ']' | '{' | '}' | ',' | '=' | ';' | ':' | '/.style' | '/.append' ) )+
-            	int cnt21 = 0;
+            	int cnt23 = 0;
             	do 
             	{
-            	    int alt21 = 2;
-            	    int LA21_0 = input.LA(1);
+            	    int alt23 = 2;
+            	    int LA23_0 = input.LA(1);
 
-            	    if ( (LA21_0 == 79) )
+            	    if ( (LA23_0 == 81) )
             	    {
-            	        int LA21_2 = input.LA(2);
+            	        int LA23_2 = input.LA(2);
 
-            	        if ( ((LA21_2 >= FLOAT_WO_EXP && LA21_2 <= INT) || (LA21_2 >= 43 && LA21_2 <= 45) || (LA21_2 >= 47 && LA21_2 <= 50) || LA21_2 == 54 || LA21_2 == 56 || LA21_2 == 79) )
+            	        if ( ((LA23_2 >= IM_PATH && LA23_2 <= COMMAND) || (LA23_2 >= WS && LA23_2 <= 54) || LA23_2 == 56 || LA23_2 == 58 || (LA23_2 >= 60 && LA23_2 <= 97)) )
             	        {
-            	            alt21 = 1;
+            	            alt23 = 1;
             	        }
-            	        else if ( ((LA21_2 >= IM_PATH && LA21_2 <= COMMAND) || (LA21_2 >= WS && LA21_2 <= 42) || LA21_2 == 46 || (LA21_2 >= 51 && LA21_2 <= 52) || (LA21_2 >= 58 && LA21_2 <= 78) || (LA21_2 >= 80 && LA21_2 <= 95)) )
+            	        else if ( ((LA23_2 >= FLOAT_WO_EXP && LA23_2 <= INT)) )
             	        {
-            	            alt21 = 1;
+            	            alt23 = 1;
             	        }
 
 
             	    }
-            	    else if ( ((LA21_0 >= IM_PATH && LA21_0 <= 42) || LA21_0 == 46 || (LA21_0 >= 51 && LA21_0 <= 52) || (LA21_0 >= 58 && LA21_0 <= 78) || (LA21_0 >= 80 && LA21_0 <= 95)) )
+            	    else if ( ((LA23_0 >= IM_PATH && LA23_0 <= 42) || LA23_0 == 46 || (LA23_0 >= 51 && LA23_0 <= 54) || (LA23_0 >= 60 && LA23_0 <= 80) || (LA23_0 >= 82 && LA23_0 <= 97)) )
             	    {
-            	        alt21 = 1;
+            	        alt23 = 1;
             	    }
 
 
-            	    switch (alt21) 
+            	    switch (alt23) 
             		{
             			case 1 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:213:6: ~ ( '(' | ')' | '[' | ']' | '{' | '}' | ',' | '=' | ';' | ':' | '/.style' | '/.append' )
             			    {
-            			    	set72 = (IToken)input.LT(1);
-            			    	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= 42) || input.LA(1) == 46 || (input.LA(1) >= 51 && input.LA(1) <= 52) || (input.LA(1) >= 58 && input.LA(1) <= 95) ) 
+            			    	set77 = (IToken)input.LT(1);
+            			    	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= 42) || input.LA(1) == 46 || (input.LA(1) >= 51 && input.LA(1) <= 54) || (input.LA(1) >= 60 && input.LA(1) <= 97) ) 
             			    	{
             			    	    input.Consume();
-            			    	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set72));
+            			    	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set77));
             			    	    state.errorRecovery = false;state.failed = false;
             			    	}
             			    	else 
@@ -2765,17 +2839,17 @@ public partial class simpletikzParser : Parser
             			    break;
 
             			default:
-            			    if ( cnt21 >= 1 ) goto loop21;
+            			    if ( cnt23 >= 1 ) goto loop23;
             			    if ( state.backtracking > 0 ) {state.failed = true; return retval;}
             		            EarlyExitException eee =
-            		                new EarlyExitException(21, input);
+            		                new EarlyExitException(23, input);
             		            throw eee;
             	    }
-            	    cnt21++;
+            	    cnt23++;
             	} while (true);
 
-            	loop21:
-            		;	// Stops C# compiler whinging that label 'loop21' has no statements
+            	loop23:
+            		;	// Stops C# compiler whinging that label 'loop23' has no statements
 
 
             }
@@ -2816,9 +2890,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken ID73 = null;
+        IToken ID78 = null;
 
-        object ID73_tree=null;
+        object ID78_tree=null;
         RewriteRuleTokenStream stream_ID = new RewriteRuleTokenStream(adaptor,"token ID");
 
         try 
@@ -2827,42 +2901,42 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:215:4: ( ID )+
             {
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:215:4: ( ID )+
-            	int cnt22 = 0;
+            	int cnt24 = 0;
             	do 
             	{
-            	    int alt22 = 2;
-            	    int LA22_0 = input.LA(1);
+            	    int alt24 = 2;
+            	    int LA24_0 = input.LA(1);
 
-            	    if ( (LA22_0 == ID) )
+            	    if ( (LA24_0 == ID) )
             	    {
-            	        alt22 = 1;
+            	        alt24 = 1;
             	    }
 
 
-            	    switch (alt22) 
+            	    switch (alt24) 
             		{
             			case 1 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:215:4: ID
             			    {
-            			    	ID73=(IToken)Match(input,ID,FOLLOW_ID_in_idd2857); if (state.failed) return retval; 
-            			    	if ( state.backtracking==0 ) stream_ID.Add(ID73);
+            			    	ID78=(IToken)Match(input,ID,FOLLOW_ID_in_idd2882); if (state.failed) return retval; 
+            			    	if ( state.backtracking==0 ) stream_ID.Add(ID78);
 
 
             			    }
             			    break;
 
             			default:
-            			    if ( cnt22 >= 1 ) goto loop22;
+            			    if ( cnt24 >= 1 ) goto loop24;
             			    if ( state.backtracking > 0 ) {state.failed = true; return retval;}
             		            EarlyExitException eee =
-            		                new EarlyExitException(22, input);
+            		                new EarlyExitException(24, input);
             		            throw eee;
             	    }
-            	    cnt22++;
+            	    cnt24++;
             	} while (true);
 
-            	loop22:
-            		;	// Stops C# compiler whinging that label 'loop22' has no statements
+            	loop24:
+            		;	// Stops C# compiler whinging that label 'loop24' has no statements
 
 
 
@@ -2928,46 +3002,46 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken COMMAND75 = null;
-        simpletikzParser.numberunit_return numberunit74 = default(simpletikzParser.numberunit_return);
+        IToken COMMAND80 = null;
+        simpletikzParser.numberunit_return numberunit79 = default(simpletikzParser.numberunit_return);
 
 
-        object COMMAND75_tree=null;
+        object COMMAND80_tree=null;
 
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:219:2: ( numberunit | COMMAND )
-            int alt23 = 2;
-            int LA23_0 = input.LA(1);
+            int alt25 = 2;
+            int LA25_0 = input.LA(1);
 
-            if ( ((LA23_0 >= FLOAT_WO_EXP && LA23_0 <= INT)) )
+            if ( ((LA25_0 >= FLOAT_WO_EXP && LA25_0 <= INT)) )
             {
-                alt23 = 1;
+                alt25 = 1;
             }
-            else if ( (LA23_0 == COMMAND) )
+            else if ( (LA25_0 == COMMAND) )
             {
-                alt23 = 2;
+                alt25 = 2;
             }
             else 
             {
                 if ( state.backtracking > 0 ) {state.failed = true; return retval;}
-                NoViableAltException nvae_d23s0 =
-                    new NoViableAltException("", 23, 0, input);
+                NoViableAltException nvae_d25s0 =
+                    new NoViableAltException("", 25, 0, input);
 
-                throw nvae_d23s0;
+                throw nvae_d25s0;
             }
-            switch (alt23) 
+            switch (alt25) 
             {
                 case 1 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:219:4: numberunit
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_numberunit_in_numberunitorvariable876);
-                    	numberunit74 = numberunit();
+                    	PushFollow(FOLLOW_numberunit_in_numberunitorvariable901);
+                    	numberunit79 = numberunit();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, numberunit74.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, numberunit79.Tree);
 
                     }
                     break;
@@ -2976,10 +3050,10 @@ public partial class simpletikzParser : Parser
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	COMMAND75=(IToken)Match(input,COMMAND,FOLLOW_COMMAND_in_numberunitorvariable881); if (state.failed) return retval;
+                    	COMMAND80=(IToken)Match(input,COMMAND,FOLLOW_COMMAND_in_numberunitorvariable906); if (state.failed) return retval;
                     	if ( state.backtracking == 0 )
-                    	{COMMAND75_tree = (object)adaptor.Create(COMMAND75);
-                    		adaptor.AddChild(root_0, COMMAND75_tree);
+                    	{COMMAND80_tree = (object)adaptor.Create(COMMAND80);
+                    		adaptor.AddChild(root_0, COMMAND80_tree);
                     	}
 
                     }
@@ -3022,9 +3096,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.number_return number76 = default(simpletikzParser.number_return);
+        simpletikzParser.number_return number81 = default(simpletikzParser.number_return);
 
-        simpletikzParser.unit_return unit77 = default(simpletikzParser.unit_return);
+        simpletikzParser.unit_return unit82 = default(simpletikzParser.unit_return);
 
 
         RewriteRuleSubtreeStream stream_number = new RewriteRuleSubtreeStream(adaptor,"rule number");
@@ -3034,29 +3108,29 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:224:2: ( number ( unit )? -> ^( IM_NUMBERUNIT number ( unit )? ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:224:4: number ( unit )?
             {
-            	PushFollow(FOLLOW_number_in_numberunit894);
-            	number76 = number();
+            	PushFollow(FOLLOW_number_in_numberunit919);
+            	number81 = number();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_number.Add(number76.Tree);
+            	if ( state.backtracking==0 ) stream_number.Add(number81.Tree);
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:224:11: ( unit )?
-            	int alt24 = 2;
-            	int LA24_0 = input.LA(1);
+            	int alt26 = 2;
+            	int LA26_0 = input.LA(1);
 
-            	if ( ((LA24_0 >= 58 && LA24_0 <= 63)) )
+            	if ( ((LA26_0 >= 60 && LA26_0 <= 65)) )
             	{
-            	    alt24 = 1;
+            	    alt26 = 1;
             	}
-            	switch (alt24) 
+            	switch (alt26) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:224:11: unit
             	        {
-            	        	PushFollow(FOLLOW_unit_in_numberunit896);
-            	        	unit77 = unit();
+            	        	PushFollow(FOLLOW_unit_in_numberunit921);
+            	        	unit82 = unit();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_unit.Add(unit77.Tree);
+            	        	if ( state.backtracking==0 ) stream_unit.Add(unit82.Tree);
 
             	        }
             	        break;
@@ -3066,7 +3140,7 @@ public partial class simpletikzParser : Parser
 
 
             	// AST REWRITE
-            	// elements:          number, unit
+            	// elements:          unit, number
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -3136,9 +3210,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set78 = null;
+        IToken set83 = null;
 
-        object set78_tree=null;
+        object set83_tree=null;
 
         try 
     	{
@@ -3147,11 +3221,11 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set78 = (IToken)input.LT(1);
+            	set83 = (IToken)input.LT(1);
             	if ( (input.LA(1) >= FLOAT_WO_EXP && input.LA(1) <= INT) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set78));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set83));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -3200,9 +3274,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set79 = null;
+        IToken set84 = null;
 
-        object set79_tree=null;
+        object set84_tree=null;
 
         try 
     	{
@@ -3211,11 +3285,11 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set79 = (IToken)input.LT(1);
-            	if ( (input.LA(1) >= 58 && input.LA(1) <= 63) ) 
+            	set84 = (IToken)input.LT(1);
+            	if ( (input.LA(1) >= 60 && input.LA(1) <= 65) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set79));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set84));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -3264,19 +3338,19 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal82 = null;
-        IToken char_literal84 = null;
-        simpletikzParser.tikz_set_start_return tikz_set_start80 = default(simpletikzParser.tikz_set_start_return);
+        IToken char_literal87 = null;
+        IToken char_literal89 = null;
+        simpletikzParser.tikz_set_start_return tikz_set_start85 = default(simpletikzParser.tikz_set_start_return);
 
-        simpletikzParser.option_return option81 = default(simpletikzParser.option_return);
+        simpletikzParser.option_return option86 = default(simpletikzParser.option_return);
 
-        simpletikzParser.option_return option83 = default(simpletikzParser.option_return);
+        simpletikzParser.option_return option88 = default(simpletikzParser.option_return);
 
-        simpletikzParser.roundbr_end_return roundbr_end85 = default(simpletikzParser.roundbr_end_return);
+        simpletikzParser.roundbr_end_return roundbr_end90 = default(simpletikzParser.roundbr_end_return);
 
 
-        object char_literal82_tree=null;
-        object char_literal84_tree=null;
+        object char_literal87_tree=null;
+        object char_literal89_tree=null;
         RewriteRuleTokenStream stream_47 = new RewriteRuleTokenStream(adaptor,"token 47");
         RewriteRuleSubtreeStream stream_tikz_set_start = new RewriteRuleSubtreeStream(adaptor,"rule tikz_set_start");
         RewriteRuleSubtreeStream stream_roundbr_end = new RewriteRuleSubtreeStream(adaptor,"rule roundbr_end");
@@ -3286,88 +3360,88 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:2: ( tikz_set_start ( option ( ',' option )* ( ',' )? )? roundbr_end -> ^( IM_TIKZSET tikz_set_start ( option )* roundbr_end ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:5: tikz_set_start ( option ( ',' option )* ( ',' )? )? roundbr_end
             {
-            	PushFollow(FOLLOW_tikz_set_start_in_tikz_set977);
-            	tikz_set_start80 = tikz_set_start();
+            	PushFollow(FOLLOW_tikz_set_start_in_tikz_set1002);
+            	tikz_set_start85 = tikz_set_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikz_set_start.Add(tikz_set_start80.Tree);
+            	if ( state.backtracking==0 ) stream_tikz_set_start.Add(tikz_set_start85.Tree);
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:20: ( option ( ',' option )* ( ',' )? )?
-            	int alt27 = 2;
-            	int LA27_0 = input.LA(1);
+            	int alt29 = 2;
+            	int LA29_0 = input.LA(1);
 
-            	if ( ((LA27_0 >= IM_PATH && LA27_0 <= 42) || LA27_0 == 46 || (LA27_0 >= 51 && LA27_0 <= 52) || (LA27_0 >= 58 && LA27_0 <= 95)) )
+            	if ( ((LA29_0 >= IM_PATH && LA29_0 <= 42) || LA29_0 == 46 || (LA29_0 >= 51 && LA29_0 <= 54) || (LA29_0 >= 60 && LA29_0 <= 97)) )
             	{
-            	    alt27 = 1;
+            	    alt29 = 1;
             	}
-            	switch (alt27) 
+            	switch (alt29) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:21: option ( ',' option )* ( ',' )?
             	        {
-            	        	PushFollow(FOLLOW_option_in_tikz_set980);
-            	        	option81 = option();
+            	        	PushFollow(FOLLOW_option_in_tikz_set1005);
+            	        	option86 = option();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_option.Add(option81.Tree);
+            	        	if ( state.backtracking==0 ) stream_option.Add(option86.Tree);
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:28: ( ',' option )*
             	        	do 
             	        	{
-            	        	    int alt25 = 2;
-            	        	    int LA25_0 = input.LA(1);
+            	        	    int alt27 = 2;
+            	        	    int LA27_0 = input.LA(1);
 
-            	        	    if ( (LA25_0 == 47) )
+            	        	    if ( (LA27_0 == 47) )
             	        	    {
-            	        	        int LA25_1 = input.LA(2);
+            	        	        int LA27_1 = input.LA(2);
 
-            	        	        if ( ((LA25_1 >= IM_PATH && LA25_1 <= 42) || LA25_1 == 46 || (LA25_1 >= 51 && LA25_1 <= 52) || (LA25_1 >= 58 && LA25_1 <= 95)) )
+            	        	        if ( ((LA27_1 >= IM_PATH && LA27_1 <= 42) || LA27_1 == 46 || (LA27_1 >= 51 && LA27_1 <= 54) || (LA27_1 >= 60 && LA27_1 <= 97)) )
             	        	        {
-            	        	            alt25 = 1;
+            	        	            alt27 = 1;
             	        	        }
 
 
             	        	    }
 
 
-            	        	    switch (alt25) 
+            	        	    switch (alt27) 
             	        		{
             	        			case 1 :
             	        			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:29: ',' option
             	        			    {
-            	        			    	char_literal82=(IToken)Match(input,47,FOLLOW_47_in_tikz_set983); if (state.failed) return retval; 
-            	        			    	if ( state.backtracking==0 ) stream_47.Add(char_literal82);
+            	        			    	char_literal87=(IToken)Match(input,47,FOLLOW_47_in_tikz_set1008); if (state.failed) return retval; 
+            	        			    	if ( state.backtracking==0 ) stream_47.Add(char_literal87);
 
-            	        			    	PushFollow(FOLLOW_option_in_tikz_set985);
-            	        			    	option83 = option();
+            	        			    	PushFollow(FOLLOW_option_in_tikz_set1010);
+            	        			    	option88 = option();
             	        			    	state.followingStackPointer--;
             	        			    	if (state.failed) return retval;
-            	        			    	if ( state.backtracking==0 ) stream_option.Add(option83.Tree);
+            	        			    	if ( state.backtracking==0 ) stream_option.Add(option88.Tree);
 
             	        			    }
             	        			    break;
 
             	        			default:
-            	        			    goto loop25;
+            	        			    goto loop27;
             	        	    }
             	        	} while (true);
 
-            	        	loop25:
-            	        		;	// Stops C# compiler whining that label 'loop25' has no statements
+            	        	loop27:
+            	        		;	// Stops C# compiler whining that label 'loop27' has no statements
 
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:42: ( ',' )?
-            	        	int alt26 = 2;
-            	        	int LA26_0 = input.LA(1);
+            	        	int alt28 = 2;
+            	        	int LA28_0 = input.LA(1);
 
-            	        	if ( (LA26_0 == 47) )
+            	        	if ( (LA28_0 == 47) )
             	        	{
-            	        	    alt26 = 1;
+            	        	    alt28 = 1;
             	        	}
-            	        	switch (alt26) 
+            	        	switch (alt28) 
             	        	{
             	        	    case 1 :
             	        	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:42: ','
             	        	        {
-            	        	        	char_literal84=(IToken)Match(input,47,FOLLOW_47_in_tikz_set989); if (state.failed) return retval; 
-            	        	        	if ( state.backtracking==0 ) stream_47.Add(char_literal84);
+            	        	        	char_literal89=(IToken)Match(input,47,FOLLOW_47_in_tikz_set1014); if (state.failed) return retval; 
+            	        	        	if ( state.backtracking==0 ) stream_47.Add(char_literal89);
 
 
             	        	        }
@@ -3381,11 +3455,11 @@ public partial class simpletikzParser : Parser
 
             	}
 
-            	PushFollow(FOLLOW_roundbr_end_in_tikz_set994);
-            	roundbr_end85 = roundbr_end();
+            	PushFollow(FOLLOW_roundbr_end_in_tikz_set1019);
+            	roundbr_end90 = roundbr_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_roundbr_end.Add(roundbr_end85.Tree);
+            	if ( state.backtracking==0 ) stream_roundbr_end.Add(roundbr_end90.Tree);
 
 
             	// AST REWRITE
@@ -3460,25 +3534,25 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal92 = null;
-        simpletikzParser.tikzpicture_start_return tikzpicture_start86 = default(simpletikzParser.tikzpicture_start_return);
+        IToken char_literal97 = null;
+        simpletikzParser.tikzpicture_start_return tikzpicture_start91 = default(simpletikzParser.tikzpicture_start_return);
 
-        simpletikzParser.tikz_options_return tikz_options87 = default(simpletikzParser.tikz_options_return);
+        simpletikzParser.tikz_options_return tikz_options92 = default(simpletikzParser.tikz_options_return);
 
-        simpletikzParser.tikzbody_return tikzbody88 = default(simpletikzParser.tikzbody_return);
+        simpletikzParser.tikzbody_return tikzbody93 = default(simpletikzParser.tikzbody_return);
 
-        simpletikzParser.tikzpicture_end_return tikzpicture_end89 = default(simpletikzParser.tikzpicture_end_return);
+        simpletikzParser.tikzpicture_end_return tikzpicture_end94 = default(simpletikzParser.tikzpicture_end_return);
 
-        simpletikzParser.tikz_start_return tikz_start90 = default(simpletikzParser.tikz_start_return);
+        simpletikzParser.tikz_start_return tikz_start95 = default(simpletikzParser.tikz_start_return);
 
-        simpletikzParser.tikz_options_return tikz_options91 = default(simpletikzParser.tikz_options_return);
+        simpletikzParser.tikz_options_return tikz_options96 = default(simpletikzParser.tikz_options_return);
 
-        simpletikzParser.tikzbody2_return tikzbody293 = default(simpletikzParser.tikzbody2_return);
+        simpletikzParser.tikzbody2_return tikzbody298 = default(simpletikzParser.tikzbody2_return);
 
-        simpletikzParser.roundbr_end_return roundbr_end94 = default(simpletikzParser.roundbr_end_return);
+        simpletikzParser.roundbr_end_return roundbr_end99 = default(simpletikzParser.roundbr_end_return);
 
 
-        object char_literal92_tree=null;
+        object char_literal97_tree=null;
         RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
         RewriteRuleSubtreeStream stream_tikz_options = new RewriteRuleSubtreeStream(adaptor,"rule tikz_options");
         RewriteRuleSubtreeStream stream_tikz_start = new RewriteRuleSubtreeStream(adaptor,"rule tikz_start");
@@ -3490,26 +3564,26 @@ public partial class simpletikzParser : Parser
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:2: ( ( tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end ) -> ^( IM_PICTURE tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end ) | ( tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end ) -> ^( IM_PICTURE tikz_start ( tikz_options )? ( tikzbody2 )? roundbr_end ) )
-            int alt32 = 2;
-            int LA32_0 = input.LA(1);
+            int alt34 = 2;
+            int LA34_0 = input.LA(1);
 
-            if ( (LA32_0 == 39) )
+            if ( (LA34_0 == 39) )
             {
-                alt32 = 1;
+                alt34 = 1;
             }
-            else if ( (LA32_0 == 42) )
+            else if ( (LA34_0 == 42) )
             {
-                alt32 = 2;
+                alt34 = 2;
             }
             else 
             {
                 if ( state.backtracking > 0 ) {state.failed = true; return retval;}
-                NoViableAltException nvae_d32s0 =
-                    new NoViableAltException("", 32, 0, input);
+                NoViableAltException nvae_d34s0 =
+                    new NoViableAltException("", 34, 0, input);
 
-                throw nvae_d32s0;
+                throw nvae_d34s0;
             }
-            switch (alt32) 
+            switch (alt34) 
             {
                 case 1 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:7: ( tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end )
@@ -3517,29 +3591,29 @@ public partial class simpletikzParser : Parser
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:7: ( tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end )
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:9: tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end
                     	{
-                    		PushFollow(FOLLOW_tikzpicture_start_in_tikzpicture1026);
-                    		tikzpicture_start86 = tikzpicture_start();
+                    		PushFollow(FOLLOW_tikzpicture_start_in_tikzpicture1051);
+                    		tikzpicture_start91 = tikzpicture_start();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_tikzpicture_start.Add(tikzpicture_start86.Tree);
+                    		if ( state.backtracking==0 ) stream_tikzpicture_start.Add(tikzpicture_start91.Tree);
                     		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:27: ( tikz_options )?
-                    		int alt28 = 2;
-                    		int LA28_0 = input.LA(1);
+                    		int alt30 = 2;
+                    		int LA30_0 = input.LA(1);
 
-                    		if ( (LA28_0 == 55) )
+                    		if ( (LA30_0 == 57) )
                     		{
-                    		    alt28 = 1;
+                    		    alt30 = 1;
                     		}
-                    		switch (alt28) 
+                    		switch (alt30) 
                     		{
                     		    case 1 :
                     		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:27: tikz_options
                     		        {
-                    		        	PushFollow(FOLLOW_tikz_options_in_tikzpicture1028);
-                    		        	tikz_options87 = tikz_options();
+                    		        	PushFollow(FOLLOW_tikz_options_in_tikzpicture1053);
+                    		        	tikz_options92 = tikz_options();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options87.Tree);
+                    		        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options92.Tree);
 
                     		        }
                     		        break;
@@ -3547,55 +3621,55 @@ public partial class simpletikzParser : Parser
                     		}
 
                     		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:41: ( tikzbody )?
-                    		int alt29 = 2;
-                    		int LA29_0 = input.LA(1);
+                    		int alt31 = 2;
+                    		int LA31_0 = input.LA(1);
 
-                    		if ( ((LA29_0 >= IM_PATH && LA29_0 <= 54) || (LA29_0 >= 56 && LA29_0 <= 63) || (LA29_0 >= 65 && LA29_0 <= 95)) )
+                    		if ( ((LA31_0 >= IM_PATH && LA31_0 <= 56) || (LA31_0 >= 58 && LA31_0 <= 65) || (LA31_0 >= 67 && LA31_0 <= 97)) )
                     		{
-                    		    alt29 = 1;
+                    		    alt31 = 1;
                     		}
-                    		else if ( (LA29_0 == 64) )
+                    		else if ( (LA31_0 == 66) )
                     		{
-                    		    int LA29_2 = input.LA(2);
+                    		    int LA31_2 = input.LA(2);
 
-                    		    if ( (LA29_2 == 43) )
+                    		    if ( (LA31_2 == 43) )
                     		    {
-                    		        int LA29_3 = input.LA(3);
+                    		        int LA31_3 = input.LA(3);
 
-                    		        if ( (LA29_3 == ID) )
+                    		        if ( (LA31_3 == ID) )
                     		        {
-                    		            alt29 = 1;
+                    		            alt31 = 1;
                     		        }
                     		    }
                     		}
-                    		switch (alt29) 
+                    		switch (alt31) 
                     		{
                     		    case 1 :
                     		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:41: tikzbody
                     		        {
-                    		        	PushFollow(FOLLOW_tikzbody_in_tikzpicture1031);
-                    		        	tikzbody88 = tikzbody();
+                    		        	PushFollow(FOLLOW_tikzbody_in_tikzpicture1056);
+                    		        	tikzbody93 = tikzbody();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_tikzbody.Add(tikzbody88.Tree);
+                    		        	if ( state.backtracking==0 ) stream_tikzbody.Add(tikzbody93.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		PushFollow(FOLLOW_tikzpicture_end_in_tikzpicture1034);
-                    		tikzpicture_end89 = tikzpicture_end();
+                    		PushFollow(FOLLOW_tikzpicture_end_in_tikzpicture1059);
+                    		tikzpicture_end94 = tikzpicture_end();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_tikzpicture_end.Add(tikzpicture_end89.Tree);
+                    		if ( state.backtracking==0 ) stream_tikzpicture_end.Add(tikzpicture_end94.Tree);
 
                     	}
 
 
 
                     	// AST REWRITE
-                    	// elements:          tikzbody, tikzpicture_start, tikzpicture_end, tikz_options
+                    	// elements:          tikz_options, tikzbody, tikzpicture_start, tikzpicture_end
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -3643,74 +3717,74 @@ public partial class simpletikzParser : Parser
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:5: ( tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end )
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:7: tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end
                     	{
-                    		PushFollow(FOLLOW_tikz_start_in_tikzpicture1059);
-                    		tikz_start90 = tikz_start();
+                    		PushFollow(FOLLOW_tikz_start_in_tikzpicture1084);
+                    		tikz_start95 = tikz_start();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_tikz_start.Add(tikz_start90.Tree);
+                    		if ( state.backtracking==0 ) stream_tikz_start.Add(tikz_start95.Tree);
                     		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:19: ( tikz_options )?
-                    		int alt30 = 2;
-                    		int LA30_0 = input.LA(1);
+                    		int alt32 = 2;
+                    		int LA32_0 = input.LA(1);
 
-                    		if ( (LA30_0 == 55) )
+                    		if ( (LA32_0 == 57) )
                     		{
-                    		    alt30 = 1;
+                    		    alt32 = 1;
                     		}
-                    		switch (alt30) 
+                    		switch (alt32) 
                     		{
                     		    case 1 :
                     		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:19: tikz_options
                     		        {
-                    		        	PushFollow(FOLLOW_tikz_options_in_tikzpicture1062);
-                    		        	tikz_options91 = tikz_options();
+                    		        	PushFollow(FOLLOW_tikz_options_in_tikzpicture1087);
+                    		        	tikz_options96 = tikz_options();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options91.Tree);
+                    		        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options96.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal92=(IToken)Match(input,43,FOLLOW_43_in_tikzpicture1065); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_43.Add(char_literal92);
+                    		char_literal97=(IToken)Match(input,43,FOLLOW_43_in_tikzpicture1090); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_43.Add(char_literal97);
 
                     		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:37: ( tikzbody2 )?
-                    		int alt31 = 2;
-                    		int LA31_0 = input.LA(1);
+                    		int alt33 = 2;
+                    		int LA33_0 = input.LA(1);
 
-                    		if ( ((LA31_0 >= IM_PATH && LA31_0 <= 42) || (LA31_0 >= 45 && LA31_0 <= 54) || (LA31_0 >= 56 && LA31_0 <= 95)) )
+                    		if ( ((LA33_0 >= IM_PATH && LA33_0 <= 42) || (LA33_0 >= 45 && LA33_0 <= 56) || (LA33_0 >= 58 && LA33_0 <= 97)) )
                     		{
-                    		    alt31 = 1;
+                    		    alt33 = 1;
                     		}
-                    		switch (alt31) 
+                    		switch (alt33) 
                     		{
                     		    case 1 :
                     		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:37: tikzbody2
                     		        {
-                    		        	PushFollow(FOLLOW_tikzbody2_in_tikzpicture1067);
-                    		        	tikzbody293 = tikzbody2();
+                    		        	PushFollow(FOLLOW_tikzbody2_in_tikzpicture1092);
+                    		        	tikzbody298 = tikzbody2();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_tikzbody2.Add(tikzbody293.Tree);
+                    		        	if ( state.backtracking==0 ) stream_tikzbody2.Add(tikzbody298.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		PushFollow(FOLLOW_roundbr_end_in_tikzpicture1070);
-                    		roundbr_end94 = roundbr_end();
+                    		PushFollow(FOLLOW_roundbr_end_in_tikzpicture1095);
+                    		roundbr_end99 = roundbr_end();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_roundbr_end.Add(roundbr_end94.Tree);
+                    		if ( state.backtracking==0 ) stream_roundbr_end.Add(roundbr_end99.Tree);
 
                     	}
 
 
 
                     	// AST REWRITE
-                    	// elements:          tikzbody2, tikz_start, tikz_options, roundbr_end
+                    	// elements:          tikz_start, roundbr_end, tikzbody2, tikz_options
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -3790,49 +3864,49 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikzscope_return tikzscope95 = default(simpletikzParser.tikzscope_return);
+        simpletikzParser.tikzscope_return tikzscope100 = default(simpletikzParser.tikzscope_return);
 
-        simpletikzParser.tikzpath_return tikzpath96 = default(simpletikzParser.tikzpath_return);
+        simpletikzParser.tikzpath_return tikzpath101 = default(simpletikzParser.tikzpath_return);
 
-        simpletikzParser.tikznode_ext_return tikznode_ext97 = default(simpletikzParser.tikznode_ext_return);
+        simpletikzParser.tikznode_ext_return tikznode_ext102 = default(simpletikzParser.tikznode_ext_return);
 
-        simpletikzParser.tikzdef_ext_return tikzdef_ext98 = default(simpletikzParser.tikzdef_ext_return);
+        simpletikzParser.tikzdef_ext_return tikzdef_ext103 = default(simpletikzParser.tikzdef_ext_return);
 
-        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext99 = default(simpletikzParser.tikzmatrix_ext_return);
+        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext104 = default(simpletikzParser.tikzmatrix_ext_return);
 
-        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext100 = default(simpletikzParser.tikzcoordinate_ext_return);
+        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext105 = default(simpletikzParser.tikzcoordinate_ext_return);
 
-        simpletikzParser.tikz_set_return tikz_set101 = default(simpletikzParser.tikz_set_return);
+        simpletikzParser.tikz_set_return tikz_set106 = default(simpletikzParser.tikz_set_return);
 
-        simpletikzParser.tikz_style_return tikz_style102 = default(simpletikzParser.tikz_style_return);
+        simpletikzParser.tikz_style_return tikz_style107 = default(simpletikzParser.tikz_style_return);
 
-        simpletikzParser.otherbegin_return otherbegin103 = default(simpletikzParser.otherbegin_return);
+        simpletikzParser.otherbegin_return otherbegin108 = default(simpletikzParser.otherbegin_return);
 
-        simpletikzParser.otherend_return otherend104 = default(simpletikzParser.otherend_return);
+        simpletikzParser.otherend_return otherend109 = default(simpletikzParser.otherend_return);
 
-        simpletikzParser.dontcare_body_nobr_return dontcare_body_nobr105 = default(simpletikzParser.dontcare_body_nobr_return);
+        simpletikzParser.dontcare_body_nobr_return dontcare_body_nobr110 = default(simpletikzParser.dontcare_body_nobr_return);
 
-        simpletikzParser.tikzscope_return tikzscope106 = default(simpletikzParser.tikzscope_return);
+        simpletikzParser.tikzscope_return tikzscope111 = default(simpletikzParser.tikzscope_return);
 
-        simpletikzParser.tikzpath_return tikzpath107 = default(simpletikzParser.tikzpath_return);
+        simpletikzParser.tikzpath_return tikzpath112 = default(simpletikzParser.tikzpath_return);
 
-        simpletikzParser.tikznode_ext_return tikznode_ext108 = default(simpletikzParser.tikznode_ext_return);
+        simpletikzParser.tikznode_ext_return tikznode_ext113 = default(simpletikzParser.tikznode_ext_return);
 
-        simpletikzParser.tikzdef_ext_return tikzdef_ext109 = default(simpletikzParser.tikzdef_ext_return);
+        simpletikzParser.tikzdef_ext_return tikzdef_ext114 = default(simpletikzParser.tikzdef_ext_return);
 
-        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext110 = default(simpletikzParser.tikzmatrix_ext_return);
+        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext115 = default(simpletikzParser.tikzmatrix_ext_return);
 
-        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext111 = default(simpletikzParser.tikzcoordinate_ext_return);
+        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext116 = default(simpletikzParser.tikzcoordinate_ext_return);
 
-        simpletikzParser.tikz_set_return tikz_set112 = default(simpletikzParser.tikz_set_return);
+        simpletikzParser.tikz_set_return tikz_set117 = default(simpletikzParser.tikz_set_return);
 
-        simpletikzParser.tikz_style_return tikz_style113 = default(simpletikzParser.tikz_style_return);
+        simpletikzParser.tikz_style_return tikz_style118 = default(simpletikzParser.tikz_style_return);
 
-        simpletikzParser.otherbegin_return otherbegin114 = default(simpletikzParser.otherbegin_return);
+        simpletikzParser.otherbegin_return otherbegin119 = default(simpletikzParser.otherbegin_return);
 
-        simpletikzParser.otherend_return otherend115 = default(simpletikzParser.otherend_return);
+        simpletikzParser.otherend_return otherend120 = default(simpletikzParser.otherend_return);
 
-        simpletikzParser.dontcare_body_return dontcare_body116 = default(simpletikzParser.dontcare_body_return);
+        simpletikzParser.dontcare_body_return dontcare_body121 = default(simpletikzParser.dontcare_body_return);
 
 
 
@@ -3844,103 +3918,103 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
 
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr )
-            	int alt33 = 11;
-            	alt33 = dfa33.Predict(input);
-            	switch (alt33) 
+            	int alt35 = 11;
+            	alt35 = dfa35.Predict(input);
+            	switch (alt35) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:6: tikzscope
             	        {
-            	        	PushFollow(FOLLOW_tikzscope_in_tikzbody1102);
-            	        	tikzscope95 = tikzscope();
+            	        	PushFollow(FOLLOW_tikzscope_in_tikzbody1127);
+            	        	tikzscope100 = tikzscope();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope95.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope100.Tree);
 
             	        }
             	        break;
             	    case 2 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:18: tikzpath
             	        {
-            	        	PushFollow(FOLLOW_tikzpath_in_tikzbody1106);
-            	        	tikzpath96 = tikzpath();
+            	        	PushFollow(FOLLOW_tikzpath_in_tikzbody1131);
+            	        	tikzpath101 = tikzpath();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath96.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath101.Tree);
 
             	        }
             	        break;
             	    case 3 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:29: tikznode_ext
             	        {
-            	        	PushFollow(FOLLOW_tikznode_ext_in_tikzbody1110);
-            	        	tikznode_ext97 = tikznode_ext();
+            	        	PushFollow(FOLLOW_tikznode_ext_in_tikzbody1135);
+            	        	tikznode_ext102 = tikznode_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext97.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext102.Tree);
 
             	        }
             	        break;
             	    case 4 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:44: tikzdef_ext
             	        {
-            	        	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody1114);
-            	        	tikzdef_ext98 = tikzdef_ext();
+            	        	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody1139);
+            	        	tikzdef_ext103 = tikzdef_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext98.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext103.Tree);
 
             	        }
             	        break;
             	    case 5 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:58: tikzmatrix_ext
             	        {
-            	        	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody1118);
-            	        	tikzmatrix_ext99 = tikzmatrix_ext();
+            	        	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody1143);
+            	        	tikzmatrix_ext104 = tikzmatrix_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext99.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext104.Tree);
 
             	        }
             	        break;
             	    case 6 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:75: tikzcoordinate_ext
             	        {
-            	        	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody1122);
-            	        	tikzcoordinate_ext100 = tikzcoordinate_ext();
+            	        	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody1147);
+            	        	tikzcoordinate_ext105 = tikzcoordinate_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext100.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext105.Tree);
 
             	        }
             	        break;
             	    case 7 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:96: tikz_set
             	        {
-            	        	PushFollow(FOLLOW_tikz_set_in_tikzbody1126);
-            	        	tikz_set101 = tikz_set();
+            	        	PushFollow(FOLLOW_tikz_set_in_tikzbody1151);
+            	        	tikz_set106 = tikz_set();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set101.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set106.Tree);
 
             	        }
             	        break;
             	    case 8 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:107: tikz_style
             	        {
-            	        	PushFollow(FOLLOW_tikz_style_in_tikzbody1130);
-            	        	tikz_style102 = tikz_style();
+            	        	PushFollow(FOLLOW_tikz_style_in_tikzbody1155);
+            	        	tikz_style107 = tikz_style();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style102.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style107.Tree);
 
             	        }
             	        break;
             	    case 9 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:120: otherbegin
             	        {
-            	        	PushFollow(FOLLOW_otherbegin_in_tikzbody1134);
-            	        	otherbegin103 = otherbegin();
+            	        	PushFollow(FOLLOW_otherbegin_in_tikzbody1159);
+            	        	otherbegin108 = otherbegin();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
 
@@ -3949,8 +4023,8 @@ public partial class simpletikzParser : Parser
             	    case 10 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:134: otherend
             	        {
-            	        	PushFollow(FOLLOW_otherend_in_tikzbody1139);
-            	        	otherend104 = otherend();
+            	        	PushFollow(FOLLOW_otherend_in_tikzbody1164);
+            	        	otherend109 = otherend();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
 
@@ -3959,8 +4033,8 @@ public partial class simpletikzParser : Parser
             	    case 11 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:146: dontcare_body_nobr
             	        {
-            	        	PushFollow(FOLLOW_dontcare_body_nobr_in_tikzbody1144);
-            	        	dontcare_body_nobr105 = dontcare_body_nobr();
+            	        	PushFollow(FOLLOW_dontcare_body_nobr_in_tikzbody1169);
+            	        	dontcare_body_nobr110 = dontcare_body_nobr();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
 
@@ -3972,103 +4046,103 @@ public partial class simpletikzParser : Parser
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:3: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body )*
             	do 
             	{
-            	    int alt34 = 12;
-            	    alt34 = dfa34.Predict(input);
-            	    switch (alt34) 
+            	    int alt36 = 12;
+            	    alt36 = dfa36.Predict(input);
+            	    switch (alt36) 
             		{
             			case 1 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:5: tikzscope
             			    {
-            			    	PushFollow(FOLLOW_tikzscope_in_tikzbody1155);
-            			    	tikzscope106 = tikzscope();
+            			    	PushFollow(FOLLOW_tikzscope_in_tikzbody1180);
+            			    	tikzscope111 = tikzscope();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope106.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope111.Tree);
 
             			    }
             			    break;
             			case 2 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:17: tikzpath
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_in_tikzbody1159);
-            			    	tikzpath107 = tikzpath();
+            			    	PushFollow(FOLLOW_tikzpath_in_tikzbody1184);
+            			    	tikzpath112 = tikzpath();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath107.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath112.Tree);
 
             			    }
             			    break;
             			case 3 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:28: tikznode_ext
             			    {
-            			    	PushFollow(FOLLOW_tikznode_ext_in_tikzbody1163);
-            			    	tikznode_ext108 = tikznode_ext();
+            			    	PushFollow(FOLLOW_tikznode_ext_in_tikzbody1188);
+            			    	tikznode_ext113 = tikznode_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext108.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext113.Tree);
 
             			    }
             			    break;
             			case 4 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:43: tikzdef_ext
             			    {
-            			    	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody1167);
-            			    	tikzdef_ext109 = tikzdef_ext();
+            			    	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody1192);
+            			    	tikzdef_ext114 = tikzdef_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext109.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext114.Tree);
 
             			    }
             			    break;
             			case 5 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:57: tikzmatrix_ext
             			    {
-            			    	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody1171);
-            			    	tikzmatrix_ext110 = tikzmatrix_ext();
+            			    	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody1196);
+            			    	tikzmatrix_ext115 = tikzmatrix_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext110.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext115.Tree);
 
             			    }
             			    break;
             			case 6 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:74: tikzcoordinate_ext
             			    {
-            			    	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody1175);
-            			    	tikzcoordinate_ext111 = tikzcoordinate_ext();
+            			    	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody1200);
+            			    	tikzcoordinate_ext116 = tikzcoordinate_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext111.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext116.Tree);
 
             			    }
             			    break;
             			case 7 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:95: tikz_set
             			    {
-            			    	PushFollow(FOLLOW_tikz_set_in_tikzbody1179);
-            			    	tikz_set112 = tikz_set();
+            			    	PushFollow(FOLLOW_tikz_set_in_tikzbody1204);
+            			    	tikz_set117 = tikz_set();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set112.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set117.Tree);
 
             			    }
             			    break;
             			case 8 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:106: tikz_style
             			    {
-            			    	PushFollow(FOLLOW_tikz_style_in_tikzbody1183);
-            			    	tikz_style113 = tikz_style();
+            			    	PushFollow(FOLLOW_tikz_style_in_tikzbody1208);
+            			    	tikz_style118 = tikz_style();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style113.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style118.Tree);
 
             			    }
             			    break;
             			case 9 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:119: otherbegin
             			    {
-            			    	PushFollow(FOLLOW_otherbegin_in_tikzbody1187);
-            			    	otherbegin114 = otherbegin();
+            			    	PushFollow(FOLLOW_otherbegin_in_tikzbody1212);
+            			    	otherbegin119 = otherbegin();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
 
@@ -4077,8 +4151,8 @@ public partial class simpletikzParser : Parser
             			case 10 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:133: otherend
             			    {
-            			    	PushFollow(FOLLOW_otherend_in_tikzbody1192);
-            			    	otherend115 = otherend();
+            			    	PushFollow(FOLLOW_otherend_in_tikzbody1217);
+            			    	otherend120 = otherend();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
 
@@ -4087,8 +4161,8 @@ public partial class simpletikzParser : Parser
             			case 11 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:145: dontcare_body
             			    {
-            			    	PushFollow(FOLLOW_dontcare_body_in_tikzbody1197);
-            			    	dontcare_body116 = dontcare_body();
+            			    	PushFollow(FOLLOW_dontcare_body_in_tikzbody1222);
+            			    	dontcare_body121 = dontcare_body();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
 
@@ -4096,12 +4170,12 @@ public partial class simpletikzParser : Parser
             			    break;
 
             			default:
-            			    goto loop34;
+            			    goto loop36;
             	    }
             	} while (true);
 
-            	loop34:
-            		;	// Stops C# compiler whining that label 'loop34' has no statements
+            	loop36:
+            		;	// Stops C# compiler whining that label 'loop36' has no statements
 
 
             }
@@ -4142,49 +4216,49 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikzscope_return tikzscope117 = default(simpletikzParser.tikzscope_return);
+        simpletikzParser.tikzscope_return tikzscope122 = default(simpletikzParser.tikzscope_return);
 
-        simpletikzParser.tikzpath_return tikzpath118 = default(simpletikzParser.tikzpath_return);
+        simpletikzParser.tikzpath_return tikzpath123 = default(simpletikzParser.tikzpath_return);
 
-        simpletikzParser.tikznode_ext_return tikznode_ext119 = default(simpletikzParser.tikznode_ext_return);
+        simpletikzParser.tikznode_ext_return tikznode_ext124 = default(simpletikzParser.tikznode_ext_return);
 
-        simpletikzParser.tikzdef_ext_return tikzdef_ext120 = default(simpletikzParser.tikzdef_ext_return);
+        simpletikzParser.tikzdef_ext_return tikzdef_ext125 = default(simpletikzParser.tikzdef_ext_return);
 
-        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext121 = default(simpletikzParser.tikzmatrix_ext_return);
+        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext126 = default(simpletikzParser.tikzmatrix_ext_return);
 
-        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext122 = default(simpletikzParser.tikzcoordinate_ext_return);
+        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext127 = default(simpletikzParser.tikzcoordinate_ext_return);
 
-        simpletikzParser.tikz_set_return tikz_set123 = default(simpletikzParser.tikz_set_return);
+        simpletikzParser.tikz_set_return tikz_set128 = default(simpletikzParser.tikz_set_return);
 
-        simpletikzParser.tikz_style_return tikz_style124 = default(simpletikzParser.tikz_style_return);
+        simpletikzParser.tikz_style_return tikz_style129 = default(simpletikzParser.tikz_style_return);
 
-        simpletikzParser.otherbegin_return otherbegin125 = default(simpletikzParser.otherbegin_return);
+        simpletikzParser.otherbegin_return otherbegin130 = default(simpletikzParser.otherbegin_return);
 
-        simpletikzParser.otherend_return otherend126 = default(simpletikzParser.otherend_return);
+        simpletikzParser.otherend_return otherend131 = default(simpletikzParser.otherend_return);
 
-        simpletikzParser.dontcare_body_nobr2_return dontcare_body_nobr2127 = default(simpletikzParser.dontcare_body_nobr2_return);
+        simpletikzParser.dontcare_body_nobr2_return dontcare_body_nobr2132 = default(simpletikzParser.dontcare_body_nobr2_return);
 
-        simpletikzParser.tikzscope_return tikzscope128 = default(simpletikzParser.tikzscope_return);
+        simpletikzParser.tikzscope_return tikzscope133 = default(simpletikzParser.tikzscope_return);
 
-        simpletikzParser.tikzpath_return tikzpath129 = default(simpletikzParser.tikzpath_return);
+        simpletikzParser.tikzpath_return tikzpath134 = default(simpletikzParser.tikzpath_return);
 
-        simpletikzParser.tikznode_ext_return tikznode_ext130 = default(simpletikzParser.tikznode_ext_return);
+        simpletikzParser.tikznode_ext_return tikznode_ext135 = default(simpletikzParser.tikznode_ext_return);
 
-        simpletikzParser.tikzdef_ext_return tikzdef_ext131 = default(simpletikzParser.tikzdef_ext_return);
+        simpletikzParser.tikzdef_ext_return tikzdef_ext136 = default(simpletikzParser.tikzdef_ext_return);
 
-        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext132 = default(simpletikzParser.tikzmatrix_ext_return);
+        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext137 = default(simpletikzParser.tikzmatrix_ext_return);
 
-        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext133 = default(simpletikzParser.tikzcoordinate_ext_return);
+        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext138 = default(simpletikzParser.tikzcoordinate_ext_return);
 
-        simpletikzParser.tikz_set_return tikz_set134 = default(simpletikzParser.tikz_set_return);
+        simpletikzParser.tikz_set_return tikz_set139 = default(simpletikzParser.tikz_set_return);
 
-        simpletikzParser.tikz_style_return tikz_style135 = default(simpletikzParser.tikz_style_return);
+        simpletikzParser.tikz_style_return tikz_style140 = default(simpletikzParser.tikz_style_return);
 
-        simpletikzParser.otherbegin_return otherbegin136 = default(simpletikzParser.otherbegin_return);
+        simpletikzParser.otherbegin_return otherbegin141 = default(simpletikzParser.otherbegin_return);
 
-        simpletikzParser.otherend_return otherend137 = default(simpletikzParser.otherend_return);
+        simpletikzParser.otherend_return otherend142 = default(simpletikzParser.otherend_return);
 
-        simpletikzParser.dontcare_body2_return dontcare_body2138 = default(simpletikzParser.dontcare_body2_return);
+        simpletikzParser.dontcare_body2_return dontcare_body2143 = default(simpletikzParser.dontcare_body2_return);
 
 
 
@@ -4196,103 +4270,103 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
 
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr2 )
-            	int alt35 = 11;
-            	alt35 = dfa35.Predict(input);
-            	switch (alt35) 
+            	int alt37 = 11;
+            	alt37 = dfa37.Predict(input);
+            	switch (alt37) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:6: tikzscope
             	        {
-            	        	PushFollow(FOLLOW_tikzscope_in_tikzbody21213);
-            	        	tikzscope117 = tikzscope();
+            	        	PushFollow(FOLLOW_tikzscope_in_tikzbody21238);
+            	        	tikzscope122 = tikzscope();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope117.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope122.Tree);
 
             	        }
             	        break;
             	    case 2 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:18: tikzpath
             	        {
-            	        	PushFollow(FOLLOW_tikzpath_in_tikzbody21217);
-            	        	tikzpath118 = tikzpath();
+            	        	PushFollow(FOLLOW_tikzpath_in_tikzbody21242);
+            	        	tikzpath123 = tikzpath();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath118.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath123.Tree);
 
             	        }
             	        break;
             	    case 3 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:29: tikznode_ext
             	        {
-            	        	PushFollow(FOLLOW_tikznode_ext_in_tikzbody21221);
-            	        	tikznode_ext119 = tikznode_ext();
+            	        	PushFollow(FOLLOW_tikznode_ext_in_tikzbody21246);
+            	        	tikznode_ext124 = tikznode_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext119.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext124.Tree);
 
             	        }
             	        break;
             	    case 4 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:44: tikzdef_ext
             	        {
-            	        	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody21225);
-            	        	tikzdef_ext120 = tikzdef_ext();
+            	        	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody21250);
+            	        	tikzdef_ext125 = tikzdef_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext120.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext125.Tree);
 
             	        }
             	        break;
             	    case 5 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:58: tikzmatrix_ext
             	        {
-            	        	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody21229);
-            	        	tikzmatrix_ext121 = tikzmatrix_ext();
+            	        	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody21254);
+            	        	tikzmatrix_ext126 = tikzmatrix_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext121.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext126.Tree);
 
             	        }
             	        break;
             	    case 6 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:75: tikzcoordinate_ext
             	        {
-            	        	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody21233);
-            	        	tikzcoordinate_ext122 = tikzcoordinate_ext();
+            	        	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody21258);
+            	        	tikzcoordinate_ext127 = tikzcoordinate_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext122.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext127.Tree);
 
             	        }
             	        break;
             	    case 7 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:96: tikz_set
             	        {
-            	        	PushFollow(FOLLOW_tikz_set_in_tikzbody21237);
-            	        	tikz_set123 = tikz_set();
+            	        	PushFollow(FOLLOW_tikz_set_in_tikzbody21262);
+            	        	tikz_set128 = tikz_set();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set123.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set128.Tree);
 
             	        }
             	        break;
             	    case 8 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:107: tikz_style
             	        {
-            	        	PushFollow(FOLLOW_tikz_style_in_tikzbody21241);
-            	        	tikz_style124 = tikz_style();
+            	        	PushFollow(FOLLOW_tikz_style_in_tikzbody21266);
+            	        	tikz_style129 = tikz_style();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style124.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style129.Tree);
 
             	        }
             	        break;
             	    case 9 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:120: otherbegin
             	        {
-            	        	PushFollow(FOLLOW_otherbegin_in_tikzbody21245);
-            	        	otherbegin125 = otherbegin();
+            	        	PushFollow(FOLLOW_otherbegin_in_tikzbody21270);
+            	        	otherbegin130 = otherbegin();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
 
@@ -4301,8 +4375,8 @@ public partial class simpletikzParser : Parser
             	    case 10 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:134: otherend
             	        {
-            	        	PushFollow(FOLLOW_otherend_in_tikzbody21250);
-            	        	otherend126 = otherend();
+            	        	PushFollow(FOLLOW_otherend_in_tikzbody21275);
+            	        	otherend131 = otherend();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
 
@@ -4311,8 +4385,8 @@ public partial class simpletikzParser : Parser
             	    case 11 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:146: dontcare_body_nobr2
             	        {
-            	        	PushFollow(FOLLOW_dontcare_body_nobr2_in_tikzbody21255);
-            	        	dontcare_body_nobr2127 = dontcare_body_nobr2();
+            	        	PushFollow(FOLLOW_dontcare_body_nobr2_in_tikzbody21280);
+            	        	dontcare_body_nobr2132 = dontcare_body_nobr2();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
 
@@ -4324,103 +4398,103 @@ public partial class simpletikzParser : Parser
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:3: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body2 )*
             	do 
             	{
-            	    int alt36 = 12;
-            	    alt36 = dfa36.Predict(input);
-            	    switch (alt36) 
+            	    int alt38 = 12;
+            	    alt38 = dfa38.Predict(input);
+            	    switch (alt38) 
             		{
             			case 1 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:5: tikzscope
             			    {
-            			    	PushFollow(FOLLOW_tikzscope_in_tikzbody21266);
-            			    	tikzscope128 = tikzscope();
+            			    	PushFollow(FOLLOW_tikzscope_in_tikzbody21291);
+            			    	tikzscope133 = tikzscope();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope128.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope133.Tree);
 
             			    }
             			    break;
             			case 2 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:17: tikzpath
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_in_tikzbody21270);
-            			    	tikzpath129 = tikzpath();
+            			    	PushFollow(FOLLOW_tikzpath_in_tikzbody21295);
+            			    	tikzpath134 = tikzpath();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath129.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath134.Tree);
 
             			    }
             			    break;
             			case 3 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:28: tikznode_ext
             			    {
-            			    	PushFollow(FOLLOW_tikznode_ext_in_tikzbody21274);
-            			    	tikznode_ext130 = tikznode_ext();
+            			    	PushFollow(FOLLOW_tikznode_ext_in_tikzbody21299);
+            			    	tikznode_ext135 = tikznode_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext130.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext135.Tree);
 
             			    }
             			    break;
             			case 4 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:43: tikzdef_ext
             			    {
-            			    	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody21278);
-            			    	tikzdef_ext131 = tikzdef_ext();
+            			    	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody21303);
+            			    	tikzdef_ext136 = tikzdef_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext131.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext136.Tree);
 
             			    }
             			    break;
             			case 5 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:57: tikzmatrix_ext
             			    {
-            			    	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody21282);
-            			    	tikzmatrix_ext132 = tikzmatrix_ext();
+            			    	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody21307);
+            			    	tikzmatrix_ext137 = tikzmatrix_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext132.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext137.Tree);
 
             			    }
             			    break;
             			case 6 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:74: tikzcoordinate_ext
             			    {
-            			    	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody21286);
-            			    	tikzcoordinate_ext133 = tikzcoordinate_ext();
+            			    	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody21311);
+            			    	tikzcoordinate_ext138 = tikzcoordinate_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext133.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext138.Tree);
 
             			    }
             			    break;
             			case 7 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:95: tikz_set
             			    {
-            			    	PushFollow(FOLLOW_tikz_set_in_tikzbody21290);
-            			    	tikz_set134 = tikz_set();
+            			    	PushFollow(FOLLOW_tikz_set_in_tikzbody21315);
+            			    	tikz_set139 = tikz_set();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set134.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set139.Tree);
 
             			    }
             			    break;
             			case 8 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:106: tikz_style
             			    {
-            			    	PushFollow(FOLLOW_tikz_style_in_tikzbody21294);
-            			    	tikz_style135 = tikz_style();
+            			    	PushFollow(FOLLOW_tikz_style_in_tikzbody21319);
+            			    	tikz_style140 = tikz_style();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style135.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style140.Tree);
 
             			    }
             			    break;
             			case 9 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:119: otherbegin
             			    {
-            			    	PushFollow(FOLLOW_otherbegin_in_tikzbody21298);
-            			    	otherbegin136 = otherbegin();
+            			    	PushFollow(FOLLOW_otherbegin_in_tikzbody21323);
+            			    	otherbegin141 = otherbegin();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
 
@@ -4429,8 +4503,8 @@ public partial class simpletikzParser : Parser
             			case 10 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:133: otherend
             			    {
-            			    	PushFollow(FOLLOW_otherend_in_tikzbody21303);
-            			    	otherend137 = otherend();
+            			    	PushFollow(FOLLOW_otherend_in_tikzbody21328);
+            			    	otherend142 = otherend();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
 
@@ -4439,8 +4513,8 @@ public partial class simpletikzParser : Parser
             			case 11 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:145: dontcare_body2
             			    {
-            			    	PushFollow(FOLLOW_dontcare_body2_in_tikzbody21308);
-            			    	dontcare_body2138 = dontcare_body2();
+            			    	PushFollow(FOLLOW_dontcare_body2_in_tikzbody21333);
+            			    	dontcare_body2143 = dontcare_body2();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
 
@@ -4448,12 +4522,12 @@ public partial class simpletikzParser : Parser
             			    break;
 
             			default:
-            			    goto loop36;
+            			    goto loop38;
             	    }
             	} while (true);
 
-            	loop36:
-            		;	// Stops C# compiler whining that label 'loop36' has no statements
+            	loop38:
+            		;	// Stops C# compiler whining that label 'loop38' has no statements
 
 
             }
@@ -4494,9 +4568,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set139 = null;
+        IToken set144 = null;
 
-        object set139_tree=null;
+        object set144_tree=null;
 
         try 
     	{
@@ -4508,11 +4582,11 @@ public partial class simpletikzParser : Parser
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:257:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' | '{' | '}' ) )
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:257:5: ~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' | '{' | '}' )
             	{
-            		set139 = (IToken)input.LT(1);
-            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || input.LA(1) == 42 || (input.LA(1) >= 45 && input.LA(1) <= 54) || (input.LA(1) >= 56 && input.LA(1) <= 63) || (input.LA(1) >= 78 && input.LA(1) <= 95) ) 
+            		set144 = (IToken)input.LT(1);
+            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || input.LA(1) == 42 || (input.LA(1) >= 45 && input.LA(1) <= 56) || (input.LA(1) >= 58 && input.LA(1) <= 65) || (input.LA(1) >= 80 && input.LA(1) <= 97) ) 
             		{
             		    input.Consume();
-            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set139));
+            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set144));
             		    state.errorRecovery = false;state.failed = false;
             		}
             		else 
@@ -4564,9 +4638,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set140 = null;
+        IToken set145 = null;
 
-        object set140_tree=null;
+        object set145_tree=null;
 
         try 
     	{
@@ -4578,11 +4652,11 @@ public partial class simpletikzParser : Parser
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:260:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '{' | '}' ) )
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:260:5: ~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '{' | '}' )
             	{
-            		set140 = (IToken)input.LT(1);
-            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || input.LA(1) == 42 || (input.LA(1) >= 45 && input.LA(1) <= 63) || (input.LA(1) >= 78 && input.LA(1) <= 95) ) 
+            		set145 = (IToken)input.LT(1);
+            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || input.LA(1) == 42 || (input.LA(1) >= 45 && input.LA(1) <= 65) || (input.LA(1) >= 80 && input.LA(1) <= 97) ) 
             		{
             		    input.Consume();
-            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set140));
+            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set145));
             		    state.errorRecovery = false;state.failed = false;
             		}
             		else 
@@ -4634,9 +4708,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set141 = null;
+        IToken set146 = null;
 
-        object set141_tree=null;
+        object set146_tree=null;
 
         try 
     	{
@@ -4648,11 +4722,11 @@ public partial class simpletikzParser : Parser
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:263:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' ) )
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:263:5: ~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' )
             	{
-            		set141 = (IToken)input.LT(1);
-            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || (input.LA(1) >= 42 && input.LA(1) <= 54) || (input.LA(1) >= 56 && input.LA(1) <= 63) || (input.LA(1) >= 78 && input.LA(1) <= 95) ) 
+            		set146 = (IToken)input.LT(1);
+            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || (input.LA(1) >= 42 && input.LA(1) <= 56) || (input.LA(1) >= 58 && input.LA(1) <= 65) || (input.LA(1) >= 80 && input.LA(1) <= 97) ) 
             		{
             		    input.Consume();
-            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set141));
+            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set146));
             		    state.errorRecovery = false;state.failed = false;
             		}
             		else 
@@ -4704,9 +4778,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set142 = null;
+        IToken set147 = null;
 
-        object set142_tree=null;
+        object set147_tree=null;
 
         try 
     	{
@@ -4718,11 +4792,11 @@ public partial class simpletikzParser : Parser
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:266:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' ) )
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:266:5: ~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' )
             	{
-            		set142 = (IToken)input.LT(1);
-            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || (input.LA(1) >= 42 && input.LA(1) <= 63) || (input.LA(1) >= 78 && input.LA(1) <= 95) ) 
+            		set147 = (IToken)input.LT(1);
+            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || (input.LA(1) >= 42 && input.LA(1) <= 65) || (input.LA(1) >= 80 && input.LA(1) <= 97) ) 
             		{
             		    input.Consume();
-            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set142));
+            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set147));
             		    state.errorRecovery = false;state.failed = false;
             		}
             		else 
@@ -4774,15 +4848,15 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal143 = null;
-        IToken char_literal144 = null;
-        IToken char_literal146 = null;
-        simpletikzParser.idd2_return idd2145 = default(simpletikzParser.idd2_return);
+        IToken string_literal148 = null;
+        IToken char_literal149 = null;
+        IToken char_literal151 = null;
+        simpletikzParser.idd2_return idd2150 = default(simpletikzParser.idd2_return);
 
 
-        object string_literal143_tree=null;
-        object char_literal144_tree=null;
-        object char_literal146_tree=null;
+        object string_literal148_tree=null;
+        object char_literal149_tree=null;
+        object char_literal151_tree=null;
 
         try 
     	{
@@ -4791,25 +4865,25 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	string_literal143=(IToken)Match(input,64,FOLLOW_64_in_otherend1679); if (state.failed) return retval;
+            	string_literal148=(IToken)Match(input,66,FOLLOW_66_in_otherend1704); if (state.failed) return retval;
             	if ( state.backtracking == 0 )
-            	{string_literal143_tree = (object)adaptor.Create(string_literal143);
-            		adaptor.AddChild(root_0, string_literal143_tree);
+            	{string_literal148_tree = (object)adaptor.Create(string_literal148);
+            		adaptor.AddChild(root_0, string_literal148_tree);
             	}
-            	char_literal144=(IToken)Match(input,43,FOLLOW_43_in_otherend1681); if (state.failed) return retval;
+            	char_literal149=(IToken)Match(input,43,FOLLOW_43_in_otherend1706); if (state.failed) return retval;
             	if ( state.backtracking == 0 )
-            	{char_literal144_tree = (object)adaptor.Create(char_literal144);
-            		adaptor.AddChild(root_0, char_literal144_tree);
+            	{char_literal149_tree = (object)adaptor.Create(char_literal149);
+            		adaptor.AddChild(root_0, char_literal149_tree);
             	}
-            	PushFollow(FOLLOW_idd2_in_otherend1683);
-            	idd2145 = idd2();
+            	PushFollow(FOLLOW_idd2_in_otherend1708);
+            	idd2150 = idd2();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, idd2145.Tree);
-            	char_literal146=(IToken)Match(input,44,FOLLOW_44_in_otherend1685); if (state.failed) return retval;
+            	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, idd2150.Tree);
+            	char_literal151=(IToken)Match(input,44,FOLLOW_44_in_otherend1710); if (state.failed) return retval;
             	if ( state.backtracking == 0 )
-            	{char_literal146_tree = (object)adaptor.Create(char_literal146);
-            		adaptor.AddChild(root_0, char_literal146_tree);
+            	{char_literal151_tree = (object)adaptor.Create(char_literal151);
+            		adaptor.AddChild(root_0, char_literal151_tree);
             	}
 
             }
@@ -4850,13 +4924,13 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikzscope_start_return tikzscope_start147 = default(simpletikzParser.tikzscope_start_return);
+        simpletikzParser.tikzscope_start_return tikzscope_start152 = default(simpletikzParser.tikzscope_start_return);
 
-        simpletikzParser.tikz_options_return tikz_options148 = default(simpletikzParser.tikz_options_return);
+        simpletikzParser.tikz_options_return tikz_options153 = default(simpletikzParser.tikz_options_return);
 
-        simpletikzParser.tikzbody_return tikzbody149 = default(simpletikzParser.tikzbody_return);
+        simpletikzParser.tikzbody_return tikzbody154 = default(simpletikzParser.tikzbody_return);
 
-        simpletikzParser.tikzscope_end_return tikzscope_end150 = default(simpletikzParser.tikzscope_end_return);
+        simpletikzParser.tikzscope_end_return tikzscope_end155 = default(simpletikzParser.tikzscope_end_return);
 
 
         RewriteRuleSubtreeStream stream_tikz_options = new RewriteRuleSubtreeStream(adaptor,"rule tikz_options");
@@ -4868,29 +4942,29 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:2: ( tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end -> ^( IM_SCOPE tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:4: tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end
             {
-            	PushFollow(FOLLOW_tikzscope_start_in_tikzscope1712);
-            	tikzscope_start147 = tikzscope_start();
+            	PushFollow(FOLLOW_tikzscope_start_in_tikzscope1737);
+            	tikzscope_start152 = tikzscope_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikzscope_start.Add(tikzscope_start147.Tree);
+            	if ( state.backtracking==0 ) stream_tikzscope_start.Add(tikzscope_start152.Tree);
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:20: ( tikz_options )?
-            	int alt37 = 2;
-            	int LA37_0 = input.LA(1);
+            	int alt39 = 2;
+            	int LA39_0 = input.LA(1);
 
-            	if ( (LA37_0 == 55) )
+            	if ( (LA39_0 == 57) )
             	{
-            	    alt37 = 1;
+            	    alt39 = 1;
             	}
-            	switch (alt37) 
+            	switch (alt39) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:20: tikz_options
             	        {
-            	        	PushFollow(FOLLOW_tikz_options_in_tikzscope1714);
-            	        	tikz_options148 = tikz_options();
+            	        	PushFollow(FOLLOW_tikz_options_in_tikzscope1739);
+            	        	tikz_options153 = tikz_options();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options148.Tree);
+            	        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options153.Tree);
 
             	        }
             	        break;
@@ -4898,52 +4972,52 @@ public partial class simpletikzParser : Parser
             	}
 
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:34: ( tikzbody )?
-            	int alt38 = 2;
-            	int LA38_0 = input.LA(1);
+            	int alt40 = 2;
+            	int LA40_0 = input.LA(1);
 
-            	if ( ((LA38_0 >= IM_PATH && LA38_0 <= 54) || (LA38_0 >= 56 && LA38_0 <= 63) || (LA38_0 >= 65 && LA38_0 <= 95)) )
+            	if ( ((LA40_0 >= IM_PATH && LA40_0 <= 56) || (LA40_0 >= 58 && LA40_0 <= 65) || (LA40_0 >= 67 && LA40_0 <= 97)) )
             	{
-            	    alt38 = 1;
+            	    alt40 = 1;
             	}
-            	else if ( (LA38_0 == 64) )
+            	else if ( (LA40_0 == 66) )
             	{
-            	    int LA38_2 = input.LA(2);
+            	    int LA40_2 = input.LA(2);
 
-            	    if ( (LA38_2 == 43) )
+            	    if ( (LA40_2 == 43) )
             	    {
-            	        int LA38_3 = input.LA(3);
+            	        int LA40_3 = input.LA(3);
 
-            	        if ( (LA38_3 == ID) )
+            	        if ( (LA40_3 == ID) )
             	        {
-            	            alt38 = 1;
+            	            alt40 = 1;
             	        }
             	    }
             	}
-            	switch (alt38) 
+            	switch (alt40) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:34: tikzbody
             	        {
-            	        	PushFollow(FOLLOW_tikzbody_in_tikzscope1717);
-            	        	tikzbody149 = tikzbody();
+            	        	PushFollow(FOLLOW_tikzbody_in_tikzscope1742);
+            	        	tikzbody154 = tikzbody();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_tikzbody.Add(tikzbody149.Tree);
+            	        	if ( state.backtracking==0 ) stream_tikzbody.Add(tikzbody154.Tree);
 
             	        }
             	        break;
 
             	}
 
-            	PushFollow(FOLLOW_tikzscope_end_in_tikzscope1720);
-            	tikzscope_end150 = tikzscope_end();
+            	PushFollow(FOLLOW_tikzscope_end_in_tikzscope1745);
+            	tikzscope_end155 = tikzscope_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikzscope_end.Add(tikzscope_end150.Tree);
+            	if ( state.backtracking==0 ) stream_tikzscope_end.Add(tikzscope_end155.Tree);
 
 
             	// AST REWRITE
-            	// elements:          tikz_options, tikzbody, tikzscope_start, tikzscope_end
+            	// elements:          tikzscope_start, tikzscope_end, tikzbody, tikz_options
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -5021,11 +5095,11 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.path_start_return path_start151 = default(simpletikzParser.path_start_return);
+        simpletikzParser.path_start_return path_start156 = default(simpletikzParser.path_start_return);
 
-        simpletikzParser.tikzpath_element_return tikzpath_element152 = default(simpletikzParser.tikzpath_element_return);
+        simpletikzParser.tikzpath_element_return tikzpath_element157 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.semicolon_end_return semicolon_end153 = default(simpletikzParser.semicolon_end_return);
+        simpletikzParser.semicolon_end_return semicolon_end158 = default(simpletikzParser.semicolon_end_return);
 
 
         RewriteRuleSubtreeStream stream_tikzpath_element = new RewriteRuleSubtreeStream(adaptor,"rule tikzpath_element");
@@ -5036,50 +5110,50 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:311:2: ( path_start ( tikzpath_element )* semicolon_end -> ^( IM_PATH path_start ( tikzpath_element )* semicolon_end ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:311:4: path_start ( tikzpath_element )* semicolon_end
             {
-            	PushFollow(FOLLOW_path_start_in_tikzpath1776);
-            	path_start151 = path_start();
+            	PushFollow(FOLLOW_path_start_in_tikzpath1801);
+            	path_start156 = path_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_path_start.Add(path_start151.Tree);
+            	if ( state.backtracking==0 ) stream_path_start.Add(path_start156.Tree);
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:311:15: ( tikzpath_element )*
             	do 
             	{
-            	    int alt39 = 2;
-            	    int LA39_0 = input.LA(1);
+            	    int alt41 = 2;
+            	    int LA41_0 = input.LA(1);
 
-            	    if ( ((LA39_0 >= ID && LA39_0 <= COMMAND) || LA39_0 == 43 || LA39_0 == 45 || LA39_0 == 53 || LA39_0 == 55 || LA39_0 == 59 || LA39_0 == 78 || (LA39_0 >= 80 && LA39_0 <= 81) || (LA39_0 >= 83 && LA39_0 <= 92)) )
+            	    if ( ((LA41_0 >= ID && LA41_0 <= COMMAND) || LA41_0 == 43 || LA41_0 == 45 || LA41_0 == 55 || LA41_0 == 57 || LA41_0 == 61 || LA41_0 == 80 || (LA41_0 >= 82 && LA41_0 <= 83) || (LA41_0 >= 85 && LA41_0 <= 94)) )
             	    {
-            	        alt39 = 1;
+            	        alt41 = 1;
             	    }
 
 
-            	    switch (alt39) 
+            	    switch (alt41) 
             		{
             			case 1 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:311:15: tikzpath_element
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzpath1778);
-            			    	tikzpath_element152 = tikzpath_element();
+            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzpath1803);
+            			    	tikzpath_element157 = tikzpath_element();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element152.Tree);
+            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element157.Tree);
 
             			    }
             			    break;
 
             			default:
-            			    goto loop39;
+            			    goto loop41;
             	    }
             	} while (true);
 
-            	loop39:
-            		;	// Stops C# compiler whining that label 'loop39' has no statements
+            	loop41:
+            		;	// Stops C# compiler whining that label 'loop41' has no statements
 
-            	PushFollow(FOLLOW_semicolon_end_in_tikzpath1781);
-            	semicolon_end153 = semicolon_end();
+            	PushFollow(FOLLOW_semicolon_end_in_tikzpath1806);
+            	semicolon_end158 = semicolon_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end153.Tree);
+            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end158.Tree);
 
 
             	// AST REWRITE
@@ -5154,9 +5228,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set154 = null;
+        IToken set159 = null;
 
-        object set154_tree=null;
+        object set159_tree=null;
 
         try 
     	{
@@ -5165,11 +5239,11 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set154 = (IToken)input.LT(1);
-            	if ( input.LA(1) == COMMAND || input.LA(1) == 45 || input.LA(1) == 59 || input.LA(1) == 78 ) 
+            	set159 = (IToken)input.LT(1);
+            	if ( input.LA(1) == COMMAND || input.LA(1) == 45 || input.LA(1) == 61 || input.LA(1) == 80 ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set154));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set159));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -5218,11 +5292,11 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal156 = null;
-        simpletikzParser.tikzpath_element_single_return tikzpath_element_single155 = default(simpletikzParser.tikzpath_element_single_return);
+        IToken char_literal161 = null;
+        simpletikzParser.tikzpath_element_single_return tikzpath_element_single160 = default(simpletikzParser.tikzpath_element_single_return);
 
 
-        object char_literal156_tree=null;
+        object char_literal161_tree=null;
 
         try 
     	{
@@ -5231,25 +5305,25 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	PushFollow(FOLLOW_tikzpath_element_single_in_tikzpath_element1837);
-            	tikzpath_element_single155 = tikzpath_element_single();
+            	PushFollow(FOLLOW_tikzpath_element_single_in_tikzpath_element1862);
+            	tikzpath_element_single160 = tikzpath_element_single();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath_element_single155.Tree);
+            	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath_element_single160.Tree);
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:322:31: ( ',' )?
-            	int alt40 = 2;
-            	int LA40_0 = input.LA(1);
+            	int alt42 = 2;
+            	int LA42_0 = input.LA(1);
 
-            	if ( (LA40_0 == 47) )
+            	if ( (LA42_0 == 47) )
             	{
-            	    alt40 = 1;
+            	    alt42 = 1;
             	}
-            	switch (alt40) 
+            	switch (alt42) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:322:31: ','
             	        {
-            	        	char_literal156=(IToken)Match(input,47,FOLLOW_47_in_tikzpath_element1839); if (state.failed) return retval;
+            	        	char_literal161=(IToken)Match(input,47,FOLLOW_47_in_tikzpath_element1864); if (state.failed) return retval;
 
             	        }
             	        break;
@@ -5295,39 +5369,39 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal168 = null;
-        IToken char_literal170 = null;
-        simpletikzParser.tikz_options_return tikz_options157 = default(simpletikzParser.tikz_options_return);
+        IToken char_literal173 = null;
+        IToken char_literal175 = null;
+        simpletikzParser.tikz_options_return tikz_options162 = default(simpletikzParser.tikz_options_return);
 
-        simpletikzParser.let_cmd_parts_return let_cmd_parts158 = default(simpletikzParser.let_cmd_parts_return);
+        simpletikzParser.let_cmd_parts_return let_cmd_parts163 = default(simpletikzParser.let_cmd_parts_return);
 
-        simpletikzParser.arc_return arc159 = default(simpletikzParser.arc_return);
+        simpletikzParser.arc_return arc164 = default(simpletikzParser.arc_return);
 
-        simpletikzParser.coord_return coord160 = default(simpletikzParser.coord_return);
+        simpletikzParser.coord_return coord165 = default(simpletikzParser.coord_return);
 
-        simpletikzParser.controls_return controls161 = default(simpletikzParser.controls_return);
+        simpletikzParser.controls_return controls166 = default(simpletikzParser.controls_return);
 
-        simpletikzParser.tikznode_int_return tikznode_int162 = default(simpletikzParser.tikznode_int_return);
+        simpletikzParser.tikznode_int_return tikznode_int167 = default(simpletikzParser.tikznode_int_return);
 
-        simpletikzParser.tikzcoordinate_int_return tikzcoordinate_int163 = default(simpletikzParser.tikzcoordinate_int_return);
+        simpletikzParser.tikzcoordinate_int_return tikzcoordinate_int168 = default(simpletikzParser.tikzcoordinate_int_return);
 
-        simpletikzParser.circle_return circle164 = default(simpletikzParser.circle_return);
+        simpletikzParser.circle_return circle169 = default(simpletikzParser.circle_return);
 
-        simpletikzParser.roundbr_start_return roundbr_start165 = default(simpletikzParser.roundbr_start_return);
+        simpletikzParser.roundbr_start_return roundbr_start170 = default(simpletikzParser.roundbr_start_return);
 
-        simpletikzParser.tikzpath_element_return tikzpath_element166 = default(simpletikzParser.tikzpath_element_return);
+        simpletikzParser.tikzpath_element_return tikzpath_element171 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.roundbr_end_return roundbr_end167 = default(simpletikzParser.roundbr_end_return);
+        simpletikzParser.roundbr_end_return roundbr_end172 = default(simpletikzParser.roundbr_end_return);
 
-        simpletikzParser.tikzpath_element_return tikzpath_element169 = default(simpletikzParser.tikzpath_element_return);
+        simpletikzParser.tikzpath_element_return tikzpath_element174 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.edgeop_return edgeop171 = default(simpletikzParser.edgeop_return);
+        simpletikzParser.edgeop_return edgeop176 = default(simpletikzParser.edgeop_return);
 
 
-        object char_literal168_tree=null;
-        object char_literal170_tree=null;
-        RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
-        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
+        object char_literal173_tree=null;
+        object char_literal175_tree=null;
+        RewriteRuleTokenStream stream_55 = new RewriteRuleTokenStream(adaptor,"token 55");
+        RewriteRuleTokenStream stream_56 = new RewriteRuleTokenStream(adaptor,"token 56");
         RewriteRuleSubtreeStream stream_tikzpath_element = new RewriteRuleSubtreeStream(adaptor,"rule tikzpath_element");
         RewriteRuleSubtreeStream stream_let_cmd_parts = new RewriteRuleSubtreeStream(adaptor,"rule let_cmd_parts");
         RewriteRuleSubtreeStream stream_roundbr_start = new RewriteRuleSubtreeStream(adaptor,"rule roundbr_start");
@@ -5335,31 +5409,31 @@ public partial class simpletikzParser : Parser
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:326:2: ( tikz_options | let_cmd_parts -> ^( IM_DONTCARE ( let_cmd_parts )+ ) | arc | ( coord )=> coord | controls | tikznode_int | tikzcoordinate_int | circle | roundbr_start ( tikzpath_element )* roundbr_end -> ^( IM_PATH roundbr_start ( tikzpath_element )* roundbr_end ) | '(' ( tikzpath_element )* ')' -> ^( IM_PATH '(' ( tikzpath_element )* ')' ) | edgeop )
-            int alt43 = 11;
-            alt43 = dfa43.Predict(input);
-            switch (alt43) 
+            int alt45 = 11;
+            alt45 = dfa45.Predict(input);
+            switch (alt45) 
             {
                 case 1 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:327:5: tikz_options
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_tikz_options_in_tikzpath_element_single1857);
-                    	tikz_options157 = tikz_options();
+                    	PushFollow(FOLLOW_tikz_options_in_tikzpath_element_single1882);
+                    	tikz_options162 = tikz_options();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_options157.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_options162.Tree);
 
                     }
                     break;
                 case 2 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:328:5: let_cmd_parts
                     {
-                    	PushFollow(FOLLOW_let_cmd_parts_in_tikzpath_element_single1864);
-                    	let_cmd_parts158 = let_cmd_parts();
+                    	PushFollow(FOLLOW_let_cmd_parts_in_tikzpath_element_single1889);
+                    	let_cmd_parts163 = let_cmd_parts();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_let_cmd_parts.Add(let_cmd_parts158.Tree);
+                    	if ( state.backtracking==0 ) stream_let_cmd_parts.Add(let_cmd_parts163.Tree);
 
 
                     	// AST REWRITE
@@ -5403,11 +5477,11 @@ public partial class simpletikzParser : Parser
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_arc_in_tikzpath_element_single1882);
-                    	arc159 = arc();
+                    	PushFollow(FOLLOW_arc_in_tikzpath_element_single1907);
+                    	arc164 = arc();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, arc159.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, arc164.Tree);
 
                     }
                     break;
@@ -5416,11 +5490,11 @@ public partial class simpletikzParser : Parser
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_coord_in_tikzpath_element_single1892);
-                    	coord160 = coord();
+                    	PushFollow(FOLLOW_coord_in_tikzpath_element_single1917);
+                    	coord165 = coord();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, coord160.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, coord165.Tree);
 
                     }
                     break;
@@ -5429,11 +5503,11 @@ public partial class simpletikzParser : Parser
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_controls_in_tikzpath_element_single1898);
-                    	controls161 = controls();
+                    	PushFollow(FOLLOW_controls_in_tikzpath_element_single1923);
+                    	controls166 = controls();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, controls161.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, controls166.Tree);
 
                     }
                     break;
@@ -5442,11 +5516,11 @@ public partial class simpletikzParser : Parser
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_tikznode_int_in_tikzpath_element_single1904);
-                    	tikznode_int162 = tikznode_int();
+                    	PushFollow(FOLLOW_tikznode_int_in_tikzpath_element_single1929);
+                    	tikznode_int167 = tikznode_int();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_int162.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_int167.Tree);
 
                     }
                     break;
@@ -5455,11 +5529,11 @@ public partial class simpletikzParser : Parser
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_tikzcoordinate_int_in_tikzpath_element_single1910);
-                    	tikzcoordinate_int163 = tikzcoordinate_int();
+                    	PushFollow(FOLLOW_tikzcoordinate_int_in_tikzpath_element_single1935);
+                    	tikzcoordinate_int168 = tikzcoordinate_int();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_int163.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_int168.Tree);
 
                     }
                     break;
@@ -5468,8 +5542,8 @@ public partial class simpletikzParser : Parser
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_circle_in_tikzpath_element_single1916);
-                    	circle164 = circle();
+                    	PushFollow(FOLLOW_circle_in_tikzpath_element_single1941);
+                    	circle169 = circle();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
 
@@ -5478,54 +5552,54 @@ public partial class simpletikzParser : Parser
                 case 9 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:336:5: roundbr_start ( tikzpath_element )* roundbr_end
                     {
-                    	PushFollow(FOLLOW_roundbr_start_in_tikzpath_element_single1923);
-                    	roundbr_start165 = roundbr_start();
+                    	PushFollow(FOLLOW_roundbr_start_in_tikzpath_element_single1948);
+                    	roundbr_start170 = roundbr_start();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_roundbr_start.Add(roundbr_start165.Tree);
+                    	if ( state.backtracking==0 ) stream_roundbr_start.Add(roundbr_start170.Tree);
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:336:19: ( tikzpath_element )*
                     	do 
                     	{
-                    	    int alt41 = 2;
-                    	    int LA41_0 = input.LA(1);
+                    	    int alt43 = 2;
+                    	    int LA43_0 = input.LA(1);
 
-                    	    if ( ((LA41_0 >= ID && LA41_0 <= COMMAND) || LA41_0 == 43 || LA41_0 == 45 || LA41_0 == 53 || LA41_0 == 55 || LA41_0 == 59 || LA41_0 == 78 || (LA41_0 >= 80 && LA41_0 <= 81) || (LA41_0 >= 83 && LA41_0 <= 92)) )
+                    	    if ( ((LA43_0 >= ID && LA43_0 <= COMMAND) || LA43_0 == 43 || LA43_0 == 45 || LA43_0 == 55 || LA43_0 == 57 || LA43_0 == 61 || LA43_0 == 80 || (LA43_0 >= 82 && LA43_0 <= 83) || (LA43_0 >= 85 && LA43_0 <= 94)) )
                     	    {
-                    	        alt41 = 1;
+                    	        alt43 = 1;
                     	    }
 
 
-                    	    switch (alt41) 
+                    	    switch (alt43) 
                     		{
                     			case 1 :
                     			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:336:19: tikzpath_element
                     			    {
-                    			    	PushFollow(FOLLOW_tikzpath_element_in_tikzpath_element_single1925);
-                    			    	tikzpath_element166 = tikzpath_element();
+                    			    	PushFollow(FOLLOW_tikzpath_element_in_tikzpath_element_single1950);
+                    			    	tikzpath_element171 = tikzpath_element();
                     			    	state.followingStackPointer--;
                     			    	if (state.failed) return retval;
-                    			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element166.Tree);
+                    			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element171.Tree);
 
                     			    }
                     			    break;
 
                     			default:
-                    			    goto loop41;
+                    			    goto loop43;
                     	    }
                     	} while (true);
 
-                    	loop41:
-                    		;	// Stops C# compiler whining that label 'loop41' has no statements
+                    	loop43:
+                    		;	// Stops C# compiler whining that label 'loop43' has no statements
 
-                    	PushFollow(FOLLOW_roundbr_end_in_tikzpath_element_single1928);
-                    	roundbr_end167 = roundbr_end();
+                    	PushFollow(FOLLOW_roundbr_end_in_tikzpath_element_single1953);
+                    	roundbr_end172 = roundbr_end();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_roundbr_end.Add(roundbr_end167.Tree);
+                    	if ( state.backtracking==0 ) stream_roundbr_end.Add(roundbr_end172.Tree);
 
 
                     	// AST REWRITE
-                    	// elements:          roundbr_end, roundbr_start, tikzpath_element
+                    	// elements:          tikzpath_element, roundbr_start, roundbr_end
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -5563,50 +5637,50 @@ public partial class simpletikzParser : Parser
                 case 10 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:337:6: '(' ( tikzpath_element )* ')'
                     {
-                    	char_literal168=(IToken)Match(input,53,FOLLOW_53_in_tikzpath_element_single1948); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_53.Add(char_literal168);
+                    	char_literal173=(IToken)Match(input,55,FOLLOW_55_in_tikzpath_element_single1973); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_55.Add(char_literal173);
 
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:337:10: ( tikzpath_element )*
                     	do 
                     	{
-                    	    int alt42 = 2;
-                    	    int LA42_0 = input.LA(1);
+                    	    int alt44 = 2;
+                    	    int LA44_0 = input.LA(1);
 
-                    	    if ( ((LA42_0 >= ID && LA42_0 <= COMMAND) || LA42_0 == 43 || LA42_0 == 45 || LA42_0 == 53 || LA42_0 == 55 || LA42_0 == 59 || LA42_0 == 78 || (LA42_0 >= 80 && LA42_0 <= 81) || (LA42_0 >= 83 && LA42_0 <= 92)) )
+                    	    if ( ((LA44_0 >= ID && LA44_0 <= COMMAND) || LA44_0 == 43 || LA44_0 == 45 || LA44_0 == 55 || LA44_0 == 57 || LA44_0 == 61 || LA44_0 == 80 || (LA44_0 >= 82 && LA44_0 <= 83) || (LA44_0 >= 85 && LA44_0 <= 94)) )
                     	    {
-                    	        alt42 = 1;
+                    	        alt44 = 1;
                     	    }
 
 
-                    	    switch (alt42) 
+                    	    switch (alt44) 
                     		{
                     			case 1 :
                     			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:337:10: tikzpath_element
                     			    {
-                    			    	PushFollow(FOLLOW_tikzpath_element_in_tikzpath_element_single1950);
-                    			    	tikzpath_element169 = tikzpath_element();
+                    			    	PushFollow(FOLLOW_tikzpath_element_in_tikzpath_element_single1975);
+                    			    	tikzpath_element174 = tikzpath_element();
                     			    	state.followingStackPointer--;
                     			    	if (state.failed) return retval;
-                    			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element169.Tree);
+                    			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element174.Tree);
 
                     			    }
                     			    break;
 
                     			default:
-                    			    goto loop42;
+                    			    goto loop44;
                     	    }
                     	} while (true);
 
-                    	loop42:
-                    		;	// Stops C# compiler whining that label 'loop42' has no statements
+                    	loop44:
+                    		;	// Stops C# compiler whining that label 'loop44' has no statements
 
-                    	char_literal170=(IToken)Match(input,54,FOLLOW_54_in_tikzpath_element_single1953); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_54.Add(char_literal170);
+                    	char_literal175=(IToken)Match(input,56,FOLLOW_56_in_tikzpath_element_single1978); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_56.Add(char_literal175);
 
 
 
                     	// AST REWRITE
-                    	// elements:          54, tikzpath_element, 53
+                    	// elements:          55, tikzpath_element, 56
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -5623,7 +5697,7 @@ public partial class simpletikzParser : Parser
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_PATH, "IM_PATH"), root_1);
 
-                    	    adaptor.AddChild(root_1, stream_53.NextNode());
+                    	    adaptor.AddChild(root_1, stream_55.NextNode());
                     	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:337:49: ( tikzpath_element )*
                     	    while ( stream_tikzpath_element.HasNext() )
                     	    {
@@ -5631,7 +5705,7 @@ public partial class simpletikzParser : Parser
 
                     	    }
                     	    stream_tikzpath_element.Reset();
-                    	    adaptor.AddChild(root_1, stream_54.NextNode());
+                    	    adaptor.AddChild(root_1, stream_56.NextNode());
 
                     	    adaptor.AddChild(root_0, root_1);
                     	    }
@@ -5646,8 +5720,8 @@ public partial class simpletikzParser : Parser
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_edgeop_in_tikzpath_element_single1972);
-                    	edgeop171 = edgeop();
+                    	PushFollow(FOLLOW_edgeop_in_tikzpath_element_single1997);
+                    	edgeop176 = edgeop();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
 
@@ -5691,18 +5765,18 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal174 = null;
-        simpletikzParser.controls_start_return controls_start172 = default(simpletikzParser.controls_start_return);
+        IToken string_literal179 = null;
+        simpletikzParser.controls_start_return controls_start177 = default(simpletikzParser.controls_start_return);
 
-        simpletikzParser.coord_return coord173 = default(simpletikzParser.coord_return);
+        simpletikzParser.coord_return coord178 = default(simpletikzParser.coord_return);
 
-        simpletikzParser.coord_return coord175 = default(simpletikzParser.coord_return);
+        simpletikzParser.coord_return coord180 = default(simpletikzParser.coord_return);
 
-        simpletikzParser.controls_end_return controls_end176 = default(simpletikzParser.controls_end_return);
+        simpletikzParser.controls_end_return controls_end181 = default(simpletikzParser.controls_end_return);
 
 
-        object string_literal174_tree=null;
-        RewriteRuleTokenStream stream_79 = new RewriteRuleTokenStream(adaptor,"token 79");
+        object string_literal179_tree=null;
+        RewriteRuleTokenStream stream_81 = new RewriteRuleTokenStream(adaptor,"token 81");
         RewriteRuleSubtreeStream stream_controls_end = new RewriteRuleSubtreeStream(adaptor,"rule controls_end");
         RewriteRuleSubtreeStream stream_coord = new RewriteRuleSubtreeStream(adaptor,"rule coord");
         RewriteRuleSubtreeStream stream_controls_start = new RewriteRuleSubtreeStream(adaptor,"rule controls_start");
@@ -5711,52 +5785,52 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:342:2: ( controls_start coord ( 'and' coord )? controls_end -> ^( IM_CONTROLS controls_start ( coord )+ controls_end ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:342:4: controls_start coord ( 'and' coord )? controls_end
             {
-            	PushFollow(FOLLOW_controls_start_in_controls1987);
-            	controls_start172 = controls_start();
+            	PushFollow(FOLLOW_controls_start_in_controls2012);
+            	controls_start177 = controls_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_controls_start.Add(controls_start172.Tree);
-            	PushFollow(FOLLOW_coord_in_controls1989);
-            	coord173 = coord();
+            	if ( state.backtracking==0 ) stream_controls_start.Add(controls_start177.Tree);
+            	PushFollow(FOLLOW_coord_in_controls2014);
+            	coord178 = coord();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_coord.Add(coord173.Tree);
+            	if ( state.backtracking==0 ) stream_coord.Add(coord178.Tree);
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:342:25: ( 'and' coord )?
-            	int alt44 = 2;
-            	int LA44_0 = input.LA(1);
+            	int alt46 = 2;
+            	int LA46_0 = input.LA(1);
 
-            	if ( (LA44_0 == 79) )
+            	if ( (LA46_0 == 81) )
             	{
-            	    alt44 = 1;
+            	    alt46 = 1;
             	}
-            	switch (alt44) 
+            	switch (alt46) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:342:26: 'and' coord
             	        {
-            	        	string_literal174=(IToken)Match(input,79,FOLLOW_79_in_controls1992); if (state.failed) return retval; 
-            	        	if ( state.backtracking==0 ) stream_79.Add(string_literal174);
+            	        	string_literal179=(IToken)Match(input,81,FOLLOW_81_in_controls2017); if (state.failed) return retval; 
+            	        	if ( state.backtracking==0 ) stream_81.Add(string_literal179);
 
-            	        	PushFollow(FOLLOW_coord_in_controls1994);
-            	        	coord175 = coord();
+            	        	PushFollow(FOLLOW_coord_in_controls2019);
+            	        	coord180 = coord();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_coord.Add(coord175.Tree);
+            	        	if ( state.backtracking==0 ) stream_coord.Add(coord180.Tree);
 
             	        }
             	        break;
 
             	}
 
-            	PushFollow(FOLLOW_controls_end_in_controls1998);
-            	controls_end176 = controls_end();
+            	PushFollow(FOLLOW_controls_end_in_controls2023);
+            	controls_end181 = controls_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_controls_end.Add(controls_end176.Tree);
+            	if ( state.backtracking==0 ) stream_controls_end.Add(controls_end181.Tree);
 
 
             	// AST REWRITE
-            	// elements:          controls_start, coord, controls_end
+            	// elements:          coord, controls_end, controls_start
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -5829,13 +5903,13 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.node_start_return node_start177 = default(simpletikzParser.node_start_return);
+        simpletikzParser.node_start_return node_start182 = default(simpletikzParser.node_start_return);
 
-        simpletikzParser.tikznode_core_return tikznode_core178 = default(simpletikzParser.tikznode_core_return);
+        simpletikzParser.tikznode_core_return tikznode_core183 = default(simpletikzParser.tikznode_core_return);
 
-        simpletikzParser.tikzpath_element_return tikzpath_element179 = default(simpletikzParser.tikzpath_element_return);
+        simpletikzParser.tikzpath_element_return tikzpath_element184 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.semicolon_end_return semicolon_end180 = default(simpletikzParser.semicolon_end_return);
+        simpletikzParser.semicolon_end_return semicolon_end185 = default(simpletikzParser.semicolon_end_return);
 
 
         RewriteRuleSubtreeStream stream_tikzpath_element = new RewriteRuleSubtreeStream(adaptor,"rule tikzpath_element");
@@ -5847,59 +5921,59 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:346:2: ( node_start tikznode_core ( tikzpath_element )* semicolon_end -> ^( IM_PATH node_start tikznode_core ( tikzpath_element )* semicolon_end ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:346:4: node_start tikznode_core ( tikzpath_element )* semicolon_end
             {
-            	PushFollow(FOLLOW_node_start_in_tikznode_ext2024);
-            	node_start177 = node_start();
+            	PushFollow(FOLLOW_node_start_in_tikznode_ext2049);
+            	node_start182 = node_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_node_start.Add(node_start177.Tree);
-            	PushFollow(FOLLOW_tikznode_core_in_tikznode_ext2026);
-            	tikznode_core178 = tikznode_core();
+            	if ( state.backtracking==0 ) stream_node_start.Add(node_start182.Tree);
+            	PushFollow(FOLLOW_tikznode_core_in_tikznode_ext2051);
+            	tikznode_core183 = tikznode_core();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_core.Add(tikznode_core178.Tree);
+            	if ( state.backtracking==0 ) stream_tikznode_core.Add(tikznode_core183.Tree);
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:346:29: ( tikzpath_element )*
             	do 
             	{
-            	    int alt45 = 2;
-            	    int LA45_0 = input.LA(1);
+            	    int alt47 = 2;
+            	    int LA47_0 = input.LA(1);
 
-            	    if ( ((LA45_0 >= ID && LA45_0 <= COMMAND) || LA45_0 == 43 || LA45_0 == 45 || LA45_0 == 53 || LA45_0 == 55 || LA45_0 == 59 || LA45_0 == 78 || (LA45_0 >= 80 && LA45_0 <= 81) || (LA45_0 >= 83 && LA45_0 <= 92)) )
+            	    if ( ((LA47_0 >= ID && LA47_0 <= COMMAND) || LA47_0 == 43 || LA47_0 == 45 || LA47_0 == 55 || LA47_0 == 57 || LA47_0 == 61 || LA47_0 == 80 || (LA47_0 >= 82 && LA47_0 <= 83) || (LA47_0 >= 85 && LA47_0 <= 94)) )
             	    {
-            	        alt45 = 1;
+            	        alt47 = 1;
             	    }
 
 
-            	    switch (alt45) 
+            	    switch (alt47) 
             		{
             			case 1 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:346:29: tikzpath_element
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_element_in_tikznode_ext2028);
-            			    	tikzpath_element179 = tikzpath_element();
+            			    	PushFollow(FOLLOW_tikzpath_element_in_tikznode_ext2053);
+            			    	tikzpath_element184 = tikzpath_element();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element179.Tree);
+            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element184.Tree);
 
             			    }
             			    break;
 
             			default:
-            			    goto loop45;
+            			    goto loop47;
             	    }
             	} while (true);
 
-            	loop45:
-            		;	// Stops C# compiler whining that label 'loop45' has no statements
+            	loop47:
+            		;	// Stops C# compiler whining that label 'loop47' has no statements
 
-            	PushFollow(FOLLOW_semicolon_end_in_tikznode_ext2031);
-            	semicolon_end180 = semicolon_end();
+            	PushFollow(FOLLOW_semicolon_end_in_tikznode_ext2056);
+            	semicolon_end185 = semicolon_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end180.Tree);
+            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end185.Tree);
 
 
             	// AST REWRITE
-            	// elements:          node_start, tikzpath_element, semicolon_end, tikznode_core
+            	// elements:          tikzpath_element, tikznode_core, node_start, semicolon_end
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -5971,11 +6045,11 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.def_start_return def_start181 = default(simpletikzParser.def_start_return);
+        simpletikzParser.def_start_return def_start186 = default(simpletikzParser.def_start_return);
 
-        simpletikzParser.tikzpath_element_return tikzpath_element182 = default(simpletikzParser.tikzpath_element_return);
+        simpletikzParser.tikzpath_element_return tikzpath_element187 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.semicolon_end_return semicolon_end183 = default(simpletikzParser.semicolon_end_return);
+        simpletikzParser.semicolon_end_return semicolon_end188 = default(simpletikzParser.semicolon_end_return);
 
 
         RewriteRuleSubtreeStream stream_tikzpath_element = new RewriteRuleSubtreeStream(adaptor,"rule tikzpath_element");
@@ -5986,54 +6060,54 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:349:2: ( def_start ( tikzpath_element )* semicolon_end -> ^( IM_PATH def_start ( tikzpath_element )* semicolon_end ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:349:4: def_start ( tikzpath_element )* semicolon_end
             {
-            	PushFollow(FOLLOW_def_start_in_tikzdef_ext2056);
-            	def_start181 = def_start();
+            	PushFollow(FOLLOW_def_start_in_tikzdef_ext2081);
+            	def_start186 = def_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_def_start.Add(def_start181.Tree);
+            	if ( state.backtracking==0 ) stream_def_start.Add(def_start186.Tree);
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:349:14: ( tikzpath_element )*
             	do 
             	{
-            	    int alt46 = 2;
-            	    int LA46_0 = input.LA(1);
+            	    int alt48 = 2;
+            	    int LA48_0 = input.LA(1);
 
-            	    if ( ((LA46_0 >= ID && LA46_0 <= COMMAND) || LA46_0 == 43 || LA46_0 == 45 || LA46_0 == 53 || LA46_0 == 55 || LA46_0 == 59 || LA46_0 == 78 || (LA46_0 >= 80 && LA46_0 <= 81) || (LA46_0 >= 83 && LA46_0 <= 92)) )
+            	    if ( ((LA48_0 >= ID && LA48_0 <= COMMAND) || LA48_0 == 43 || LA48_0 == 45 || LA48_0 == 55 || LA48_0 == 57 || LA48_0 == 61 || LA48_0 == 80 || (LA48_0 >= 82 && LA48_0 <= 83) || (LA48_0 >= 85 && LA48_0 <= 94)) )
             	    {
-            	        alt46 = 1;
+            	        alt48 = 1;
             	    }
 
 
-            	    switch (alt46) 
+            	    switch (alt48) 
             		{
             			case 1 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:349:14: tikzpath_element
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzdef_ext2058);
-            			    	tikzpath_element182 = tikzpath_element();
+            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzdef_ext2083);
+            			    	tikzpath_element187 = tikzpath_element();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element182.Tree);
+            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element187.Tree);
 
             			    }
             			    break;
 
             			default:
-            			    goto loop46;
+            			    goto loop48;
             	    }
             	} while (true);
 
-            	loop46:
-            		;	// Stops C# compiler whining that label 'loop46' has no statements
+            	loop48:
+            		;	// Stops C# compiler whining that label 'loop48' has no statements
 
-            	PushFollow(FOLLOW_semicolon_end_in_tikzdef_ext2061);
-            	semicolon_end183 = semicolon_end();
+            	PushFollow(FOLLOW_semicolon_end_in_tikzdef_ext2086);
+            	semicolon_end188 = semicolon_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end183.Tree);
+            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end188.Tree);
 
 
             	// AST REWRITE
-            	// elements:          def_start, semicolon_end, tikzpath_element
+            	// elements:          semicolon_end, def_start, tikzpath_element
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -6104,13 +6178,13 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.matrix_start_return matrix_start184 = default(simpletikzParser.matrix_start_return);
+        simpletikzParser.matrix_start_return matrix_start189 = default(simpletikzParser.matrix_start_return);
 
-        simpletikzParser.tikznode_core_return tikznode_core185 = default(simpletikzParser.tikznode_core_return);
+        simpletikzParser.tikznode_core_return tikznode_core190 = default(simpletikzParser.tikznode_core_return);
 
-        simpletikzParser.tikzpath_element_return tikzpath_element186 = default(simpletikzParser.tikzpath_element_return);
+        simpletikzParser.tikzpath_element_return tikzpath_element191 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.semicolon_end_return semicolon_end187 = default(simpletikzParser.semicolon_end_return);
+        simpletikzParser.semicolon_end_return semicolon_end192 = default(simpletikzParser.semicolon_end_return);
 
 
         RewriteRuleSubtreeStream stream_tikzpath_element = new RewriteRuleSubtreeStream(adaptor,"rule tikzpath_element");
@@ -6122,59 +6196,59 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:353:2: ( matrix_start tikznode_core ( tikzpath_element )* semicolon_end -> ^( IM_PATH matrix_start tikznode_core ( tikzpath_element )* semicolon_end ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:353:4: matrix_start tikznode_core ( tikzpath_element )* semicolon_end
             {
-            	PushFollow(FOLLOW_matrix_start_in_tikzmatrix_ext2086);
-            	matrix_start184 = matrix_start();
+            	PushFollow(FOLLOW_matrix_start_in_tikzmatrix_ext2111);
+            	matrix_start189 = matrix_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_matrix_start.Add(matrix_start184.Tree);
-            	PushFollow(FOLLOW_tikznode_core_in_tikzmatrix_ext2088);
-            	tikznode_core185 = tikznode_core();
+            	if ( state.backtracking==0 ) stream_matrix_start.Add(matrix_start189.Tree);
+            	PushFollow(FOLLOW_tikznode_core_in_tikzmatrix_ext2113);
+            	tikznode_core190 = tikznode_core();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_core.Add(tikznode_core185.Tree);
+            	if ( state.backtracking==0 ) stream_tikznode_core.Add(tikznode_core190.Tree);
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:353:31: ( tikzpath_element )*
             	do 
             	{
-            	    int alt47 = 2;
-            	    int LA47_0 = input.LA(1);
+            	    int alt49 = 2;
+            	    int LA49_0 = input.LA(1);
 
-            	    if ( ((LA47_0 >= ID && LA47_0 <= COMMAND) || LA47_0 == 43 || LA47_0 == 45 || LA47_0 == 53 || LA47_0 == 55 || LA47_0 == 59 || LA47_0 == 78 || (LA47_0 >= 80 && LA47_0 <= 81) || (LA47_0 >= 83 && LA47_0 <= 92)) )
+            	    if ( ((LA49_0 >= ID && LA49_0 <= COMMAND) || LA49_0 == 43 || LA49_0 == 45 || LA49_0 == 55 || LA49_0 == 57 || LA49_0 == 61 || LA49_0 == 80 || (LA49_0 >= 82 && LA49_0 <= 83) || (LA49_0 >= 85 && LA49_0 <= 94)) )
             	    {
-            	        alt47 = 1;
+            	        alt49 = 1;
             	    }
 
 
-            	    switch (alt47) 
+            	    switch (alt49) 
             		{
             			case 1 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:353:31: tikzpath_element
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzmatrix_ext2090);
-            			    	tikzpath_element186 = tikzpath_element();
+            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzmatrix_ext2115);
+            			    	tikzpath_element191 = tikzpath_element();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element186.Tree);
+            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element191.Tree);
 
             			    }
             			    break;
 
             			default:
-            			    goto loop47;
+            			    goto loop49;
             	    }
             	} while (true);
 
-            	loop47:
-            		;	// Stops C# compiler whining that label 'loop47' has no statements
+            	loop49:
+            		;	// Stops C# compiler whining that label 'loop49' has no statements
 
-            	PushFollow(FOLLOW_semicolon_end_in_tikzmatrix_ext2093);
-            	semicolon_end187 = semicolon_end();
+            	PushFollow(FOLLOW_semicolon_end_in_tikzmatrix_ext2118);
+            	semicolon_end192 = semicolon_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end187.Tree);
+            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end192.Tree);
 
 
             	// AST REWRITE
-            	// elements:          matrix_start, semicolon_end, tikzpath_element, tikznode_core
+            	// elements:          tikznode_core, matrix_start, tikzpath_element, semicolon_end
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -6246,17 +6320,17 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.coordinate_start_return coordinate_start188 = default(simpletikzParser.coordinate_start_return);
+        simpletikzParser.coordinate_start_return coordinate_start193 = default(simpletikzParser.coordinate_start_return);
 
-        simpletikzParser.tikzcoordinate_core3_return tikzcoordinate_core3189 = default(simpletikzParser.tikzcoordinate_core3_return);
+        simpletikzParser.tikzcoordinate_core3_return tikzcoordinate_core3194 = default(simpletikzParser.tikzcoordinate_core3_return);
 
-        simpletikzParser.tikzcoordinate_core2_return tikzcoordinate_core2190 = default(simpletikzParser.tikzcoordinate_core2_return);
+        simpletikzParser.tikzcoordinate_core2_return tikzcoordinate_core2195 = default(simpletikzParser.tikzcoordinate_core2_return);
 
-        simpletikzParser.tikzcoordinate_core1_return tikzcoordinate_core1191 = default(simpletikzParser.tikzcoordinate_core1_return);
+        simpletikzParser.tikzcoordinate_core1_return tikzcoordinate_core1196 = default(simpletikzParser.tikzcoordinate_core1_return);
 
-        simpletikzParser.tikzpath_element_return tikzpath_element192 = default(simpletikzParser.tikzpath_element_return);
+        simpletikzParser.tikzpath_element_return tikzpath_element197 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.semicolon_end_return semicolon_end193 = default(simpletikzParser.semicolon_end_return);
+        simpletikzParser.semicolon_end_return semicolon_end198 = default(simpletikzParser.semicolon_end_return);
 
 
         RewriteRuleSubtreeStream stream_tikzcoordinate_core3 = new RewriteRuleSubtreeStream(adaptor,"rule tikzcoordinate_core3");
@@ -6270,15 +6344,15 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:358:2: ( coordinate_start ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )? ( tikzpath_element )* semicolon_end -> ^( IM_PATH coordinate_start ( tikzcoordinate_core3 )? ( tikzcoordinate_core2 )? ( tikzcoordinate_core1 )? ( tikzpath_element )* semicolon_end ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:358:4: coordinate_start ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )? ( tikzpath_element )* semicolon_end
             {
-            	PushFollow(FOLLOW_coordinate_start_in_tikzcoordinate_ext2121);
-            	coordinate_start188 = coordinate_start();
+            	PushFollow(FOLLOW_coordinate_start_in_tikzcoordinate_ext2146);
+            	coordinate_start193 = coordinate_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_coordinate_start.Add(coordinate_start188.Tree);
+            	if ( state.backtracking==0 ) stream_coordinate_start.Add(coordinate_start193.Tree);
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:5: ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )?
-            	int alt48 = 4;
-            	alt48 = dfa48.Predict(input);
-            	switch (alt48) 
+            	int alt50 = 4;
+            	alt50 = dfa50.Predict(input);
+            	switch (alt50) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:7: ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 )
@@ -6286,11 +6360,11 @@ public partial class simpletikzParser : Parser
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:7: ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 )
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:8: ( tikzcoordinate_core3 )=> tikzcoordinate_core3
             	        	{
-            	        		PushFollow(FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_ext2136);
-            	        		tikzcoordinate_core3189 = tikzcoordinate_core3();
+            	        		PushFollow(FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_ext2161);
+            	        		tikzcoordinate_core3194 = tikzcoordinate_core3();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking==0 ) stream_tikzcoordinate_core3.Add(tikzcoordinate_core3189.Tree);
+            	        		if ( state.backtracking==0 ) stream_tikzcoordinate_core3.Add(tikzcoordinate_core3194.Tree);
 
             	        	}
 
@@ -6303,11 +6377,11 @@ public partial class simpletikzParser : Parser
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:360:11: ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 )
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:360:12: ( tikzcoordinate_core2 )=> tikzcoordinate_core2
             	        	{
-            	        		PushFollow(FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_ext2155);
-            	        		tikzcoordinate_core2190 = tikzcoordinate_core2();
+            	        		PushFollow(FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_ext2180);
+            	        		tikzcoordinate_core2195 = tikzcoordinate_core2();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking==0 ) stream_tikzcoordinate_core2.Add(tikzcoordinate_core2190.Tree);
+            	        		if ( state.backtracking==0 ) stream_tikzcoordinate_core2.Add(tikzcoordinate_core2195.Tree);
 
             	        	}
 
@@ -6320,11 +6394,11 @@ public partial class simpletikzParser : Parser
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:361:11: ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 )
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:361:12: ( tikzcoordinate_core1 )=> tikzcoordinate_core1
             	        	{
-            	        		PushFollow(FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_ext2175);
-            	        		tikzcoordinate_core1191 = tikzcoordinate_core1();
+            	        		PushFollow(FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_ext2200);
+            	        		tikzcoordinate_core1196 = tikzcoordinate_core1();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking==0 ) stream_tikzcoordinate_core1.Add(tikzcoordinate_core1191.Tree);
+            	        		if ( state.backtracking==0 ) stream_tikzcoordinate_core1.Add(tikzcoordinate_core1196.Tree);
 
             	        	}
 
@@ -6337,46 +6411,46 @@ public partial class simpletikzParser : Parser
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:362:6: ( tikzpath_element )*
             	do 
             	{
-            	    int alt49 = 2;
-            	    int LA49_0 = input.LA(1);
+            	    int alt51 = 2;
+            	    int LA51_0 = input.LA(1);
 
-            	    if ( ((LA49_0 >= ID && LA49_0 <= COMMAND) || LA49_0 == 43 || LA49_0 == 45 || LA49_0 == 53 || LA49_0 == 55 || LA49_0 == 59 || LA49_0 == 78 || (LA49_0 >= 80 && LA49_0 <= 81) || (LA49_0 >= 83 && LA49_0 <= 92)) )
+            	    if ( ((LA51_0 >= ID && LA51_0 <= COMMAND) || LA51_0 == 43 || LA51_0 == 45 || LA51_0 == 55 || LA51_0 == 57 || LA51_0 == 61 || LA51_0 == 80 || (LA51_0 >= 82 && LA51_0 <= 83) || (LA51_0 >= 85 && LA51_0 <= 94)) )
             	    {
-            	        alt49 = 1;
+            	        alt51 = 1;
             	    }
 
 
-            	    switch (alt49) 
+            	    switch (alt51) 
             		{
             			case 1 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:362:6: tikzpath_element
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzcoordinate_ext2186);
-            			    	tikzpath_element192 = tikzpath_element();
+            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzcoordinate_ext2211);
+            			    	tikzpath_element197 = tikzpath_element();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element192.Tree);
+            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element197.Tree);
 
             			    }
             			    break;
 
             			default:
-            			    goto loop49;
+            			    goto loop51;
             	    }
             	} while (true);
 
-            	loop49:
-            		;	// Stops C# compiler whining that label 'loop49' has no statements
+            	loop51:
+            		;	// Stops C# compiler whining that label 'loop51' has no statements
 
-            	PushFollow(FOLLOW_semicolon_end_in_tikzcoordinate_ext2189);
-            	semicolon_end193 = semicolon_end();
+            	PushFollow(FOLLOW_semicolon_end_in_tikzcoordinate_ext2214);
+            	semicolon_end198 = semicolon_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end193.Tree);
+            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end198.Tree);
 
 
             	// AST REWRITE
-            	// elements:          semicolon_end, coordinate_start, tikzcoordinate_core2, tikzcoordinate_core3, tikzcoordinate_core1, tikzpath_element
+            	// elements:          tikzcoordinate_core2, coordinate_start, tikzcoordinate_core1, semicolon_end, tikzcoordinate_core3, tikzpath_element
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -6468,15 +6542,15 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal194 = null;
-        simpletikzParser.tikzcoordinate_core3_return tikzcoordinate_core3195 = default(simpletikzParser.tikzcoordinate_core3_return);
+        IToken string_literal199 = null;
+        simpletikzParser.tikzcoordinate_core3_return tikzcoordinate_core3200 = default(simpletikzParser.tikzcoordinate_core3_return);
 
-        simpletikzParser.tikzcoordinate_core2_return tikzcoordinate_core2196 = default(simpletikzParser.tikzcoordinate_core2_return);
+        simpletikzParser.tikzcoordinate_core2_return tikzcoordinate_core2201 = default(simpletikzParser.tikzcoordinate_core2_return);
 
-        simpletikzParser.tikzcoordinate_core1_return tikzcoordinate_core1197 = default(simpletikzParser.tikzcoordinate_core1_return);
+        simpletikzParser.tikzcoordinate_core1_return tikzcoordinate_core1202 = default(simpletikzParser.tikzcoordinate_core1_return);
 
 
-        object string_literal194_tree=null;
+        object string_literal199_tree=null;
 
         try 
     	{
@@ -6485,11 +6559,11 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	string_literal194=(IToken)Match(input,80,FOLLOW_80_in_tikzcoordinate_int2249); if (state.failed) return retval;
+            	string_literal199=(IToken)Match(input,82,FOLLOW_82_in_tikzcoordinate_int2274); if (state.failed) return retval;
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:18: ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )?
-            	int alt50 = 4;
-            	alt50 = dfa50.Predict(input);
-            	switch (alt50) 
+            	int alt52 = 4;
+            	alt52 = dfa52.Predict(input);
+            	switch (alt52) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:20: ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 )
@@ -6497,11 +6571,11 @@ public partial class simpletikzParser : Parser
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:20: ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 )
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:21: ( tikzcoordinate_core3 )=> tikzcoordinate_core3
             	        	{
-            	        		PushFollow(FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_int2260);
-            	        		tikzcoordinate_core3195 = tikzcoordinate_core3();
+            	        		PushFollow(FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_int2285);
+            	        		tikzcoordinate_core3200 = tikzcoordinate_core3();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_core3195.Tree);
+            	        		if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_core3200.Tree);
 
             	        	}
 
@@ -6514,11 +6588,11 @@ public partial class simpletikzParser : Parser
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:371:11: ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 )
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:371:12: ( tikzcoordinate_core2 )=> tikzcoordinate_core2
             	        	{
-            	        		PushFollow(FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_int2279);
-            	        		tikzcoordinate_core2196 = tikzcoordinate_core2();
+            	        		PushFollow(FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_int2304);
+            	        		tikzcoordinate_core2201 = tikzcoordinate_core2();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_core2196.Tree);
+            	        		if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_core2201.Tree);
 
             	        	}
 
@@ -6531,11 +6605,11 @@ public partial class simpletikzParser : Parser
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:372:11: ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 )
             	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:372:12: ( tikzcoordinate_core1 )=> tikzcoordinate_core1
             	        	{
-            	        		PushFollow(FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_int2299);
-            	        		tikzcoordinate_core1197 = tikzcoordinate_core1();
+            	        		PushFollow(FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_int2324);
+            	        		tikzcoordinate_core1202 = tikzcoordinate_core1();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_core1197.Tree);
+            	        		if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_core1202.Tree);
 
             	        	}
 
@@ -6584,11 +6658,11 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal198 = null;
-        simpletikzParser.tikznode_core_return tikznode_core199 = default(simpletikzParser.tikznode_core_return);
+        IToken string_literal203 = null;
+        simpletikzParser.tikznode_core_return tikznode_core204 = default(simpletikzParser.tikznode_core_return);
 
 
-        object string_literal198_tree=null;
+        object string_literal203_tree=null;
 
         try 
     	{
@@ -6597,12 +6671,12 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	string_literal198=(IToken)Match(input,81,FOLLOW_81_in_tikznode_int2315); if (state.failed) return retval;
-            	PushFollow(FOLLOW_tikznode_core_in_tikznode_int2318);
-            	tikznode_core199 = tikznode_core();
+            	string_literal203=(IToken)Match(input,83,FOLLOW_83_in_tikznode_int2340); if (state.failed) return retval;
+            	PushFollow(FOLLOW_tikznode_core_in_tikznode_int2343);
+            	tikznode_core204 = tikznode_core();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_core199.Tree);
+            	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_core204.Tree);
 
             }
 
@@ -6642,9 +6716,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator200 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator205 = default(simpletikzParser.tikznode_decorator_return);
 
-        simpletikzParser.tikzstring_return tikzstring201 = default(simpletikzParser.tikzstring_return);
+        simpletikzParser.tikzstring_return tikzstring206 = default(simpletikzParser.tikzstring_return);
 
 
         RewriteRuleSubtreeStream stream_tikzstring = new RewriteRuleSubtreeStream(adaptor,"rule tikzstring");
@@ -6657,46 +6731,46 @@ public partial class simpletikzParser : Parser
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:378:4: ( tikznode_decorator )*
             	do 
             	{
-            	    int alt51 = 2;
-            	    int LA51_0 = input.LA(1);
+            	    int alt53 = 2;
+            	    int LA53_0 = input.LA(1);
 
-            	    if ( (LA51_0 == 53 || LA51_0 == 55 || LA51_0 == 82) )
+            	    if ( (LA53_0 == 55 || LA53_0 == 57 || LA53_0 == 84) )
             	    {
-            	        alt51 = 1;
+            	        alt53 = 1;
             	    }
 
 
-            	    switch (alt51) 
+            	    switch (alt53) 
             		{
             			case 1 :
             			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:378:4: tikznode_decorator
             			    {
-            			    	PushFollow(FOLLOW_tikznode_decorator_in_tikznode_core2328);
-            			    	tikznode_decorator200 = tikznode_decorator();
+            			    	PushFollow(FOLLOW_tikznode_decorator_in_tikznode_core2353);
+            			    	tikznode_decorator205 = tikznode_decorator();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator200.Tree);
+            			    	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator205.Tree);
 
             			    }
             			    break;
 
             			default:
-            			    goto loop51;
+            			    goto loop53;
             	    }
             	} while (true);
 
-            	loop51:
-            		;	// Stops C# compiler whining that label 'loop51' has no statements
+            	loop53:
+            		;	// Stops C# compiler whining that label 'loop53' has no statements
 
-            	PushFollow(FOLLOW_tikzstring_in_tikznode_core2331);
-            	tikzstring201 = tikzstring();
+            	PushFollow(FOLLOW_tikzstring_in_tikznode_core2356);
+            	tikzstring206 = tikzstring();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikzstring.Add(tikzstring201.Tree);
+            	if ( state.backtracking==0 ) stream_tikzstring.Add(tikzstring206.Tree);
 
 
             	// AST REWRITE
-            	// elements:          tikzstring, tikznode_decorator
+            	// elements:          tikznode_decorator, tikzstring
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -6766,11 +6840,11 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator202 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator207 = default(simpletikzParser.tikznode_decorator_return);
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator203 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator208 = default(simpletikzParser.tikznode_decorator_return);
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator204 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator209 = default(simpletikzParser.tikznode_decorator_return);
 
 
         RewriteRuleSubtreeStream stream_tikznode_decorator = new RewriteRuleSubtreeStream(adaptor,"rule tikznode_decorator");
@@ -6779,21 +6853,21 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:382:2: ( tikznode_decorator tikznode_decorator tikznode_decorator -> ^( IM_NODE tikznode_decorator tikznode_decorator tikznode_decorator ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:382:6: tikznode_decorator tikznode_decorator tikznode_decorator
             {
-            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core32356);
-            	tikznode_decorator202 = tikznode_decorator();
+            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core32381);
+            	tikznode_decorator207 = tikznode_decorator();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator202.Tree);
-            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core32358);
-            	tikznode_decorator203 = tikznode_decorator();
+            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator207.Tree);
+            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core32383);
+            	tikznode_decorator208 = tikznode_decorator();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator203.Tree);
-            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core32360);
-            	tikznode_decorator204 = tikznode_decorator();
+            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator208.Tree);
+            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core32385);
+            	tikznode_decorator209 = tikznode_decorator();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator204.Tree);
+            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator209.Tree);
 
 
             	// AST REWRITE
@@ -6862,9 +6936,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator205 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator210 = default(simpletikzParser.tikznode_decorator_return);
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator206 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator211 = default(simpletikzParser.tikznode_decorator_return);
 
 
         RewriteRuleSubtreeStream stream_tikznode_decorator = new RewriteRuleSubtreeStream(adaptor,"rule tikznode_decorator");
@@ -6873,16 +6947,16 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:387:2: ( tikznode_decorator tikznode_decorator -> ^( IM_NODE tikznode_decorator tikznode_decorator ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:388:4: tikznode_decorator tikznode_decorator
             {
-            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core22394);
-            	tikznode_decorator205 = tikznode_decorator();
+            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core22419);
+            	tikznode_decorator210 = tikznode_decorator();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator205.Tree);
-            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core22396);
-            	tikznode_decorator206 = tikznode_decorator();
+            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator210.Tree);
+            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core22421);
+            	tikznode_decorator211 = tikznode_decorator();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator206.Tree);
+            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator211.Tree);
 
 
             	// AST REWRITE
@@ -6950,7 +7024,7 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator207 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator212 = default(simpletikzParser.tikznode_decorator_return);
 
 
         RewriteRuleSubtreeStream stream_tikznode_decorator = new RewriteRuleSubtreeStream(adaptor,"rule tikznode_decorator");
@@ -6959,11 +7033,11 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:392:2: ( tikznode_decorator -> ^( IM_NODE tikznode_decorator ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:393:4: tikznode_decorator
             {
-            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core12429);
-            	tikznode_decorator207 = tikznode_decorator();
+            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core12454);
+            	tikznode_decorator212 = tikznode_decorator();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator207.Tree);
+            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator212.Tree);
 
 
             	// AST REWRITE
@@ -7030,78 +7104,78 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal209 = null;
-        IToken COMMAND210 = null;
-        IToken string_literal211 = null;
-        simpletikzParser.nodename_return nodename208 = default(simpletikzParser.nodename_return);
+        IToken string_literal214 = null;
+        IToken COMMAND215 = null;
+        IToken string_literal216 = null;
+        simpletikzParser.nodename_return nodename213 = default(simpletikzParser.nodename_return);
 
-        simpletikzParser.coord_return coord212 = default(simpletikzParser.coord_return);
+        simpletikzParser.coord_return coord217 = default(simpletikzParser.coord_return);
 
-        simpletikzParser.tikz_options_dontcare_return tikz_options_dontcare213 = default(simpletikzParser.tikz_options_dontcare_return);
+        simpletikzParser.tikz_options_dontcare_return tikz_options_dontcare218 = default(simpletikzParser.tikz_options_dontcare_return);
 
 
-        object string_literal209_tree=null;
-        object COMMAND210_tree=null;
-        object string_literal211_tree=null;
+        object string_literal214_tree=null;
+        object COMMAND215_tree=null;
+        object string_literal216_tree=null;
 
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:401:2: ( nodename | 'at' COMMAND | 'at' coord | tikz_options_dontcare )
-            int alt52 = 4;
+            int alt54 = 4;
             switch ( input.LA(1) ) 
             {
-            case 53:
+            case 55:
             	{
-                alt52 = 1;
+                alt54 = 1;
                 }
                 break;
-            case 82:
+            case 84:
             	{
-                int LA52_2 = input.LA(2);
+                int LA54_2 = input.LA(2);
 
-                if ( (LA52_2 == COMMAND) )
+                if ( (LA54_2 == COMMAND) )
                 {
-                    alt52 = 2;
+                    alt54 = 2;
                 }
-                else if ( (LA52_2 == 53 || (LA52_2 >= 90 && LA52_2 <= 91)) )
+                else if ( (LA54_2 == 55 || (LA54_2 >= 92 && LA54_2 <= 93)) )
                 {
-                    alt52 = 3;
+                    alt54 = 3;
                 }
                 else 
                 {
                     if ( state.backtracking > 0 ) {state.failed = true; return retval;}
-                    NoViableAltException nvae_d52s2 =
-                        new NoViableAltException("", 52, 2, input);
+                    NoViableAltException nvae_d54s2 =
+                        new NoViableAltException("", 54, 2, input);
 
-                    throw nvae_d52s2;
+                    throw nvae_d54s2;
                 }
                 }
                 break;
-            case 55:
+            case 57:
             	{
-                alt52 = 4;
+                alt54 = 4;
                 }
                 break;
             	default:
             	    if ( state.backtracking > 0 ) {state.failed = true; return retval;}
-            	    NoViableAltException nvae_d52s0 =
-            	        new NoViableAltException("", 52, 0, input);
+            	    NoViableAltException nvae_d54s0 =
+            	        new NoViableAltException("", 54, 0, input);
 
-            	    throw nvae_d52s0;
+            	    throw nvae_d54s0;
             }
 
-            switch (alt52) 
+            switch (alt54) 
             {
                 case 1 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:401:6: nodename
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_nodename_in_tikznode_decorator2466);
-                    	nodename208 = nodename();
+                    	PushFollow(FOLLOW_nodename_in_tikznode_decorator2491);
+                    	nodename213 = nodename();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, nodename208.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, nodename213.Tree);
 
                     }
                     break;
@@ -7110,11 +7184,11 @@ public partial class simpletikzParser : Parser
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	string_literal209=(IToken)Match(input,82,FOLLOW_82_in_tikznode_decorator2473); if (state.failed) return retval;
-                    	COMMAND210=(IToken)Match(input,COMMAND,FOLLOW_COMMAND_in_tikznode_decorator2476); if (state.failed) return retval;
+                    	string_literal214=(IToken)Match(input,84,FOLLOW_84_in_tikznode_decorator2498); if (state.failed) return retval;
+                    	COMMAND215=(IToken)Match(input,COMMAND,FOLLOW_COMMAND_in_tikznode_decorator2501); if (state.failed) return retval;
                     	if ( state.backtracking == 0 )
-                    	{COMMAND210_tree = (object)adaptor.Create(COMMAND210);
-                    		adaptor.AddChild(root_0, COMMAND210_tree);
+                    	{COMMAND215_tree = (object)adaptor.Create(COMMAND215);
+                    		adaptor.AddChild(root_0, COMMAND215_tree);
                     	}
 
                     }
@@ -7124,12 +7198,12 @@ public partial class simpletikzParser : Parser
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	string_literal211=(IToken)Match(input,82,FOLLOW_82_in_tikznode_decorator2482); if (state.failed) return retval;
-                    	PushFollow(FOLLOW_coord_in_tikznode_decorator2485);
-                    	coord212 = coord();
+                    	string_literal216=(IToken)Match(input,84,FOLLOW_84_in_tikznode_decorator2507); if (state.failed) return retval;
+                    	PushFollow(FOLLOW_coord_in_tikznode_decorator2510);
+                    	coord217 = coord();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, coord212.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, coord217.Tree);
 
                     }
                     break;
@@ -7138,11 +7212,11 @@ public partial class simpletikzParser : Parser
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_tikz_options_dontcare_in_tikznode_decorator2491);
-                    	tikz_options_dontcare213 = tikz_options_dontcare();
+                    	PushFollow(FOLLOW_tikz_options_dontcare_in_tikznode_decorator2516);
+                    	tikz_options_dontcare218 = tikz_options_dontcare();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_options_dontcare213.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_options_dontcare218.Tree);
 
                     }
                     break;
@@ -7184,19 +7258,19 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal214 = null;
-        IToken char_literal218 = null;
-        simpletikzParser.no_rlbracket_return no_rlbracket215 = default(simpletikzParser.no_rlbracket_return);
+        IToken char_literal219 = null;
+        IToken char_literal223 = null;
+        simpletikzParser.no_rlbracket_return no_rlbracket220 = default(simpletikzParser.no_rlbracket_return);
 
-        simpletikzParser.tikz_options_dontcare_return tikz_options_dontcare216 = default(simpletikzParser.tikz_options_dontcare_return);
+        simpletikzParser.tikz_options_dontcare_return tikz_options_dontcare221 = default(simpletikzParser.tikz_options_dontcare_return);
 
-        simpletikzParser.no_rlbracket_return no_rlbracket217 = default(simpletikzParser.no_rlbracket_return);
+        simpletikzParser.no_rlbracket_return no_rlbracket222 = default(simpletikzParser.no_rlbracket_return);
 
 
-        object char_literal214_tree=null;
-        object char_literal218_tree=null;
-        RewriteRuleTokenStream stream_55 = new RewriteRuleTokenStream(adaptor,"token 55");
-        RewriteRuleTokenStream stream_56 = new RewriteRuleTokenStream(adaptor,"token 56");
+        object char_literal219_tree=null;
+        object char_literal223_tree=null;
+        RewriteRuleTokenStream stream_57 = new RewriteRuleTokenStream(adaptor,"token 57");
+        RewriteRuleTokenStream stream_58 = new RewriteRuleTokenStream(adaptor,"token 58");
         RewriteRuleSubtreeStream stream_tikz_options_dontcare = new RewriteRuleSubtreeStream(adaptor,"rule tikz_options_dontcare");
         RewriteRuleSubtreeStream stream_no_rlbracket = new RewriteRuleSubtreeStream(adaptor,"rule no_rlbracket");
         try 
@@ -7204,50 +7278,16 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:2: ( '[' ( no_rlbracket )* ( tikz_options_dontcare ( no_rlbracket )* )* ']' -> ^( IM_OPTIONS ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:4: '[' ( no_rlbracket )* ( tikz_options_dontcare ( no_rlbracket )* )* ']'
             {
-            	char_literal214=(IToken)Match(input,55,FOLLOW_55_in_tikz_options_dontcare2501); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_55.Add(char_literal214);
+            	char_literal219=(IToken)Match(input,57,FOLLOW_57_in_tikz_options_dontcare2526); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_57.Add(char_literal219);
 
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:8: ( no_rlbracket )*
-            	do 
-            	{
-            	    int alt53 = 2;
-            	    int LA53_0 = input.LA(1);
-
-            	    if ( ((LA53_0 >= IM_PATH && LA53_0 <= 54) || (LA53_0 >= 57 && LA53_0 <= 95)) )
-            	    {
-            	        alt53 = 1;
-            	    }
-
-
-            	    switch (alt53) 
-            		{
-            			case 1 :
-            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:8: no_rlbracket
-            			    {
-            			    	PushFollow(FOLLOW_no_rlbracket_in_tikz_options_dontcare2503);
-            			    	no_rlbracket215 = no_rlbracket();
-            			    	state.followingStackPointer--;
-            			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_no_rlbracket.Add(no_rlbracket215.Tree);
-
-            			    }
-            			    break;
-
-            			default:
-            			    goto loop53;
-            	    }
-            	} while (true);
-
-            	loop53:
-            		;	// Stops C# compiler whining that label 'loop53' has no statements
-
-            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:22: ( tikz_options_dontcare ( no_rlbracket )* )*
             	do 
             	{
             	    int alt55 = 2;
             	    int LA55_0 = input.LA(1);
 
-            	    if ( (LA55_0 == 55) )
+            	    if ( ((LA55_0 >= IM_PATH && LA55_0 <= 56) || (LA55_0 >= 59 && LA55_0 <= 97)) )
             	    {
             	        alt55 = 1;
             	    }
@@ -7256,47 +7296,13 @@ public partial class simpletikzParser : Parser
             	    switch (alt55) 
             		{
             			case 1 :
-            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:23: tikz_options_dontcare ( no_rlbracket )*
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:8: no_rlbracket
             			    {
-            			    	PushFollow(FOLLOW_tikz_options_dontcare_in_tikz_options_dontcare2507);
-            			    	tikz_options_dontcare216 = tikz_options_dontcare();
+            			    	PushFollow(FOLLOW_no_rlbracket_in_tikz_options_dontcare2528);
+            			    	no_rlbracket220 = no_rlbracket();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikz_options_dontcare.Add(tikz_options_dontcare216.Tree);
-            			    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:45: ( no_rlbracket )*
-            			    	do 
-            			    	{
-            			    	    int alt54 = 2;
-            			    	    int LA54_0 = input.LA(1);
-
-            			    	    if ( ((LA54_0 >= IM_PATH && LA54_0 <= 54) || (LA54_0 >= 57 && LA54_0 <= 95)) )
-            			    	    {
-            			    	        alt54 = 1;
-            			    	    }
-
-
-            			    	    switch (alt54) 
-            			    		{
-            			    			case 1 :
-            			    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:45: no_rlbracket
-            			    			    {
-            			    			    	PushFollow(FOLLOW_no_rlbracket_in_tikz_options_dontcare2509);
-            			    			    	no_rlbracket217 = no_rlbracket();
-            			    			    	state.followingStackPointer--;
-            			    			    	if (state.failed) return retval;
-            			    			    	if ( state.backtracking==0 ) stream_no_rlbracket.Add(no_rlbracket217.Tree);
-
-            			    			    }
-            			    			    break;
-
-            			    			default:
-            			    			    goto loop54;
-            			    	    }
-            			    	} while (true);
-
-            			    	loop54:
-            			    		;	// Stops C# compiler whining that label 'loop54' has no statements
-
+            			    	if ( state.backtracking==0 ) stream_no_rlbracket.Add(no_rlbracket220.Tree);
 
             			    }
             			    break;
@@ -7309,8 +7315,76 @@ public partial class simpletikzParser : Parser
             	loop55:
             		;	// Stops C# compiler whining that label 'loop55' has no statements
 
-            	char_literal218=(IToken)Match(input,56,FOLLOW_56_in_tikz_options_dontcare2514); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_56.Add(char_literal218);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:22: ( tikz_options_dontcare ( no_rlbracket )* )*
+            	do 
+            	{
+            	    int alt57 = 2;
+            	    int LA57_0 = input.LA(1);
+
+            	    if ( (LA57_0 == 57) )
+            	    {
+            	        alt57 = 1;
+            	    }
+
+
+            	    switch (alt57) 
+            		{
+            			case 1 :
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:23: tikz_options_dontcare ( no_rlbracket )*
+            			    {
+            			    	PushFollow(FOLLOW_tikz_options_dontcare_in_tikz_options_dontcare2532);
+            			    	tikz_options_dontcare221 = tikz_options_dontcare();
+            			    	state.followingStackPointer--;
+            			    	if (state.failed) return retval;
+            			    	if ( state.backtracking==0 ) stream_tikz_options_dontcare.Add(tikz_options_dontcare221.Tree);
+            			    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:45: ( no_rlbracket )*
+            			    	do 
+            			    	{
+            			    	    int alt56 = 2;
+            			    	    int LA56_0 = input.LA(1);
+
+            			    	    if ( ((LA56_0 >= IM_PATH && LA56_0 <= 56) || (LA56_0 >= 59 && LA56_0 <= 97)) )
+            			    	    {
+            			    	        alt56 = 1;
+            			    	    }
+
+
+            			    	    switch (alt56) 
+            			    		{
+            			    			case 1 :
+            			    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:45: no_rlbracket
+            			    			    {
+            			    			    	PushFollow(FOLLOW_no_rlbracket_in_tikz_options_dontcare2534);
+            			    			    	no_rlbracket222 = no_rlbracket();
+            			    			    	state.followingStackPointer--;
+            			    			    	if (state.failed) return retval;
+            			    			    	if ( state.backtracking==0 ) stream_no_rlbracket.Add(no_rlbracket222.Tree);
+
+            			    			    }
+            			    			    break;
+
+            			    			default:
+            			    			    goto loop56;
+            			    	    }
+            			    	} while (true);
+
+            			    	loop56:
+            			    		;	// Stops C# compiler whining that label 'loop56' has no statements
+
+
+            			    }
+            			    break;
+
+            			default:
+            			    goto loop57;
+            	    }
+            	} while (true);
+
+            	loop57:
+            		;	// Stops C# compiler whining that label 'loop57' has no statements
+
+            	char_literal223=(IToken)Match(input,58,FOLLOW_58_in_tikz_options_dontcare2539); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_58.Add(char_literal223);
 
 
 
@@ -7376,9 +7450,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set219 = null;
+        IToken set224 = null;
 
-        object set219_tree=null;
+        object set224_tree=null;
 
         try 
     	{
@@ -7387,11 +7461,11 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set219 = (IToken)input.LT(1);
-            	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= 54) || (input.LA(1) >= 57 && input.LA(1) <= 95) ) 
+            	set224 = (IToken)input.LT(1);
+            	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= 56) || (input.LA(1) >= 59 && input.LA(1) <= 97) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set219));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set224));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -7440,31 +7514,31 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal220 = null;
-        IToken char_literal222 = null;
-        simpletikzParser.idd_return idd221 = default(simpletikzParser.idd_return);
+        IToken char_literal225 = null;
+        IToken char_literal227 = null;
+        simpletikzParser.idd_return idd226 = default(simpletikzParser.idd_return);
 
 
-        object char_literal220_tree=null;
-        object char_literal222_tree=null;
-        RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
-        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
+        object char_literal225_tree=null;
+        object char_literal227_tree=null;
+        RewriteRuleTokenStream stream_55 = new RewriteRuleTokenStream(adaptor,"token 55");
+        RewriteRuleTokenStream stream_56 = new RewriteRuleTokenStream(adaptor,"token 56");
         RewriteRuleSubtreeStream stream_idd = new RewriteRuleSubtreeStream(adaptor,"rule idd");
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:413:2: ( '(' idd ')' -> ^( IM_NODENAME idd ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:413:4: '(' idd ')'
             {
-            	char_literal220=(IToken)Match(input,53,FOLLOW_53_in_nodename2549); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_53.Add(char_literal220);
+            	char_literal225=(IToken)Match(input,55,FOLLOW_55_in_nodename2574); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_55.Add(char_literal225);
 
-            	PushFollow(FOLLOW_idd_in_nodename2551);
-            	idd221 = idd();
+            	PushFollow(FOLLOW_idd_in_nodename2576);
+            	idd226 = idd();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_idd.Add(idd221.Tree);
-            	char_literal222=(IToken)Match(input,54,FOLLOW_54_in_nodename2553); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_54.Add(char_literal222);
+            	if ( state.backtracking==0 ) stream_idd.Add(idd226.Tree);
+            	char_literal227=(IToken)Match(input,56,FOLLOW_56_in_nodename2578); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_56.Add(char_literal227);
 
 
 
@@ -7532,15 +7606,15 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal223 = null;
-        IToken string_literal224 = null;
-        simpletikzParser.size_return size225 = default(simpletikzParser.size_return);
+        IToken string_literal228 = null;
+        IToken string_literal229 = null;
+        simpletikzParser.size_return size230 = default(simpletikzParser.size_return);
 
 
-        object string_literal223_tree=null;
-        object string_literal224_tree=null;
-        RewriteRuleTokenStream stream_83 = new RewriteRuleTokenStream(adaptor,"token 83");
-        RewriteRuleTokenStream stream_84 = new RewriteRuleTokenStream(adaptor,"token 84");
+        object string_literal228_tree=null;
+        object string_literal229_tree=null;
+        RewriteRuleTokenStream stream_85 = new RewriteRuleTokenStream(adaptor,"token 85");
+        RewriteRuleTokenStream stream_86 = new RewriteRuleTokenStream(adaptor,"token 86");
         RewriteRuleSubtreeStream stream_size = new RewriteRuleSubtreeStream(adaptor,"rule size");
         try 
     	{
@@ -7548,32 +7622,32 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:4: ( 'circle' | 'ellipse' ) ( ( size )=> size )?
             {
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:4: ( 'circle' | 'ellipse' )
-            	int alt56 = 2;
-            	int LA56_0 = input.LA(1);
+            	int alt58 = 2;
+            	int LA58_0 = input.LA(1);
 
-            	if ( (LA56_0 == 83) )
+            	if ( (LA58_0 == 85) )
             	{
-            	    alt56 = 1;
+            	    alt58 = 1;
             	}
-            	else if ( (LA56_0 == 84) )
+            	else if ( (LA58_0 == 86) )
             	{
-            	    alt56 = 2;
+            	    alt58 = 2;
             	}
             	else 
             	{
             	    if ( state.backtracking > 0 ) {state.failed = true; return retval;}
-            	    NoViableAltException nvae_d56s0 =
-            	        new NoViableAltException("", 56, 0, input);
+            	    NoViableAltException nvae_d58s0 =
+            	        new NoViableAltException("", 58, 0, input);
 
-            	    throw nvae_d56s0;
+            	    throw nvae_d58s0;
             	}
-            	switch (alt56) 
+            	switch (alt58) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:5: 'circle'
             	        {
-            	        	string_literal223=(IToken)Match(input,83,FOLLOW_83_in_circle2578); if (state.failed) return retval; 
-            	        	if ( state.backtracking==0 ) stream_83.Add(string_literal223);
+            	        	string_literal228=(IToken)Match(input,85,FOLLOW_85_in_circle2603); if (state.failed) return retval; 
+            	        	if ( state.backtracking==0 ) stream_85.Add(string_literal228);
 
 
             	        }
@@ -7581,8 +7655,8 @@ public partial class simpletikzParser : Parser
             	    case 2 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:16: 'ellipse'
             	        {
-            	        	string_literal224=(IToken)Match(input,84,FOLLOW_84_in_circle2582); if (state.failed) return retval; 
-            	        	if ( state.backtracking==0 ) stream_84.Add(string_literal224);
+            	        	string_literal229=(IToken)Match(input,86,FOLLOW_86_in_circle2607); if (state.failed) return retval; 
+            	        	if ( state.backtracking==0 ) stream_86.Add(string_literal229);
 
 
             	        }
@@ -7591,18 +7665,18 @@ public partial class simpletikzParser : Parser
             	}
 
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:27: ( ( size )=> size )?
-            	int alt57 = 2;
-            	alt57 = dfa57.Predict(input);
-            	switch (alt57) 
+            	int alt59 = 2;
+            	alt59 = dfa59.Predict(input);
+            	switch (alt59) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:28: ( size )=> size
             	        {
-            	        	PushFollow(FOLLOW_size_in_circle2591);
-            	        	size225 = size();
+            	        	PushFollow(FOLLOW_size_in_circle2616);
+            	        	size230 = size();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_size.Add(size225.Tree);
+            	        	if ( state.backtracking==0 ) stream_size.Add(size230.Tree);
 
             	        }
             	        break;
@@ -7666,56 +7740,56 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal226 = null;
-        IToken char_literal227 = null;
-        IToken char_literal229 = null;
-        IToken char_literal231 = null;
-        IToken string_literal233 = null;
-        IToken char_literal235 = null;
-        IToken string_literal236 = null;
-        IToken char_literal237 = null;
-        IToken char_literal239 = null;
-        IToken char_literal241 = null;
-        IToken string_literal243 = null;
-        IToken char_literal245 = null;
-        IToken string_literal246 = null;
-        simpletikzParser.numberunitorvariable_return numberunitorvariable228 = default(simpletikzParser.numberunitorvariable_return);
+        IToken string_literal231 = null;
+        IToken char_literal232 = null;
+        IToken char_literal234 = null;
+        IToken char_literal236 = null;
+        IToken string_literal238 = null;
+        IToken char_literal240 = null;
+        IToken string_literal241 = null;
+        IToken char_literal242 = null;
+        IToken char_literal244 = null;
+        IToken char_literal246 = null;
+        IToken string_literal248 = null;
+        IToken char_literal250 = null;
+        IToken string_literal251 = null;
+        simpletikzParser.numberunitorvariable_return numberunitorvariable233 = default(simpletikzParser.numberunitorvariable_return);
 
-        simpletikzParser.numberunitorvariable_return numberunitorvariable230 = default(simpletikzParser.numberunitorvariable_return);
+        simpletikzParser.numberunitorvariable_return numberunitorvariable235 = default(simpletikzParser.numberunitorvariable_return);
 
-        simpletikzParser.numberunitorvariable_return numberunitorvariable232 = default(simpletikzParser.numberunitorvariable_return);
+        simpletikzParser.numberunitorvariable_return numberunitorvariable237 = default(simpletikzParser.numberunitorvariable_return);
 
-        simpletikzParser.numberunit_return numberunit234 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit239 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.coord_part_return coord_part238 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part243 = default(simpletikzParser.coord_part_return);
 
-        simpletikzParser.coord_part_return coord_part240 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part245 = default(simpletikzParser.coord_part_return);
 
-        simpletikzParser.coord_part_return coord_part242 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part247 = default(simpletikzParser.coord_part_return);
 
-        simpletikzParser.numberunit_return numberunit244 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit249 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.tikz_options_return tikz_options247 = default(simpletikzParser.tikz_options_return);
+        simpletikzParser.tikz_options_return tikz_options252 = default(simpletikzParser.tikz_options_return);
 
 
-        object string_literal226_tree=null;
-        object char_literal227_tree=null;
-        object char_literal229_tree=null;
-        object char_literal231_tree=null;
-        object string_literal233_tree=null;
-        object char_literal235_tree=null;
-        object string_literal236_tree=null;
-        object char_literal237_tree=null;
-        object char_literal239_tree=null;
-        object char_literal241_tree=null;
-        object string_literal243_tree=null;
-        object char_literal245_tree=null;
-        object string_literal246_tree=null;
-        RewriteRuleTokenStream stream_79 = new RewriteRuleTokenStream(adaptor,"token 79");
+        object string_literal231_tree=null;
+        object char_literal232_tree=null;
+        object char_literal234_tree=null;
+        object char_literal236_tree=null;
+        object string_literal238_tree=null;
+        object char_literal240_tree=null;
+        object string_literal241_tree=null;
+        object char_literal242_tree=null;
+        object char_literal244_tree=null;
+        object char_literal246_tree=null;
+        object string_literal248_tree=null;
+        object char_literal250_tree=null;
+        object string_literal251_tree=null;
+        RewriteRuleTokenStream stream_55 = new RewriteRuleTokenStream(adaptor,"token 55");
+        RewriteRuleTokenStream stream_56 = new RewriteRuleTokenStream(adaptor,"token 56");
         RewriteRuleTokenStream stream_48 = new RewriteRuleTokenStream(adaptor,"token 48");
-        RewriteRuleTokenStream stream_85 = new RewriteRuleTokenStream(adaptor,"token 85");
-        RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
-        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
+        RewriteRuleTokenStream stream_81 = new RewriteRuleTokenStream(adaptor,"token 81");
+        RewriteRuleTokenStream stream_87 = new RewriteRuleTokenStream(adaptor,"token 87");
         RewriteRuleSubtreeStream stream_numberunitorvariable = new RewriteRuleSubtreeStream(adaptor,"rule numberunitorvariable");
         RewriteRuleSubtreeStream stream_coord_part = new RewriteRuleSubtreeStream(adaptor,"rule coord_part");
         RewriteRuleSubtreeStream stream_tikz_options = new RewriteRuleSubtreeStream(adaptor,"rule tikz_options");
@@ -7723,72 +7797,72 @@ public partial class simpletikzParser : Parser
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:2: ( 'arc' ( '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')' ) -> ^( IM_ARC ( numberunitorvariable )+ ( numberunit )? ) | 'arc' ( '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')' ) -> ^( IM_ARC ( coord_part )+ ( numberunit )? ) | 'arc' tikz_options -> ^( IM_DONTCARE ) )
-            int alt60 = 3;
-            alt60 = dfa60.Predict(input);
-            switch (alt60) 
+            int alt62 = 3;
+            alt62 = dfa62.Predict(input);
+            switch (alt62) 
             {
                 case 1 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:4: 'arc' ( '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')' )
                     {
-                    	string_literal226=(IToken)Match(input,85,FOLLOW_85_in_arc2606); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_85.Add(string_literal226);
+                    	string_literal231=(IToken)Match(input,87,FOLLOW_87_in_arc2631); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_87.Add(string_literal231);
 
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:10: ( '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')' )
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:11: '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')'
                     	{
-                    		char_literal227=(IToken)Match(input,53,FOLLOW_53_in_arc2609); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal227);
+                    		char_literal232=(IToken)Match(input,55,FOLLOW_55_in_arc2634); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_55.Add(char_literal232);
 
-                    		PushFollow(FOLLOW_numberunitorvariable_in_arc2611);
-                    		numberunitorvariable228 = numberunitorvariable();
+                    		PushFollow(FOLLOW_numberunitorvariable_in_arc2636);
+                    		numberunitorvariable233 = numberunitorvariable();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunitorvariable.Add(numberunitorvariable228.Tree);
-                    		char_literal229=(IToken)Match(input,48,FOLLOW_48_in_arc2613); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_48.Add(char_literal229);
+                    		if ( state.backtracking==0 ) stream_numberunitorvariable.Add(numberunitorvariable233.Tree);
+                    		char_literal234=(IToken)Match(input,48,FOLLOW_48_in_arc2638); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_48.Add(char_literal234);
 
-                    		PushFollow(FOLLOW_numberunitorvariable_in_arc2615);
-                    		numberunitorvariable230 = numberunitorvariable();
+                    		PushFollow(FOLLOW_numberunitorvariable_in_arc2640);
+                    		numberunitorvariable235 = numberunitorvariable();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunitorvariable.Add(numberunitorvariable230.Tree);
-                    		char_literal231=(IToken)Match(input,48,FOLLOW_48_in_arc2617); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_48.Add(char_literal231);
+                    		if ( state.backtracking==0 ) stream_numberunitorvariable.Add(numberunitorvariable235.Tree);
+                    		char_literal236=(IToken)Match(input,48,FOLLOW_48_in_arc2642); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_48.Add(char_literal236);
 
-                    		PushFollow(FOLLOW_numberunitorvariable_in_arc2619);
-                    		numberunitorvariable232 = numberunitorvariable();
+                    		PushFollow(FOLLOW_numberunitorvariable_in_arc2644);
+                    		numberunitorvariable237 = numberunitorvariable();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunitorvariable.Add(numberunitorvariable232.Tree);
+                    		if ( state.backtracking==0 ) stream_numberunitorvariable.Add(numberunitorvariable237.Tree);
                     		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:86: ( 'and' numberunit )?
-                    		int alt58 = 2;
-                    		int LA58_0 = input.LA(1);
+                    		int alt60 = 2;
+                    		int LA60_0 = input.LA(1);
 
-                    		if ( (LA58_0 == 79) )
+                    		if ( (LA60_0 == 81) )
                     		{
-                    		    alt58 = 1;
+                    		    alt60 = 1;
                     		}
-                    		switch (alt58) 
+                    		switch (alt60) 
                     		{
                     		    case 1 :
                     		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:87: 'and' numberunit
                     		        {
-                    		        	string_literal233=(IToken)Match(input,79,FOLLOW_79_in_arc2622); if (state.failed) return retval; 
-                    		        	if ( state.backtracking==0 ) stream_79.Add(string_literal233);
+                    		        	string_literal238=(IToken)Match(input,81,FOLLOW_81_in_arc2647); if (state.failed) return retval; 
+                    		        	if ( state.backtracking==0 ) stream_81.Add(string_literal238);
 
-                    		        	PushFollow(FOLLOW_numberunit_in_arc2624);
-                    		        	numberunit234 = numberunit();
+                    		        	PushFollow(FOLLOW_numberunit_in_arc2649);
+                    		        	numberunit239 = numberunit();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit234.Tree);
+                    		        	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit239.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal235=(IToken)Match(input,54,FOLLOW_54_in_arc2628); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_54.Add(char_literal235);
+                    		char_literal240=(IToken)Match(input,56,FOLLOW_56_in_arc2653); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_56.Add(char_literal240);
 
 
                     	}
@@ -7796,7 +7870,7 @@ public partial class simpletikzParser : Parser
 
 
                     	// AST REWRITE
-                    	// elements:          numberunit, numberunitorvariable
+                    	// elements:          numberunitorvariable, numberunit
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -7841,65 +7915,65 @@ public partial class simpletikzParser : Parser
                 case 2 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:424:4: 'arc' ( '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')' )
                     {
-                    	string_literal236=(IToken)Match(input,85,FOLLOW_85_in_arc2646); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_85.Add(string_literal236);
+                    	string_literal241=(IToken)Match(input,87,FOLLOW_87_in_arc2671); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_87.Add(string_literal241);
 
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:424:10: ( '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')' )
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:424:11: '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')'
                     	{
-                    		char_literal237=(IToken)Match(input,53,FOLLOW_53_in_arc2649); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal237);
+                    		char_literal242=(IToken)Match(input,55,FOLLOW_55_in_arc2674); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_55.Add(char_literal242);
 
-                    		PushFollow(FOLLOW_coord_part_in_arc2651);
-                    		coord_part238 = coord_part();
+                    		PushFollow(FOLLOW_coord_part_in_arc2676);
+                    		coord_part243 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part238.Tree);
-                    		char_literal239=(IToken)Match(input,48,FOLLOW_48_in_arc2653); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_48.Add(char_literal239);
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part243.Tree);
+                    		char_literal244=(IToken)Match(input,48,FOLLOW_48_in_arc2678); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_48.Add(char_literal244);
 
-                    		PushFollow(FOLLOW_coord_part_in_arc2655);
-                    		coord_part240 = coord_part();
+                    		PushFollow(FOLLOW_coord_part_in_arc2680);
+                    		coord_part245 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part240.Tree);
-                    		char_literal241=(IToken)Match(input,48,FOLLOW_48_in_arc2657); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_48.Add(char_literal241);
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part245.Tree);
+                    		char_literal246=(IToken)Match(input,48,FOLLOW_48_in_arc2682); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_48.Add(char_literal246);
 
-                    		PushFollow(FOLLOW_coord_part_in_arc2659);
-                    		coord_part242 = coord_part();
+                    		PushFollow(FOLLOW_coord_part_in_arc2684);
+                    		coord_part247 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part242.Tree);
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part247.Tree);
                     		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:424:56: ( 'and' numberunit )?
-                    		int alt59 = 2;
-                    		int LA59_0 = input.LA(1);
+                    		int alt61 = 2;
+                    		int LA61_0 = input.LA(1);
 
-                    		if ( (LA59_0 == 79) )
+                    		if ( (LA61_0 == 81) )
                     		{
-                    		    alt59 = 1;
+                    		    alt61 = 1;
                     		}
-                    		switch (alt59) 
+                    		switch (alt61) 
                     		{
                     		    case 1 :
                     		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:424:57: 'and' numberunit
                     		        {
-                    		        	string_literal243=(IToken)Match(input,79,FOLLOW_79_in_arc2662); if (state.failed) return retval; 
-                    		        	if ( state.backtracking==0 ) stream_79.Add(string_literal243);
+                    		        	string_literal248=(IToken)Match(input,81,FOLLOW_81_in_arc2687); if (state.failed) return retval; 
+                    		        	if ( state.backtracking==0 ) stream_81.Add(string_literal248);
 
-                    		        	PushFollow(FOLLOW_numberunit_in_arc2664);
-                    		        	numberunit244 = numberunit();
+                    		        	PushFollow(FOLLOW_numberunit_in_arc2689);
+                    		        	numberunit249 = numberunit();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit244.Tree);
+                    		        	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit249.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal245=(IToken)Match(input,54,FOLLOW_54_in_arc2668); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_54.Add(char_literal245);
+                    		char_literal250=(IToken)Match(input,56,FOLLOW_56_in_arc2693); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_56.Add(char_literal250);
 
 
                     	}
@@ -7952,14 +8026,14 @@ public partial class simpletikzParser : Parser
                 case 3 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:425:4: 'arc' tikz_options
                     {
-                    	string_literal246=(IToken)Match(input,85,FOLLOW_85_in_arc2686); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_85.Add(string_literal246);
+                    	string_literal251=(IToken)Match(input,87,FOLLOW_87_in_arc2711); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_87.Add(string_literal251);
 
-                    	PushFollow(FOLLOW_tikz_options_in_arc2688);
-                    	tikz_options247 = tikz_options();
+                    	PushFollow(FOLLOW_tikz_options_in_arc2713);
+                    	tikz_options252 = tikz_options();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options247.Tree);
+                    	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options252.Tree);
 
 
                     	// AST REWRITE
@@ -8026,63 +8100,63 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal248 = null;
-        IToken string_literal250 = null;
-        IToken char_literal252 = null;
-        simpletikzParser.numberunit_return numberunit249 = default(simpletikzParser.numberunit_return);
+        IToken char_literal253 = null;
+        IToken string_literal255 = null;
+        IToken char_literal257 = null;
+        simpletikzParser.numberunit_return numberunit254 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.numberunit_return numberunit251 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit256 = default(simpletikzParser.numberunit_return);
 
 
-        object char_literal248_tree=null;
-        object string_literal250_tree=null;
-        object char_literal252_tree=null;
-        RewriteRuleTokenStream stream_79 = new RewriteRuleTokenStream(adaptor,"token 79");
-        RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
-        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
+        object char_literal253_tree=null;
+        object string_literal255_tree=null;
+        object char_literal257_tree=null;
+        RewriteRuleTokenStream stream_55 = new RewriteRuleTokenStream(adaptor,"token 55");
+        RewriteRuleTokenStream stream_56 = new RewriteRuleTokenStream(adaptor,"token 56");
+        RewriteRuleTokenStream stream_81 = new RewriteRuleTokenStream(adaptor,"token 81");
         RewriteRuleSubtreeStream stream_numberunit = new RewriteRuleSubtreeStream(adaptor,"rule numberunit");
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:433:2: ( '(' numberunit ( 'and' numberunit )? ')' -> ^( IM_SIZE ( numberunit )* ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:433:6: '(' numberunit ( 'and' numberunit )? ')'
             {
-            	char_literal248=(IToken)Match(input,53,FOLLOW_53_in_size2713); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_53.Add(char_literal248);
+            	char_literal253=(IToken)Match(input,55,FOLLOW_55_in_size2738); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_55.Add(char_literal253);
 
-            	PushFollow(FOLLOW_numberunit_in_size2715);
-            	numberunit249 = numberunit();
+            	PushFollow(FOLLOW_numberunit_in_size2740);
+            	numberunit254 = numberunit();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit249.Tree);
+            	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit254.Tree);
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:433:21: ( 'and' numberunit )?
-            	int alt61 = 2;
-            	int LA61_0 = input.LA(1);
+            	int alt63 = 2;
+            	int LA63_0 = input.LA(1);
 
-            	if ( (LA61_0 == 79) )
+            	if ( (LA63_0 == 81) )
             	{
-            	    alt61 = 1;
+            	    alt63 = 1;
             	}
-            	switch (alt61) 
+            	switch (alt63) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:433:22: 'and' numberunit
             	        {
-            	        	string_literal250=(IToken)Match(input,79,FOLLOW_79_in_size2718); if (state.failed) return retval; 
-            	        	if ( state.backtracking==0 ) stream_79.Add(string_literal250);
+            	        	string_literal255=(IToken)Match(input,81,FOLLOW_81_in_size2743); if (state.failed) return retval; 
+            	        	if ( state.backtracking==0 ) stream_81.Add(string_literal255);
 
-            	        	PushFollow(FOLLOW_numberunit_in_size2720);
-            	        	numberunit251 = numberunit();
+            	        	PushFollow(FOLLOW_numberunit_in_size2745);
+            	        	numberunit256 = numberunit();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit251.Tree);
+            	        	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit256.Tree);
 
             	        }
             	        break;
 
             	}
 
-            	char_literal252=(IToken)Match(input,54,FOLLOW_54_in_size2724); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_54.Add(char_literal252);
+            	char_literal257=(IToken)Match(input,56,FOLLOW_56_in_size2749); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_56.Add(char_literal257);
 
 
 
@@ -8156,17 +8230,17 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal253 = null;
-        IToken char_literal256 = null;
-        simpletikzParser.tikz_options_return tikz_options254 = default(simpletikzParser.tikz_options_return);
+        IToken char_literal258 = null;
+        IToken char_literal261 = null;
+        simpletikzParser.tikz_options_return tikz_options259 = default(simpletikzParser.tikz_options_return);
 
-        simpletikzParser.idd_return idd255 = default(simpletikzParser.idd_return);
+        simpletikzParser.idd_return idd260 = default(simpletikzParser.idd_return);
 
 
-        object char_literal253_tree=null;
-        object char_literal256_tree=null;
-        RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
-        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
+        object char_literal258_tree=null;
+        object char_literal261_tree=null;
+        RewriteRuleTokenStream stream_55 = new RewriteRuleTokenStream(adaptor,"token 55");
+        RewriteRuleTokenStream stream_56 = new RewriteRuleTokenStream(adaptor,"token 56");
         RewriteRuleSubtreeStream stream_tikz_options = new RewriteRuleSubtreeStream(adaptor,"rule tikz_options");
         RewriteRuleSubtreeStream stream_idd = new RewriteRuleSubtreeStream(adaptor,"rule idd");
         try 
@@ -8174,40 +8248,40 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:441:2: ( '(' ( tikz_options )? idd ')' -> ^( IM_NODENAME idd ( tikz_options )? ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:441:4: '(' ( tikz_options )? idd ')'
             {
-            	char_literal253=(IToken)Match(input,53,FOLLOW_53_in_coord_nodename2752); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_53.Add(char_literal253);
+            	char_literal258=(IToken)Match(input,55,FOLLOW_55_in_coord_nodename2777); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_55.Add(char_literal258);
 
             	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:441:8: ( tikz_options )?
-            	int alt62 = 2;
-            	int LA62_0 = input.LA(1);
+            	int alt64 = 2;
+            	int LA64_0 = input.LA(1);
 
-            	if ( (LA62_0 == 55) )
+            	if ( (LA64_0 == 57) )
             	{
-            	    alt62 = 1;
+            	    alt64 = 1;
             	}
-            	switch (alt62) 
+            	switch (alt64) 
             	{
             	    case 1 :
             	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:441:8: tikz_options
             	        {
-            	        	PushFollow(FOLLOW_tikz_options_in_coord_nodename2754);
-            	        	tikz_options254 = tikz_options();
+            	        	PushFollow(FOLLOW_tikz_options_in_coord_nodename2779);
+            	        	tikz_options259 = tikz_options();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options254.Tree);
+            	        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options259.Tree);
 
             	        }
             	        break;
 
             	}
 
-            	PushFollow(FOLLOW_idd_in_coord_nodename2757);
-            	idd255 = idd();
+            	PushFollow(FOLLOW_idd_in_coord_nodename2782);
+            	idd260 = idd();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_idd.Add(idd255.Tree);
-            	char_literal256=(IToken)Match(input,54,FOLLOW_54_in_coord_nodename2760); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_54.Add(char_literal256);
+            	if ( state.backtracking==0 ) stream_idd.Add(idd260.Tree);
+            	char_literal261=(IToken)Match(input,56,FOLLOW_56_in_coord_nodename2785); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_56.Add(char_literal261);
 
 
 
@@ -8282,43 +8356,43 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal260 = null;
-        IToken char_literal264 = null;
-        IToken char_literal266 = null;
-        IToken char_literal270 = null;
-        IToken char_literal272 = null;
-        IToken char_literal273 = null;
-        simpletikzParser.coord_modifier_return coord_modifier257 = default(simpletikzParser.coord_modifier_return);
+        IToken char_literal265 = null;
+        IToken char_literal269 = null;
+        IToken char_literal271 = null;
+        IToken char_literal275 = null;
+        IToken char_literal277 = null;
+        IToken char_literal278 = null;
+        simpletikzParser.coord_modifier_return coord_modifier262 = default(simpletikzParser.coord_modifier_return);
 
-        simpletikzParser.coord_nodename_return coord_nodename258 = default(simpletikzParser.coord_nodename_return);
+        simpletikzParser.coord_nodename_return coord_nodename263 = default(simpletikzParser.coord_nodename_return);
 
-        simpletikzParser.coord_modifier_return coord_modifier259 = default(simpletikzParser.coord_modifier_return);
+        simpletikzParser.coord_modifier_return coord_modifier264 = default(simpletikzParser.coord_modifier_return);
 
-        simpletikzParser.numberunit_return numberunit261 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit266 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.coord_sep_return coord_sep262 = default(simpletikzParser.coord_sep_return);
+        simpletikzParser.coord_sep_return coord_sep267 = default(simpletikzParser.coord_sep_return);
 
-        simpletikzParser.numberunit_return numberunit263 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit268 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.coord_modifier_return coord_modifier265 = default(simpletikzParser.coord_modifier_return);
+        simpletikzParser.coord_modifier_return coord_modifier270 = default(simpletikzParser.coord_modifier_return);
 
-        simpletikzParser.coord_part_return coord_part267 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part272 = default(simpletikzParser.coord_part_return);
 
-        simpletikzParser.coord_sep_return coord_sep268 = default(simpletikzParser.coord_sep_return);
+        simpletikzParser.coord_sep_return coord_sep273 = default(simpletikzParser.coord_sep_return);
 
-        simpletikzParser.coord_part_return coord_part269 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part274 = default(simpletikzParser.coord_part_return);
 
-        simpletikzParser.coord_modifier_return coord_modifier271 = default(simpletikzParser.coord_modifier_return);
+        simpletikzParser.coord_modifier_return coord_modifier276 = default(simpletikzParser.coord_modifier_return);
 
 
-        object char_literal260_tree=null;
-        object char_literal264_tree=null;
-        object char_literal266_tree=null;
-        object char_literal270_tree=null;
-        object char_literal272_tree=null;
-        object char_literal273_tree=null;
-        RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
-        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
+        object char_literal265_tree=null;
+        object char_literal269_tree=null;
+        object char_literal271_tree=null;
+        object char_literal275_tree=null;
+        object char_literal277_tree=null;
+        object char_literal278_tree=null;
+        RewriteRuleTokenStream stream_55 = new RewriteRuleTokenStream(adaptor,"token 55");
+        RewriteRuleTokenStream stream_56 = new RewriteRuleTokenStream(adaptor,"token 56");
         RewriteRuleSubtreeStream stream_coord_part = new RewriteRuleSubtreeStream(adaptor,"rule coord_part");
         RewriteRuleSubtreeStream stream_coord_nodename = new RewriteRuleSubtreeStream(adaptor,"rule coord_nodename");
         RewriteRuleSubtreeStream stream_numberunit = new RewriteRuleSubtreeStream(adaptor,"rule numberunit");
@@ -8327,9 +8401,9 @@ public partial class simpletikzParser : Parser
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:2: ( ( ( coord_modifier )? coord_nodename ) -> ^( IM_COORD ( coord_modifier )? coord_nodename ) | ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' ) -> ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep ) | ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' ) -> ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep ) | ( ( coord_modifier )? '(' ')' ) -> ^( IM_COORD ) )
-            int alt67 = 4;
-            alt67 = dfa67.Predict(input);
-            switch (alt67) 
+            int alt69 = 4;
+            alt69 = dfa69.Predict(input);
+            switch (alt69) 
             {
                 case 1 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:6: ( ( coord_modifier )? coord_nodename )
@@ -8338,41 +8412,41 @@ public partial class simpletikzParser : Parser
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:8: ( coord_modifier )? coord_nodename
                     	{
                     		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:8: ( coord_modifier )?
-                    		int alt63 = 2;
-                    		int LA63_0 = input.LA(1);
+                    		int alt65 = 2;
+                    		int LA65_0 = input.LA(1);
 
-                    		if ( ((LA63_0 >= 90 && LA63_0 <= 91)) )
+                    		if ( ((LA65_0 >= 92 && LA65_0 <= 93)) )
                     		{
-                    		    alt63 = 1;
+                    		    alt65 = 1;
                     		}
-                    		switch (alt63) 
+                    		switch (alt65) 
                     		{
                     		    case 1 :
                     		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:8: coord_modifier
                     		        {
-                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2786);
-                    		        	coord_modifier257 = coord_modifier();
+                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2811);
+                    		        	coord_modifier262 = coord_modifier();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier257.Tree);
+                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier262.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		PushFollow(FOLLOW_coord_nodename_in_coord2789);
-                    		coord_nodename258 = coord_nodename();
+                    		PushFollow(FOLLOW_coord_nodename_in_coord2814);
+                    		coord_nodename263 = coord_nodename();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_nodename.Add(coord_nodename258.Tree);
+                    		if ( state.backtracking==0 ) stream_coord_nodename.Add(coord_nodename263.Tree);
 
                     	}
 
 
 
                     	// AST REWRITE
-                    	// elements:          coord_nodename, coord_modifier
+                    	// elements:          coord_modifier, coord_nodename
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -8413,49 +8487,49 @@ public partial class simpletikzParser : Parser
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:444:7: ( coord_modifier )? '(' numberunit coord_sep numberunit ')'
                     	{
                     		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:444:7: ( coord_modifier )?
-                    		int alt64 = 2;
-                    		int LA64_0 = input.LA(1);
+                    		int alt66 = 2;
+                    		int LA66_0 = input.LA(1);
 
-                    		if ( ((LA64_0 >= 90 && LA64_0 <= 91)) )
+                    		if ( ((LA66_0 >= 92 && LA66_0 <= 93)) )
                     		{
-                    		    alt64 = 1;
+                    		    alt66 = 1;
                     		}
-                    		switch (alt64) 
+                    		switch (alt66) 
                     		{
                     		    case 1 :
                     		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:444:7: coord_modifier
                     		        {
-                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2815);
-                    		        	coord_modifier259 = coord_modifier();
+                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2840);
+                    		        	coord_modifier264 = coord_modifier();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier259.Tree);
+                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier264.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal260=(IToken)Match(input,53,FOLLOW_53_in_coord2818); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal260);
+                    		char_literal265=(IToken)Match(input,55,FOLLOW_55_in_coord2843); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_55.Add(char_literal265);
 
-                    		PushFollow(FOLLOW_numberunit_in_coord2820);
-                    		numberunit261 = numberunit();
+                    		PushFollow(FOLLOW_numberunit_in_coord2845);
+                    		numberunit266 = numberunit();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit261.Tree);
-                    		PushFollow(FOLLOW_coord_sep_in_coord2822);
-                    		coord_sep262 = coord_sep();
+                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit266.Tree);
+                    		PushFollow(FOLLOW_coord_sep_in_coord2847);
+                    		coord_sep267 = coord_sep();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep262.Tree);
-                    		PushFollow(FOLLOW_numberunit_in_coord2824);
-                    		numberunit263 = numberunit();
+                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep267.Tree);
+                    		PushFollow(FOLLOW_numberunit_in_coord2849);
+                    		numberunit268 = numberunit();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit263.Tree);
-                    		char_literal264=(IToken)Match(input,54,FOLLOW_54_in_coord2826); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_54.Add(char_literal264);
+                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit268.Tree);
+                    		char_literal269=(IToken)Match(input,56,FOLLOW_56_in_coord2851); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_56.Add(char_literal269);
 
 
                     	}
@@ -8463,7 +8537,7 @@ public partial class simpletikzParser : Parser
 
 
                     	// AST REWRITE
-                    	// elements:          coord_modifier, coord_sep, numberunit
+                    	// elements:          coord_sep, numberunit, coord_modifier
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -8513,49 +8587,49 @@ public partial class simpletikzParser : Parser
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:445:7: ( coord_modifier )? '(' coord_part coord_sep coord_part ')'
                     	{
                     		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:445:7: ( coord_modifier )?
-                    		int alt65 = 2;
-                    		int LA65_0 = input.LA(1);
+                    		int alt67 = 2;
+                    		int LA67_0 = input.LA(1);
 
-                    		if ( ((LA65_0 >= 90 && LA65_0 <= 91)) )
+                    		if ( ((LA67_0 >= 92 && LA67_0 <= 93)) )
                     		{
-                    		    alt65 = 1;
+                    		    alt67 = 1;
                     		}
-                    		switch (alt65) 
+                    		switch (alt67) 
                     		{
                     		    case 1 :
                     		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:445:7: coord_modifier
                     		        {
-                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2850);
-                    		        	coord_modifier265 = coord_modifier();
+                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2875);
+                    		        	coord_modifier270 = coord_modifier();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier265.Tree);
+                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier270.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal266=(IToken)Match(input,53,FOLLOW_53_in_coord2853); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal266);
+                    		char_literal271=(IToken)Match(input,55,FOLLOW_55_in_coord2878); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_55.Add(char_literal271);
 
-                    		PushFollow(FOLLOW_coord_part_in_coord2855);
-                    		coord_part267 = coord_part();
+                    		PushFollow(FOLLOW_coord_part_in_coord2880);
+                    		coord_part272 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part267.Tree);
-                    		PushFollow(FOLLOW_coord_sep_in_coord2857);
-                    		coord_sep268 = coord_sep();
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part272.Tree);
+                    		PushFollow(FOLLOW_coord_sep_in_coord2882);
+                    		coord_sep273 = coord_sep();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep268.Tree);
-                    		PushFollow(FOLLOW_coord_part_in_coord2859);
-                    		coord_part269 = coord_part();
+                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep273.Tree);
+                    		PushFollow(FOLLOW_coord_part_in_coord2884);
+                    		coord_part274 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part269.Tree);
-                    		char_literal270=(IToken)Match(input,54,FOLLOW_54_in_coord2861); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_54.Add(char_literal270);
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part274.Tree);
+                    		char_literal275=(IToken)Match(input,56,FOLLOW_56_in_coord2886); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_56.Add(char_literal275);
 
 
                     	}
@@ -8613,34 +8687,34 @@ public partial class simpletikzParser : Parser
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:446:7: ( coord_modifier )? '(' ')'
                     	{
                     		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:446:7: ( coord_modifier )?
-                    		int alt66 = 2;
-                    		int LA66_0 = input.LA(1);
+                    		int alt68 = 2;
+                    		int LA68_0 = input.LA(1);
 
-                    		if ( ((LA66_0 >= 90 && LA66_0 <= 91)) )
+                    		if ( ((LA68_0 >= 92 && LA68_0 <= 93)) )
                     		{
-                    		    alt66 = 1;
+                    		    alt68 = 1;
                     		}
-                    		switch (alt66) 
+                    		switch (alt68) 
                     		{
                     		    case 1 :
                     		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:446:7: coord_modifier
                     		        {
-                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2885);
-                    		        	coord_modifier271 = coord_modifier();
+                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2910);
+                    		        	coord_modifier276 = coord_modifier();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier271.Tree);
+                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier276.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal272=(IToken)Match(input,53,FOLLOW_53_in_coord2888); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal272);
+                    		char_literal277=(IToken)Match(input,55,FOLLOW_55_in_coord2913); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_55.Add(char_literal277);
 
-                    		char_literal273=(IToken)Match(input,54,FOLLOW_54_in_coord2890); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_54.Add(char_literal273);
+                    		char_literal278=(IToken)Match(input,56,FOLLOW_56_in_coord2915); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_56.Add(char_literal278);
 
 
                     	}
@@ -8711,35 +8785,35 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal276 = null;
-        IToken char_literal280 = null;
-        IToken char_literal282 = null;
-        IToken char_literal286 = null;
-        simpletikzParser.nodename_return nodename274 = default(simpletikzParser.nodename_return);
+        IToken char_literal281 = null;
+        IToken char_literal285 = null;
+        IToken char_literal287 = null;
+        IToken char_literal291 = null;
+        simpletikzParser.nodename_return nodename279 = default(simpletikzParser.nodename_return);
 
-        simpletikzParser.coord_modifier_return coord_modifier275 = default(simpletikzParser.coord_modifier_return);
+        simpletikzParser.coord_modifier_return coord_modifier280 = default(simpletikzParser.coord_modifier_return);
 
-        simpletikzParser.numberunit_return numberunit277 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit282 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.coord_sep_return coord_sep278 = default(simpletikzParser.coord_sep_return);
+        simpletikzParser.coord_sep_return coord_sep283 = default(simpletikzParser.coord_sep_return);
 
-        simpletikzParser.numberunit_return numberunit279 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit284 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.coord_modifier_return coord_modifier281 = default(simpletikzParser.coord_modifier_return);
+        simpletikzParser.coord_modifier_return coord_modifier286 = default(simpletikzParser.coord_modifier_return);
 
-        simpletikzParser.coord_part_return coord_part283 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part288 = default(simpletikzParser.coord_part_return);
 
-        simpletikzParser.coord_sep_return coord_sep284 = default(simpletikzParser.coord_sep_return);
+        simpletikzParser.coord_sep_return coord_sep289 = default(simpletikzParser.coord_sep_return);
 
-        simpletikzParser.coord_part_return coord_part285 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part290 = default(simpletikzParser.coord_part_return);
 
 
-        object char_literal276_tree=null;
-        object char_literal280_tree=null;
-        object char_literal282_tree=null;
-        object char_literal286_tree=null;
-        RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
-        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
+        object char_literal281_tree=null;
+        object char_literal285_tree=null;
+        object char_literal287_tree=null;
+        object char_literal291_tree=null;
+        RewriteRuleTokenStream stream_55 = new RewriteRuleTokenStream(adaptor,"token 55");
+        RewriteRuleTokenStream stream_56 = new RewriteRuleTokenStream(adaptor,"token 56");
         RewriteRuleSubtreeStream stream_nodename = new RewriteRuleSubtreeStream(adaptor,"rule nodename");
         RewriteRuleSubtreeStream stream_coord_part = new RewriteRuleSubtreeStream(adaptor,"rule coord_part");
         RewriteRuleSubtreeStream stream_numberunit = new RewriteRuleSubtreeStream(adaptor,"rule numberunit");
@@ -8748,18 +8822,18 @@ public partial class simpletikzParser : Parser
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:449:2: ( nodename -> ^( IM_COORD nodename ) | ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' ) -> ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep ) | ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' ) -> ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep ) )
-            int alt70 = 3;
-            alt70 = dfa70.Predict(input);
-            switch (alt70) 
+            int alt72 = 3;
+            alt72 = dfa72.Predict(input);
+            switch (alt72) 
             {
                 case 1 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:449:6: nodename
                     {
-                    	PushFollow(FOLLOW_nodename_in_coord_nooption2918);
-                    	nodename274 = nodename();
+                    	PushFollow(FOLLOW_nodename_in_coord_nooption2943);
+                    	nodename279 = nodename();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_nodename.Add(nodename274.Tree);
+                    	if ( state.backtracking==0 ) stream_nodename.Add(nodename279.Tree);
 
 
                     	// AST REWRITE
@@ -8797,49 +8871,49 @@ public partial class simpletikzParser : Parser
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:450:7: ( coord_modifier )? '(' numberunit coord_sep numberunit ')'
                     	{
                     		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:450:7: ( coord_modifier )?
-                    		int alt68 = 2;
-                    		int LA68_0 = input.LA(1);
+                    		int alt70 = 2;
+                    		int LA70_0 = input.LA(1);
 
-                    		if ( ((LA68_0 >= 90 && LA68_0 <= 91)) )
+                    		if ( ((LA70_0 >= 92 && LA70_0 <= 93)) )
                     		{
-                    		    alt68 = 1;
+                    		    alt70 = 1;
                     		}
-                    		switch (alt68) 
+                    		switch (alt70) 
                     		{
                     		    case 1 :
                     		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:450:7: coord_modifier
                     		        {
-                    		        	PushFollow(FOLLOW_coord_modifier_in_coord_nooption2942);
-                    		        	coord_modifier275 = coord_modifier();
+                    		        	PushFollow(FOLLOW_coord_modifier_in_coord_nooption2967);
+                    		        	coord_modifier280 = coord_modifier();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier275.Tree);
+                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier280.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal276=(IToken)Match(input,53,FOLLOW_53_in_coord_nooption2945); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal276);
+                    		char_literal281=(IToken)Match(input,55,FOLLOW_55_in_coord_nooption2970); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_55.Add(char_literal281);
 
-                    		PushFollow(FOLLOW_numberunit_in_coord_nooption2947);
-                    		numberunit277 = numberunit();
+                    		PushFollow(FOLLOW_numberunit_in_coord_nooption2972);
+                    		numberunit282 = numberunit();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit277.Tree);
-                    		PushFollow(FOLLOW_coord_sep_in_coord_nooption2949);
-                    		coord_sep278 = coord_sep();
+                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit282.Tree);
+                    		PushFollow(FOLLOW_coord_sep_in_coord_nooption2974);
+                    		coord_sep283 = coord_sep();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep278.Tree);
-                    		PushFollow(FOLLOW_numberunit_in_coord_nooption2951);
-                    		numberunit279 = numberunit();
+                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep283.Tree);
+                    		PushFollow(FOLLOW_numberunit_in_coord_nooption2976);
+                    		numberunit284 = numberunit();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit279.Tree);
-                    		char_literal280=(IToken)Match(input,54,FOLLOW_54_in_coord_nooption2953); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_54.Add(char_literal280);
+                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit284.Tree);
+                    		char_literal285=(IToken)Match(input,56,FOLLOW_56_in_coord_nooption2978); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_56.Add(char_literal285);
 
 
                     	}
@@ -8847,7 +8921,7 @@ public partial class simpletikzParser : Parser
 
 
                     	// AST REWRITE
-                    	// elements:          numberunit, coord_sep, coord_modifier
+                    	// elements:          coord_sep, numberunit, coord_modifier
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -8897,49 +8971,49 @@ public partial class simpletikzParser : Parser
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:451:7: ( coord_modifier )? '(' coord_part coord_sep coord_part ')'
                     	{
                     		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:451:7: ( coord_modifier )?
-                    		int alt69 = 2;
-                    		int LA69_0 = input.LA(1);
+                    		int alt71 = 2;
+                    		int LA71_0 = input.LA(1);
 
-                    		if ( ((LA69_0 >= 90 && LA69_0 <= 91)) )
+                    		if ( ((LA71_0 >= 92 && LA71_0 <= 93)) )
                     		{
-                    		    alt69 = 1;
+                    		    alt71 = 1;
                     		}
-                    		switch (alt69) 
+                    		switch (alt71) 
                     		{
                     		    case 1 :
                     		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:451:7: coord_modifier
                     		        {
-                    		        	PushFollow(FOLLOW_coord_modifier_in_coord_nooption2977);
-                    		        	coord_modifier281 = coord_modifier();
+                    		        	PushFollow(FOLLOW_coord_modifier_in_coord_nooption3002);
+                    		        	coord_modifier286 = coord_modifier();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier281.Tree);
+                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier286.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal282=(IToken)Match(input,53,FOLLOW_53_in_coord_nooption2980); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal282);
+                    		char_literal287=(IToken)Match(input,55,FOLLOW_55_in_coord_nooption3005); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_55.Add(char_literal287);
 
-                    		PushFollow(FOLLOW_coord_part_in_coord_nooption2982);
-                    		coord_part283 = coord_part();
+                    		PushFollow(FOLLOW_coord_part_in_coord_nooption3007);
+                    		coord_part288 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part283.Tree);
-                    		PushFollow(FOLLOW_coord_sep_in_coord_nooption2984);
-                    		coord_sep284 = coord_sep();
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part288.Tree);
+                    		PushFollow(FOLLOW_coord_sep_in_coord_nooption3009);
+                    		coord_sep289 = coord_sep();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep284.Tree);
-                    		PushFollow(FOLLOW_coord_part_in_coord_nooption2986);
-                    		coord_part285 = coord_part();
+                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep289.Tree);
+                    		PushFollow(FOLLOW_coord_part_in_coord_nooption3011);
+                    		coord_part290 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part285.Tree);
-                    		char_literal286=(IToken)Match(input,54,FOLLOW_54_in_coord_nooption2988); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_54.Add(char_literal286);
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part290.Tree);
+                    		char_literal291=(IToken)Match(input,56,FOLLOW_56_in_coord_nooption3013); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_56.Add(char_literal291);
 
 
                     	}
@@ -8947,7 +9021,7 @@ public partial class simpletikzParser : Parser
 
 
                     	// AST REWRITE
-                    	// elements:          coord_sep, coord_modifier, coord_part
+                    	// elements:          coord_modifier, coord_sep, coord_part
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -9028,23 +9102,23 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal288 = null;
-        IToken char_literal290 = null;
-        IToken char_literal292 = null;
-        IToken char_literal294 = null;
-        simpletikzParser.idd_return idd287 = default(simpletikzParser.idd_return);
+        IToken char_literal293 = null;
+        IToken char_literal295 = null;
+        IToken char_literal297 = null;
+        IToken char_literal299 = null;
+        simpletikzParser.idd_return idd292 = default(simpletikzParser.idd_return);
 
-        simpletikzParser.idd_return idd289 = default(simpletikzParser.idd_return);
+        simpletikzParser.idd_return idd294 = default(simpletikzParser.idd_return);
 
-        simpletikzParser.idd_return idd291 = default(simpletikzParser.idd_return);
+        simpletikzParser.idd_return idd296 = default(simpletikzParser.idd_return);
 
-        simpletikzParser.numberunit_return numberunit293 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit298 = default(simpletikzParser.numberunit_return);
 
 
-        object char_literal288_tree=null;
-        object char_literal290_tree=null;
-        object char_literal292_tree=null;
-        object char_literal294_tree=null;
+        object char_literal293_tree=null;
+        object char_literal295_tree=null;
+        object char_literal297_tree=null;
+        object char_literal299_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
         RewriteRuleTokenStream stream_45 = new RewriteRuleTokenStream(adaptor,"token 45");
         RewriteRuleTokenStream stream_47 = new RewriteRuleTokenStream(adaptor,"token 47");
@@ -9054,18 +9128,18 @@ public partial class simpletikzParser : Parser
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:461:2: ( idd -> ^( IM_DONTCARE idd ) | '{' idd '}' -> ^( IM_DONTCARE '{' idd '}' ) | ( idd '=' numberunit ( ',' )? )+ -> ^( IM_DONTCARE ( idd '=' numberunit ( ',' )? )+ ) )
-            int alt73 = 3;
-            alt73 = dfa73.Predict(input);
-            switch (alt73) 
+            int alt75 = 3;
+            alt75 = dfa75.Predict(input);
+            switch (alt75) 
             {
                 case 1 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:461:4: idd
                     {
-                    	PushFollow(FOLLOW_idd_in_coord_part3021);
-                    	idd287 = idd();
+                    	PushFollow(FOLLOW_idd_in_coord_part3046);
+                    	idd292 = idd();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_idd.Add(idd287.Tree);
+                    	if ( state.backtracking==0 ) stream_idd.Add(idd292.Tree);
 
 
                     	// AST REWRITE
@@ -9099,21 +9173,21 @@ public partial class simpletikzParser : Parser
                 case 2 :
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:462:4: '{' idd '}'
                     {
-                    	char_literal288=(IToken)Match(input,43,FOLLOW_43_in_coord_part3036); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_43.Add(char_literal288);
+                    	char_literal293=(IToken)Match(input,43,FOLLOW_43_in_coord_part3061); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_43.Add(char_literal293);
 
-                    	PushFollow(FOLLOW_idd_in_coord_part3038);
-                    	idd289 = idd();
+                    	PushFollow(FOLLOW_idd_in_coord_part3063);
+                    	idd294 = idd();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_idd.Add(idd289.Tree);
-                    	char_literal290=(IToken)Match(input,44,FOLLOW_44_in_coord_part3040); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_44.Add(char_literal290);
+                    	if ( state.backtracking==0 ) stream_idd.Add(idd294.Tree);
+                    	char_literal295=(IToken)Match(input,44,FOLLOW_44_in_coord_part3065); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_44.Add(char_literal295);
 
 
 
                     	// AST REWRITE
-                    	// elements:          43, 44, idd
+                    	// elements:          idd, 43, 44
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -9146,84 +9220,84 @@ public partial class simpletikzParser : Parser
                     // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:463:4: ( idd '=' numberunit ( ',' )? )+
                     {
                     	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:463:4: ( idd '=' numberunit ( ',' )? )+
-                    	int cnt72 = 0;
+                    	int cnt74 = 0;
                     	do 
                     	{
-                    	    int alt72 = 2;
-                    	    int LA72_0 = input.LA(1);
+                    	    int alt74 = 2;
+                    	    int LA74_0 = input.LA(1);
 
-                    	    if ( (LA72_0 == 79) )
+                    	    if ( (LA74_0 == 81) )
                     	    {
-                    	        int LA72_2 = input.LA(2);
+                    	        int LA74_2 = input.LA(2);
 
-                    	        if ( ((LA72_2 >= FLOAT_WO_EXP && LA72_2 <= INT)) )
+                    	        if ( ((LA74_2 >= FLOAT_WO_EXP && LA74_2 <= INT)) )
                     	        {
-                    	            int LA72_4 = input.LA(3);
+                    	            int LA74_4 = input.LA(3);
 
-                    	            if ( ((LA72_4 >= 58 && LA72_4 <= 63)) )
+                    	            if ( ((LA74_4 >= 60 && LA74_4 <= 65)) )
                     	            {
-                    	                int LA72_5 = input.LA(4);
+                    	                int LA74_5 = input.LA(4);
 
-                    	                if ( ((LA72_5 >= IM_PATH && LA72_5 <= 42) || (LA72_5 >= 45 && LA72_5 <= 46) || (LA72_5 >= 51 && LA72_5 <= 52) || (LA72_5 >= 58 && LA72_5 <= 95)) )
+                    	                if ( ((LA74_5 >= IM_PATH && LA74_5 <= 42) || (LA74_5 >= 45 && LA74_5 <= 46) || (LA74_5 >= 51 && LA74_5 <= 54) || (LA74_5 >= 60 && LA74_5 <= 97)) )
                     	                {
-                    	                    alt72 = 1;
+                    	                    alt74 = 1;
                     	                }
 
 
                     	            }
-                    	            else if ( ((LA72_4 >= IM_PATH && LA72_4 <= 42) || (LA72_4 >= 45 && LA72_4 <= 46) || (LA72_4 >= 51 && LA72_4 <= 52) || (LA72_4 >= 64 && LA72_4 <= 95)) )
+                    	            else if ( ((LA74_4 >= IM_PATH && LA74_4 <= 42) || (LA74_4 >= 45 && LA74_4 <= 46) || (LA74_4 >= 51 && LA74_4 <= 54) || (LA74_4 >= 66 && LA74_4 <= 97)) )
                     	            {
-                    	                alt72 = 1;
+                    	                alt74 = 1;
                     	            }
 
 
                     	        }
-                    	        else if ( ((LA72_2 >= IM_PATH && LA72_2 <= COMMAND) || (LA72_2 >= WS && LA72_2 <= 42) || (LA72_2 >= 45 && LA72_2 <= 46) || (LA72_2 >= 51 && LA72_2 <= 52) || (LA72_2 >= 58 && LA72_2 <= 95)) )
+                    	        else if ( ((LA74_2 >= IM_PATH && LA74_2 <= COMMAND) || (LA74_2 >= WS && LA74_2 <= 42) || (LA74_2 >= 45 && LA74_2 <= 46) || (LA74_2 >= 51 && LA74_2 <= 54) || (LA74_2 >= 60 && LA74_2 <= 97)) )
                     	        {
-                    	            alt72 = 1;
+                    	            alt74 = 1;
                     	        }
 
 
                     	    }
-                    	    else if ( ((LA72_0 >= IM_PATH && LA72_0 <= 42) || LA72_0 == 46 || (LA72_0 >= 51 && LA72_0 <= 52) || (LA72_0 >= 58 && LA72_0 <= 78) || (LA72_0 >= 80 && LA72_0 <= 95)) )
+                    	    else if ( ((LA74_0 >= IM_PATH && LA74_0 <= 42) || LA74_0 == 46 || (LA74_0 >= 51 && LA74_0 <= 54) || (LA74_0 >= 60 && LA74_0 <= 80) || (LA74_0 >= 82 && LA74_0 <= 97)) )
                     	    {
-                    	        alt72 = 1;
+                    	        alt74 = 1;
                     	    }
 
 
-                    	    switch (alt72) 
+                    	    switch (alt74) 
                     		{
                     			case 1 :
                     			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:463:5: idd '=' numberunit ( ',' )?
                     			    {
-                    			    	PushFollow(FOLLOW_idd_in_coord_part3058);
-                    			    	idd291 = idd();
+                    			    	PushFollow(FOLLOW_idd_in_coord_part3083);
+                    			    	idd296 = idd();
                     			    	state.followingStackPointer--;
                     			    	if (state.failed) return retval;
-                    			    	if ( state.backtracking==0 ) stream_idd.Add(idd291.Tree);
-                    			    	char_literal292=(IToken)Match(input,45,FOLLOW_45_in_coord_part3060); if (state.failed) return retval; 
-                    			    	if ( state.backtracking==0 ) stream_45.Add(char_literal292);
+                    			    	if ( state.backtracking==0 ) stream_idd.Add(idd296.Tree);
+                    			    	char_literal297=(IToken)Match(input,45,FOLLOW_45_in_coord_part3085); if (state.failed) return retval; 
+                    			    	if ( state.backtracking==0 ) stream_45.Add(char_literal297);
 
-                    			    	PushFollow(FOLLOW_numberunit_in_coord_part3062);
-                    			    	numberunit293 = numberunit();
+                    			    	PushFollow(FOLLOW_numberunit_in_coord_part3087);
+                    			    	numberunit298 = numberunit();
                     			    	state.followingStackPointer--;
                     			    	if (state.failed) return retval;
-                    			    	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit293.Tree);
+                    			    	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit298.Tree);
                     			    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:463:24: ( ',' )?
-                    			    	int alt71 = 2;
-                    			    	int LA71_0 = input.LA(1);
+                    			    	int alt73 = 2;
+                    			    	int LA73_0 = input.LA(1);
 
-                    			    	if ( (LA71_0 == 47) )
+                    			    	if ( (LA73_0 == 47) )
                     			    	{
-                    			    	    alt71 = 1;
+                    			    	    alt73 = 1;
                     			    	}
-                    			    	switch (alt71) 
+                    			    	switch (alt73) 
                     			    	{
                     			    	    case 1 :
                     			    	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:463:24: ','
                     			    	        {
-                    			    	        	char_literal294=(IToken)Match(input,47,FOLLOW_47_in_coord_part3064); if (state.failed) return retval; 
-                    			    	        	if ( state.backtracking==0 ) stream_47.Add(char_literal294);
+                    			    	        	char_literal299=(IToken)Match(input,47,FOLLOW_47_in_coord_part3089); if (state.failed) return retval; 
+                    			    	        	if ( state.backtracking==0 ) stream_47.Add(char_literal299);
 
 
                     			    	        }
@@ -9236,22 +9310,22 @@ public partial class simpletikzParser : Parser
                     			    break;
 
                     			default:
-                    			    if ( cnt72 >= 1 ) goto loop72;
+                    			    if ( cnt74 >= 1 ) goto loop74;
                     			    if ( state.backtracking > 0 ) {state.failed = true; return retval;}
                     		            EarlyExitException eee =
-                    		                new EarlyExitException(72, input);
+                    		                new EarlyExitException(74, input);
                     		            throw eee;
                     	    }
-                    	    cnt72++;
+                    	    cnt74++;
                     	} while (true);
 
-                    	loop72:
-                    		;	// Stops C# compiler whinging that label 'loop72' has no statements
+                    	loop74:
+                    		;	// Stops C# compiler whinging that label 'loop74' has no statements
 
 
 
                     	// AST REWRITE
-                    	// elements:          45, idd, numberunit, 47
+                    	// elements:          idd, 45, 47, numberunit
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -9268,10 +9342,10 @@ public partial class simpletikzParser : Parser
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_DONTCARE, "IM_DONTCARE"), root_1);
 
-                    	    if ( !(stream_45.HasNext() || stream_idd.HasNext() || stream_numberunit.HasNext()) ) {
+                    	    if ( !(stream_idd.HasNext() || stream_45.HasNext() || stream_numberunit.HasNext()) ) {
                     	        throw new RewriteEarlyExitException();
                     	    }
-                    	    while ( stream_45.HasNext() || stream_idd.HasNext() || stream_numberunit.HasNext() )
+                    	    while ( stream_idd.HasNext() || stream_45.HasNext() || stream_numberunit.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_idd.NextTree());
                     	        adaptor.AddChild(root_1, stream_45.NextNode());
@@ -9285,8 +9359,8 @@ public partial class simpletikzParser : Parser
                     	        stream_47.Reset();
 
                     	    }
-                    	    stream_45.Reset();
                     	    stream_idd.Reset();
+                    	    stream_45.Reset();
                     	    stream_numberunit.Reset();
 
                     	    adaptor.AddChild(root_0, root_1);
@@ -9335,9 +9409,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set295 = null;
+        IToken set300 = null;
 
-        object set295_tree=null;
+        object set300_tree=null;
 
         try 
     	{
@@ -9346,11 +9420,11 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set295 = (IToken)input.LT(1);
+            	set300 = (IToken)input.LT(1);
             	if ( (input.LA(1) >= 47 && input.LA(1) <= 48) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set295));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set300));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -9399,9 +9473,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set296 = null;
+        IToken set301 = null;
 
-        object set296_tree=null;
+        object set301_tree=null;
 
         try 
     	{
@@ -9410,11 +9484,11 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set296 = (IToken)input.LT(1);
-            	if ( input.LA(1) == ID || (input.LA(1) >= 86 && input.LA(1) <= 89) ) 
+            	set301 = (IToken)input.LT(1);
+            	if ( input.LA(1) == ID || (input.LA(1) >= 88 && input.LA(1) <= 91) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set296));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set301));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -9463,9 +9537,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set297 = null;
+        IToken set302 = null;
 
-        object set297_tree=null;
+        object set302_tree=null;
 
         try 
     	{
@@ -9474,11 +9548,11 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set297 = (IToken)input.LT(1);
-            	if ( (input.LA(1) >= 90 && input.LA(1) <= 91) ) 
+            	set302 = (IToken)input.LT(1);
+            	if ( (input.LA(1) >= 92 && input.LA(1) <= 93) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set297));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set302));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -9527,23 +9601,23 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal298 = null;
+        IToken char_literal303 = null;
 
-        object char_literal298_tree=null;
-        RewriteRuleTokenStream stream_55 = new RewriteRuleTokenStream(adaptor,"token 55");
+        object char_literal303_tree=null;
+        RewriteRuleTokenStream stream_57 = new RewriteRuleTokenStream(adaptor,"token 57");
 
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:519:2: ( '[' -> ^( IM_STARTTAG '[' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:519:4: '['
             {
-            	char_literal298=(IToken)Match(input,55,FOLLOW_55_in_squarebr_start3170); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_55.Add(char_literal298);
+            	char_literal303=(IToken)Match(input,57,FOLLOW_57_in_squarebr_start3195); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_57.Add(char_literal303);
 
 
 
             	// AST REWRITE
-            	// elements:          55
+            	// elements:          57
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -9560,7 +9634,7 @@ public partial class simpletikzParser : Parser
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_55.NextNode());
+            	    adaptor.AddChild(root_1, stream_57.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -9606,23 +9680,23 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal299 = null;
+        IToken char_literal304 = null;
 
-        object char_literal299_tree=null;
-        RewriteRuleTokenStream stream_56 = new RewriteRuleTokenStream(adaptor,"token 56");
+        object char_literal304_tree=null;
+        RewriteRuleTokenStream stream_58 = new RewriteRuleTokenStream(adaptor,"token 58");
 
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:522:2: ( ']' -> ^( IM_ENDTAG ']' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:522:4: ']'
             {
-            	char_literal299=(IToken)Match(input,56,FOLLOW_56_in_squarebr_end3188); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_56.Add(char_literal299);
+            	char_literal304=(IToken)Match(input,58,FOLLOW_58_in_squarebr_end3213); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_58.Add(char_literal304);
 
 
 
             	// AST REWRITE
-            	// elements:          56
+            	// elements:          58
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -9639,7 +9713,7 @@ public partial class simpletikzParser : Parser
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ENDTAG, "IM_ENDTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_56.NextNode());
+            	    adaptor.AddChild(root_1, stream_58.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -9685,23 +9759,23 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal300 = null;
+        IToken char_literal305 = null;
 
-        object char_literal300_tree=null;
-        RewriteRuleTokenStream stream_57 = new RewriteRuleTokenStream(adaptor,"token 57");
+        object char_literal305_tree=null;
+        RewriteRuleTokenStream stream_59 = new RewriteRuleTokenStream(adaptor,"token 59");
 
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:525:2: ( ';' -> ^( IM_ENDTAG ';' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:525:4: ';'
             {
-            	char_literal300=(IToken)Match(input,57,FOLLOW_57_in_semicolon_end3207); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_57.Add(char_literal300);
+            	char_literal305=(IToken)Match(input,59,FOLLOW_59_in_semicolon_end3232); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_59.Add(char_literal305);
 
 
 
             	// AST REWRITE
-            	// elements:          57
+            	// elements:          59
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -9718,7 +9792,7 @@ public partial class simpletikzParser : Parser
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ENDTAG, "IM_ENDTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_57.NextNode());
+            	    adaptor.AddChild(root_1, stream_59.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -9764,9 +9838,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal301 = null;
+        IToken char_literal306 = null;
 
-        object char_literal301_tree=null;
+        object char_literal306_tree=null;
         RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
 
         try 
@@ -9774,8 +9848,8 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:528:2: ( '{' -> ^( IM_STARTTAG '{' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:528:4: '{'
             {
-            	char_literal301=(IToken)Match(input,43,FOLLOW_43_in_roundbr_start3225); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal301);
+            	char_literal306=(IToken)Match(input,43,FOLLOW_43_in_roundbr_start3250); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal306);
 
 
 
@@ -9843,9 +9917,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal302 = null;
+        IToken char_literal307 = null;
 
-        object char_literal302_tree=null;
+        object char_literal307_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
 
         try 
@@ -9853,8 +9927,8 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:531:2: ( '}' -> ^( IM_ENDTAG '}' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:531:4: '}'
             {
-            	char_literal302=(IToken)Match(input,44,FOLLOW_44_in_roundbr_end3243); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_44.Add(char_literal302);
+            	char_literal307=(IToken)Match(input,44,FOLLOW_44_in_roundbr_end3268); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_44.Add(char_literal307);
 
 
 
@@ -9922,29 +9996,29 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal303 = null;
-        IToken string_literal304 = null;
+        IToken string_literal308 = null;
+        IToken string_literal309 = null;
 
-        object string_literal303_tree=null;
-        object string_literal304_tree=null;
-        RewriteRuleTokenStream stream_92 = new RewriteRuleTokenStream(adaptor,"token 92");
-        RewriteRuleTokenStream stream_93 = new RewriteRuleTokenStream(adaptor,"token 93");
+        object string_literal308_tree=null;
+        object string_literal309_tree=null;
+        RewriteRuleTokenStream stream_94 = new RewriteRuleTokenStream(adaptor,"token 94");
+        RewriteRuleTokenStream stream_95 = new RewriteRuleTokenStream(adaptor,"token 95");
 
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:534:2: ( '..' 'controls' -> ^( IM_STARTTAG '..' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:534:4: '..' 'controls'
             {
-            	string_literal303=(IToken)Match(input,92,FOLLOW_92_in_controls_start3261); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_92.Add(string_literal303);
+            	string_literal308=(IToken)Match(input,94,FOLLOW_94_in_controls_start3286); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_94.Add(string_literal308);
 
-            	string_literal304=(IToken)Match(input,93,FOLLOW_93_in_controls_start3263); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_93.Add(string_literal304);
+            	string_literal309=(IToken)Match(input,95,FOLLOW_95_in_controls_start3288); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_95.Add(string_literal309);
 
 
 
             	// AST REWRITE
-            	// elements:          92
+            	// elements:          94
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -9961,7 +10035,7 @@ public partial class simpletikzParser : Parser
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_92.NextNode());
+            	    adaptor.AddChild(root_1, stream_94.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -10007,23 +10081,23 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal305 = null;
+        IToken string_literal310 = null;
 
-        object string_literal305_tree=null;
-        RewriteRuleTokenStream stream_92 = new RewriteRuleTokenStream(adaptor,"token 92");
+        object string_literal310_tree=null;
+        RewriteRuleTokenStream stream_94 = new RewriteRuleTokenStream(adaptor,"token 94");
 
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:537:2: ( '..' -> ^( IM_ENDTAG '..' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:537:4: '..'
             {
-            	string_literal305=(IToken)Match(input,92,FOLLOW_92_in_controls_end3281); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_92.Add(string_literal305);
+            	string_literal310=(IToken)Match(input,94,FOLLOW_94_in_controls_end3306); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_94.Add(string_literal310);
 
 
 
             	// AST REWRITE
-            	// elements:          92
+            	// elements:          94
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -10040,7 +10114,7 @@ public partial class simpletikzParser : Parser
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ENDTAG, "IM_ENDTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_92.NextNode());
+            	    adaptor.AddChild(root_1, stream_94.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -10086,11 +10160,11 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal306 = null;
-        IToken char_literal307 = null;
+        IToken string_literal311 = null;
+        IToken char_literal312 = null;
 
-        object string_literal306_tree=null;
-        object char_literal307_tree=null;
+        object string_literal311_tree=null;
+        object char_literal312_tree=null;
         RewriteRuleTokenStream stream_41 = new RewriteRuleTokenStream(adaptor,"token 41");
         RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
 
@@ -10099,11 +10173,11 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:540:2: ( '\\\\tikzset' '{' -> ^( IM_STARTTAG ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:540:4: '\\\\tikzset' '{'
             {
-            	string_literal306=(IToken)Match(input,41,FOLLOW_41_in_tikz_set_start3299); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_41.Add(string_literal306);
+            	string_literal311=(IToken)Match(input,41,FOLLOW_41_in_tikz_set_start3324); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_41.Add(string_literal311);
 
-            	char_literal307=(IToken)Match(input,43,FOLLOW_43_in_tikz_set_start3301); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal307);
+            	char_literal312=(IToken)Match(input,43,FOLLOW_43_in_tikz_set_start3326); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal312);
 
 
 
@@ -10169,18 +10243,18 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal308 = null;
-        IToken char_literal309 = null;
-        IToken string_literal310 = null;
-        IToken char_literal311 = null;
+        IToken string_literal313 = null;
+        IToken char_literal314 = null;
+        IToken string_literal315 = null;
+        IToken char_literal316 = null;
 
-        object string_literal308_tree=null;
-        object char_literal309_tree=null;
-        object string_literal310_tree=null;
-        object char_literal311_tree=null;
+        object string_literal313_tree=null;
+        object char_literal314_tree=null;
+        object string_literal315_tree=null;
+        object char_literal316_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
         RewriteRuleTokenStream stream_39 = new RewriteRuleTokenStream(adaptor,"token 39");
-        RewriteRuleTokenStream stream_94 = new RewriteRuleTokenStream(adaptor,"token 94");
+        RewriteRuleTokenStream stream_96 = new RewriteRuleTokenStream(adaptor,"token 96");
         RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
 
         try 
@@ -10188,17 +10262,17 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:543:2: ( '\\\\begin' '{' 'tikzpicture' '}' -> ^( IM_STARTTAG '\\\\begin' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:543:4: '\\\\begin' '{' 'tikzpicture' '}'
             {
-            	string_literal308=(IToken)Match(input,39,FOLLOW_39_in_tikzpicture_start3320); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_39.Add(string_literal308);
+            	string_literal313=(IToken)Match(input,39,FOLLOW_39_in_tikzpicture_start3345); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_39.Add(string_literal313);
 
-            	char_literal309=(IToken)Match(input,43,FOLLOW_43_in_tikzpicture_start3322); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal309);
+            	char_literal314=(IToken)Match(input,43,FOLLOW_43_in_tikzpicture_start3347); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal314);
 
-            	string_literal310=(IToken)Match(input,94,FOLLOW_94_in_tikzpicture_start3324); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_94.Add(string_literal310);
+            	string_literal315=(IToken)Match(input,96,FOLLOW_96_in_tikzpicture_start3349); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_96.Add(string_literal315);
 
-            	char_literal311=(IToken)Match(input,44,FOLLOW_44_in_tikzpicture_start3326); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_44.Add(char_literal311);
+            	char_literal316=(IToken)Match(input,44,FOLLOW_44_in_tikzpicture_start3351); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_44.Add(char_literal316);
 
 
 
@@ -10266,9 +10340,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal312 = null;
+        IToken string_literal317 = null;
 
-        object string_literal312_tree=null;
+        object string_literal317_tree=null;
         RewriteRuleTokenStream stream_42 = new RewriteRuleTokenStream(adaptor,"token 42");
 
         try 
@@ -10276,8 +10350,8 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:546:2: ( '\\\\tikz' -> ^( IM_STARTTAG '\\\\tikz' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:546:4: '\\\\tikz'
             {
-            	string_literal312=(IToken)Match(input,42,FOLLOW_42_in_tikz_start3344); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_42.Add(string_literal312);
+            	string_literal317=(IToken)Match(input,42,FOLLOW_42_in_tikz_start3369); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_42.Add(string_literal317);
 
 
 
@@ -10345,18 +10419,18 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal313 = null;
-        IToken char_literal314 = null;
-        IToken string_literal315 = null;
-        IToken char_literal316 = null;
+        IToken string_literal318 = null;
+        IToken char_literal319 = null;
+        IToken string_literal320 = null;
+        IToken char_literal321 = null;
 
-        object string_literal313_tree=null;
-        object char_literal314_tree=null;
-        object string_literal315_tree=null;
-        object char_literal316_tree=null;
+        object string_literal318_tree=null;
+        object char_literal319_tree=null;
+        object string_literal320_tree=null;
+        object char_literal321_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
-        RewriteRuleTokenStream stream_94 = new RewriteRuleTokenStream(adaptor,"token 94");
-        RewriteRuleTokenStream stream_64 = new RewriteRuleTokenStream(adaptor,"token 64");
+        RewriteRuleTokenStream stream_66 = new RewriteRuleTokenStream(adaptor,"token 66");
+        RewriteRuleTokenStream stream_96 = new RewriteRuleTokenStream(adaptor,"token 96");
         RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
 
         try 
@@ -10364,22 +10438,22 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:549:2: ( '\\\\end' '{' 'tikzpicture' '}' -> ^( IM_ENDTAG '\\\\end' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:549:4: '\\\\end' '{' 'tikzpicture' '}'
             {
-            	string_literal313=(IToken)Match(input,64,FOLLOW_64_in_tikzpicture_end3362); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_64.Add(string_literal313);
+            	string_literal318=(IToken)Match(input,66,FOLLOW_66_in_tikzpicture_end3387); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_66.Add(string_literal318);
 
-            	char_literal314=(IToken)Match(input,43,FOLLOW_43_in_tikzpicture_end3364); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal314);
+            	char_literal319=(IToken)Match(input,43,FOLLOW_43_in_tikzpicture_end3389); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal319);
 
-            	string_literal315=(IToken)Match(input,94,FOLLOW_94_in_tikzpicture_end3366); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_94.Add(string_literal315);
+            	string_literal320=(IToken)Match(input,96,FOLLOW_96_in_tikzpicture_end3391); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_96.Add(string_literal320);
 
-            	char_literal316=(IToken)Match(input,44,FOLLOW_44_in_tikzpicture_end3368); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_44.Add(char_literal316);
+            	char_literal321=(IToken)Match(input,44,FOLLOW_44_in_tikzpicture_end3393); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_44.Add(char_literal321);
 
 
 
             	// AST REWRITE
-            	// elements:          64
+            	// elements:          66
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -10396,7 +10470,7 @@ public partial class simpletikzParser : Parser
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ENDTAG, "IM_ENDTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_64.NextNode());
+            	    adaptor.AddChild(root_1, stream_66.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -10442,18 +10516,18 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal317 = null;
-        IToken char_literal318 = null;
-        IToken string_literal319 = null;
-        IToken char_literal320 = null;
+        IToken string_literal322 = null;
+        IToken char_literal323 = null;
+        IToken string_literal324 = null;
+        IToken char_literal325 = null;
 
-        object string_literal317_tree=null;
-        object char_literal318_tree=null;
-        object string_literal319_tree=null;
-        object char_literal320_tree=null;
+        object string_literal322_tree=null;
+        object char_literal323_tree=null;
+        object string_literal324_tree=null;
+        object char_literal325_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
         RewriteRuleTokenStream stream_39 = new RewriteRuleTokenStream(adaptor,"token 39");
-        RewriteRuleTokenStream stream_95 = new RewriteRuleTokenStream(adaptor,"token 95");
+        RewriteRuleTokenStream stream_97 = new RewriteRuleTokenStream(adaptor,"token 97");
         RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
 
         try 
@@ -10461,17 +10535,17 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:552:2: ( '\\\\begin' '{' 'scope' '}' -> ^( IM_STARTTAG '\\\\begin' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:552:4: '\\\\begin' '{' 'scope' '}'
             {
-            	string_literal317=(IToken)Match(input,39,FOLLOW_39_in_tikzscope_start3386); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_39.Add(string_literal317);
+            	string_literal322=(IToken)Match(input,39,FOLLOW_39_in_tikzscope_start3411); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_39.Add(string_literal322);
 
-            	char_literal318=(IToken)Match(input,43,FOLLOW_43_in_tikzscope_start3388); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal318);
+            	char_literal323=(IToken)Match(input,43,FOLLOW_43_in_tikzscope_start3413); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal323);
 
-            	string_literal319=(IToken)Match(input,95,FOLLOW_95_in_tikzscope_start3390); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_95.Add(string_literal319);
+            	string_literal324=(IToken)Match(input,97,FOLLOW_97_in_tikzscope_start3415); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_97.Add(string_literal324);
 
-            	char_literal320=(IToken)Match(input,44,FOLLOW_44_in_tikzscope_start3392); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_44.Add(char_literal320);
+            	char_literal325=(IToken)Match(input,44,FOLLOW_44_in_tikzscope_start3417); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_44.Add(char_literal325);
 
 
 
@@ -10539,18 +10613,18 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal321 = null;
-        IToken char_literal322 = null;
-        IToken string_literal323 = null;
-        IToken char_literal324 = null;
+        IToken string_literal326 = null;
+        IToken char_literal327 = null;
+        IToken string_literal328 = null;
+        IToken char_literal329 = null;
 
-        object string_literal321_tree=null;
-        object char_literal322_tree=null;
-        object string_literal323_tree=null;
-        object char_literal324_tree=null;
+        object string_literal326_tree=null;
+        object char_literal327_tree=null;
+        object string_literal328_tree=null;
+        object char_literal329_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
-        RewriteRuleTokenStream stream_95 = new RewriteRuleTokenStream(adaptor,"token 95");
-        RewriteRuleTokenStream stream_64 = new RewriteRuleTokenStream(adaptor,"token 64");
+        RewriteRuleTokenStream stream_66 = new RewriteRuleTokenStream(adaptor,"token 66");
+        RewriteRuleTokenStream stream_97 = new RewriteRuleTokenStream(adaptor,"token 97");
         RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
 
         try 
@@ -10558,22 +10632,22 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:555:2: ( '\\\\end' '{' 'scope' '}' -> ^( IM_ENDTAG '\\\\end' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:555:4: '\\\\end' '{' 'scope' '}'
             {
-            	string_literal321=(IToken)Match(input,64,FOLLOW_64_in_tikzscope_end3410); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_64.Add(string_literal321);
+            	string_literal326=(IToken)Match(input,66,FOLLOW_66_in_tikzscope_end3435); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_66.Add(string_literal326);
 
-            	char_literal322=(IToken)Match(input,43,FOLLOW_43_in_tikzscope_end3412); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal322);
+            	char_literal327=(IToken)Match(input,43,FOLLOW_43_in_tikzscope_end3437); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal327);
 
-            	string_literal323=(IToken)Match(input,95,FOLLOW_95_in_tikzscope_end3414); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_95.Add(string_literal323);
+            	string_literal328=(IToken)Match(input,97,FOLLOW_97_in_tikzscope_end3439); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_97.Add(string_literal328);
 
-            	char_literal324=(IToken)Match(input,44,FOLLOW_44_in_tikzscope_end3416); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_44.Add(char_literal324);
+            	char_literal329=(IToken)Match(input,44,FOLLOW_44_in_tikzscope_end3441); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_44.Add(char_literal329);
 
 
 
             	// AST REWRITE
-            	// elements:          64
+            	// elements:          66
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -10590,7 +10664,7 @@ public partial class simpletikzParser : Parser
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ENDTAG, "IM_ENDTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_64.NextNode());
+            	    adaptor.AddChild(root_1, stream_66.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -10636,7 +10710,7 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.path_start_tag_return path_start_tag325 = default(simpletikzParser.path_start_tag_return);
+        simpletikzParser.path_start_tag_return path_start_tag330 = default(simpletikzParser.path_start_tag_return);
 
 
         RewriteRuleSubtreeStream stream_path_start_tag = new RewriteRuleSubtreeStream(adaptor,"rule path_start_tag");
@@ -10645,11 +10719,11 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:558:2: ( path_start_tag -> ^( IM_STARTTAG path_start_tag ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:558:4: path_start_tag
             {
-            	PushFollow(FOLLOW_path_start_tag_in_path_start3435);
-            	path_start_tag325 = path_start_tag();
+            	PushFollow(FOLLOW_path_start_tag_in_path_start3460);
+            	path_start_tag330 = path_start_tag();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_path_start_tag.Add(path_start_tag325.Tree);
+            	if ( state.backtracking==0 ) stream_path_start_tag.Add(path_start_tag330.Tree);
 
 
             	// AST REWRITE
@@ -10716,7 +10790,7 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.node_start_tag_return node_start_tag326 = default(simpletikzParser.node_start_tag_return);
+        simpletikzParser.node_start_tag_return node_start_tag331 = default(simpletikzParser.node_start_tag_return);
 
 
         RewriteRuleSubtreeStream stream_node_start_tag = new RewriteRuleSubtreeStream(adaptor,"rule node_start_tag");
@@ -10725,11 +10799,11 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:561:2: ( node_start_tag -> ^( IM_STARTTAG node_start_tag ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:561:4: node_start_tag
             {
-            	PushFollow(FOLLOW_node_start_tag_in_node_start3453);
-            	node_start_tag326 = node_start_tag();
+            	PushFollow(FOLLOW_node_start_tag_in_node_start3478);
+            	node_start_tag331 = node_start_tag();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_node_start_tag.Add(node_start_tag326.Tree);
+            	if ( state.backtracking==0 ) stream_node_start_tag.Add(node_start_tag331.Tree);
 
 
             	// AST REWRITE
@@ -10796,7 +10870,7 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.def_start_tag_return def_start_tag327 = default(simpletikzParser.def_start_tag_return);
+        simpletikzParser.def_start_tag_return def_start_tag332 = default(simpletikzParser.def_start_tag_return);
 
 
         RewriteRuleSubtreeStream stream_def_start_tag = new RewriteRuleSubtreeStream(adaptor,"rule def_start_tag");
@@ -10805,11 +10879,11 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:564:2: ( def_start_tag -> ^( IM_STARTTAG def_start_tag ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:564:4: def_start_tag
             {
-            	PushFollow(FOLLOW_def_start_tag_in_def_start3471);
-            	def_start_tag327 = def_start_tag();
+            	PushFollow(FOLLOW_def_start_tag_in_def_start3496);
+            	def_start_tag332 = def_start_tag();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_def_start_tag.Add(def_start_tag327.Tree);
+            	if ( state.backtracking==0 ) stream_def_start_tag.Add(def_start_tag332.Tree);
 
 
             	// AST REWRITE
@@ -10876,7 +10950,7 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.matrix_start_tag_return matrix_start_tag328 = default(simpletikzParser.matrix_start_tag_return);
+        simpletikzParser.matrix_start_tag_return matrix_start_tag333 = default(simpletikzParser.matrix_start_tag_return);
 
 
         RewriteRuleSubtreeStream stream_matrix_start_tag = new RewriteRuleSubtreeStream(adaptor,"rule matrix_start_tag");
@@ -10885,11 +10959,11 @@ public partial class simpletikzParser : Parser
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:567:2: ( matrix_start_tag -> ^( IM_STARTTAG matrix_start_tag ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:567:4: matrix_start_tag
             {
-            	PushFollow(FOLLOW_matrix_start_tag_in_matrix_start3489);
-            	matrix_start_tag328 = matrix_start_tag();
+            	PushFollow(FOLLOW_matrix_start_tag_in_matrix_start3514);
+            	matrix_start_tag333 = matrix_start_tag();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_matrix_start_tag.Add(matrix_start_tag328.Tree);
+            	if ( state.backtracking==0 ) stream_matrix_start_tag.Add(matrix_start_tag333.Tree);
 
 
             	// AST REWRITE
@@ -10956,9 +11030,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal329 = null;
+        IToken string_literal334 = null;
 
-        object string_literal329_tree=null;
+        object string_literal334_tree=null;
 
         try 
     	{
@@ -10967,10 +11041,10 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	string_literal329=(IToken)Match(input,65,FOLLOW_65_in_node_start_tag3507); if (state.failed) return retval;
+            	string_literal334=(IToken)Match(input,67,FOLLOW_67_in_node_start_tag3532); if (state.failed) return retval;
             	if ( state.backtracking == 0 )
-            	{string_literal329_tree = (object)adaptor.Create(string_literal329);
-            		adaptor.AddChild(root_0, string_literal329_tree);
+            	{string_literal334_tree = (object)adaptor.Create(string_literal334);
+            		adaptor.AddChild(root_0, string_literal334_tree);
             	}
 
             }
@@ -11011,9 +11085,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal330 = null;
+        IToken string_literal335 = null;
 
-        object string_literal330_tree=null;
+        object string_literal335_tree=null;
 
         try 
     	{
@@ -11022,10 +11096,10 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	string_literal330=(IToken)Match(input,70,FOLLOW_70_in_def_start_tag3517); if (state.failed) return retval;
+            	string_literal335=(IToken)Match(input,72,FOLLOW_72_in_def_start_tag3542); if (state.failed) return retval;
             	if ( state.backtracking == 0 )
-            	{string_literal330_tree = (object)adaptor.Create(string_literal330);
-            		adaptor.AddChild(root_0, string_literal330_tree);
+            	{string_literal335_tree = (object)adaptor.Create(string_literal335);
+            		adaptor.AddChild(root_0, string_literal335_tree);
             	}
 
             }
@@ -11066,9 +11140,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal331 = null;
+        IToken string_literal336 = null;
 
-        object string_literal331_tree=null;
+        object string_literal336_tree=null;
 
         try 
     	{
@@ -11077,10 +11151,10 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	string_literal331=(IToken)Match(input,66,FOLLOW_66_in_matrix_start_tag3527); if (state.failed) return retval;
+            	string_literal336=(IToken)Match(input,68,FOLLOW_68_in_matrix_start_tag3552); if (state.failed) return retval;
             	if ( state.backtracking == 0 )
-            	{string_literal331_tree = (object)adaptor.Create(string_literal331);
-            		adaptor.AddChild(root_0, string_literal331_tree);
+            	{string_literal336_tree = (object)adaptor.Create(string_literal336);
+            		adaptor.AddChild(root_0, string_literal336_tree);
             	}
 
             }
@@ -11121,23 +11195,23 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal332 = null;
+        IToken string_literal337 = null;
 
-        object string_literal332_tree=null;
-        RewriteRuleTokenStream stream_67 = new RewriteRuleTokenStream(adaptor,"token 67");
+        object string_literal337_tree=null;
+        RewriteRuleTokenStream stream_69 = new RewriteRuleTokenStream(adaptor,"token 69");
 
         try 
     	{
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:579:2: ( '\\\\coordinate' -> ^( IM_STARTTAG '\\\\coordinate' ) )
             // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:579:4: '\\\\coordinate'
             {
-            	string_literal332=(IToken)Match(input,67,FOLLOW_67_in_coordinate_start3537); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_67.Add(string_literal332);
+            	string_literal337=(IToken)Match(input,69,FOLLOW_69_in_coordinate_start3562); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_69.Add(string_literal337);
 
 
 
             	// AST REWRITE
-            	// elements:          67
+            	// elements:          69
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -11154,7 +11228,7 @@ public partial class simpletikzParser : Parser
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_67.NextNode());
+            	    adaptor.AddChild(root_1, stream_69.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -11200,9 +11274,9 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set333 = null;
+        IToken set338 = null;
 
-        object set333_tree=null;
+        object set338_tree=null;
 
         try 
     	{
@@ -11211,11 +11285,11 @@ public partial class simpletikzParser : Parser
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set333 = (IToken)input.LT(1);
-            	if ( (input.LA(1) >= 68 && input.LA(1) <= 69) || (input.LA(1) >= 71 && input.LA(1) <= 77) ) 
+            	set338 = (IToken)input.LT(1);
+            	if ( (input.LA(1) >= 70 && input.LA(1) <= 71) || (input.LA(1) >= 73 && input.LA(1) <= 79) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set333));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set338));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -11247,13 +11321,11 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred1_simpletikz"
     public void synpred1_simpletikz_fragment() {
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:331:5: ( coord )
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:331:6: coord
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:46: ( 'n' 'args' )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:47: 'n' 'args'
         {
-        	PushFollow(FOLLOW_coord_in_synpred1_simpletikz1889);
-        	coord();
-        	state.followingStackPointer--;
-        	if (state.failed) return ;
+        	Match(input,52,FOLLOW_52_in_synpred1_simpletikz715); if (state.failed) return ;
+        	Match(input,53,FOLLOW_53_in_synpred1_simpletikz717); if (state.failed) return ;
 
         }
     }
@@ -11261,11 +11333,11 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred2_simpletikz"
     public void synpred2_simpletikz_fragment() {
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:8: ( tikzcoordinate_core3 )
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:9: tikzcoordinate_core3
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:331:5: ( coord )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:331:6: coord
         {
-        	PushFollow(FOLLOW_tikzcoordinate_core3_in_synpred2_simpletikz2132);
-        	tikzcoordinate_core3();
+        	PushFollow(FOLLOW_coord_in_synpred2_simpletikz1914);
+        	coord();
         	state.followingStackPointer--;
         	if (state.failed) return ;
 
@@ -11275,11 +11347,11 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred3_simpletikz"
     public void synpred3_simpletikz_fragment() {
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:360:12: ( tikzcoordinate_core2 )
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:360:13: tikzcoordinate_core2
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:8: ( tikzcoordinate_core3 )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:9: tikzcoordinate_core3
         {
-        	PushFollow(FOLLOW_tikzcoordinate_core2_in_synpred3_simpletikz2151);
-        	tikzcoordinate_core2();
+        	PushFollow(FOLLOW_tikzcoordinate_core3_in_synpred3_simpletikz2157);
+        	tikzcoordinate_core3();
         	state.followingStackPointer--;
         	if (state.failed) return ;
 
@@ -11289,11 +11361,11 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred4_simpletikz"
     public void synpred4_simpletikz_fragment() {
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:361:12: ( tikzcoordinate_core1 )
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:361:13: tikzcoordinate_core1
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:360:12: ( tikzcoordinate_core2 )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:360:13: tikzcoordinate_core2
         {
-        	PushFollow(FOLLOW_tikzcoordinate_core1_in_synpred4_simpletikz2171);
-        	tikzcoordinate_core1();
+        	PushFollow(FOLLOW_tikzcoordinate_core2_in_synpred4_simpletikz2176);
+        	tikzcoordinate_core2();
         	state.followingStackPointer--;
         	if (state.failed) return ;
 
@@ -11303,11 +11375,11 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred5_simpletikz"
     public void synpred5_simpletikz_fragment() {
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:21: ( tikzcoordinate_core3 )
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:22: tikzcoordinate_core3
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:361:12: ( tikzcoordinate_core1 )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:361:13: tikzcoordinate_core1
         {
-        	PushFollow(FOLLOW_tikzcoordinate_core3_in_synpred5_simpletikz2256);
-        	tikzcoordinate_core3();
+        	PushFollow(FOLLOW_tikzcoordinate_core1_in_synpred5_simpletikz2196);
+        	tikzcoordinate_core1();
         	state.followingStackPointer--;
         	if (state.failed) return ;
 
@@ -11317,11 +11389,11 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred6_simpletikz"
     public void synpred6_simpletikz_fragment() {
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:371:12: ( tikzcoordinate_core2 )
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:371:13: tikzcoordinate_core2
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:21: ( tikzcoordinate_core3 )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:22: tikzcoordinate_core3
         {
-        	PushFollow(FOLLOW_tikzcoordinate_core2_in_synpred6_simpletikz2275);
-        	tikzcoordinate_core2();
+        	PushFollow(FOLLOW_tikzcoordinate_core3_in_synpred6_simpletikz2281);
+        	tikzcoordinate_core3();
         	state.followingStackPointer--;
         	if (state.failed) return ;
 
@@ -11331,11 +11403,11 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred7_simpletikz"
     public void synpred7_simpletikz_fragment() {
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:372:12: ( tikzcoordinate_core1 )
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:372:13: tikzcoordinate_core1
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:371:12: ( tikzcoordinate_core2 )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:371:13: tikzcoordinate_core2
         {
-        	PushFollow(FOLLOW_tikzcoordinate_core1_in_synpred7_simpletikz2295);
-        	tikzcoordinate_core1();
+        	PushFollow(FOLLOW_tikzcoordinate_core2_in_synpred7_simpletikz2300);
+        	tikzcoordinate_core2();
         	state.followingStackPointer--;
         	if (state.failed) return ;
 
@@ -11345,11 +11417,11 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred8_simpletikz"
     public void synpred8_simpletikz_fragment() {
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:28: ( size )
-        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:29: size
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:372:12: ( tikzcoordinate_core1 )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:372:13: tikzcoordinate_core1
         {
-        	PushFollow(FOLLOW_size_in_synpred8_simpletikz2587);
-        	size();
+        	PushFollow(FOLLOW_tikzcoordinate_core1_in_synpred8_simpletikz2320);
+        	tikzcoordinate_core1();
         	state.followingStackPointer--;
         	if (state.failed) return ;
 
@@ -11357,8 +11429,40 @@ public partial class simpletikzParser : Parser
     }
     // $ANTLR end "synpred8_simpletikz"
 
+    // $ANTLR start "synpred9_simpletikz"
+    public void synpred9_simpletikz_fragment() {
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:28: ( size )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:29: size
+        {
+        	PushFollow(FOLLOW_size_in_synpred9_simpletikz2612);
+        	size();
+        	state.followingStackPointer--;
+        	if (state.failed) return ;
+
+        }
+    }
+    // $ANTLR end "synpred9_simpletikz"
+
     // Delegated rules
 
+   	public bool synpred9_simpletikz() 
+   	{
+   	    state.backtracking++;
+   	    int start = input.Mark();
+   	    try 
+   	    {
+   	        synpred9_simpletikz_fragment(); // can never throw exception
+   	    }
+   	    catch (RecognitionException re) 
+   	    {
+   	        Console.Error.WriteLine("impossible: "+re);
+   	    }
+   	    bool success = !state.failed;
+   	    input.Rewind(start);
+   	    state.backtracking--;
+   	    state.failed = false;
+   	    return success;
+   	}
    	public bool synpred8_simpletikz() 
    	{
    	    state.backtracking++;
@@ -11507,44 +11611,44 @@ public partial class simpletikzParser : Parser
 
    	protected DFA10 dfa10;
    	protected DFA16 dfa16;
-   	protected DFA33 dfa33;
-   	protected DFA34 dfa34;
    	protected DFA35 dfa35;
    	protected DFA36 dfa36;
-   	protected DFA43 dfa43;
-   	protected DFA48 dfa48;
+   	protected DFA37 dfa37;
+   	protected DFA38 dfa38;
+   	protected DFA45 dfa45;
    	protected DFA50 dfa50;
-   	protected DFA57 dfa57;
-   	protected DFA60 dfa60;
-   	protected DFA67 dfa67;
-   	protected DFA70 dfa70;
-   	protected DFA73 dfa73;
+   	protected DFA52 dfa52;
+   	protected DFA59 dfa59;
+   	protected DFA62 dfa62;
+   	protected DFA69 dfa69;
+   	protected DFA72 dfa72;
+   	protected DFA75 dfa75;
 	private void InitializeCyclicDFAs()
 	{
     	this.dfa10 = new DFA10(this);
     	this.dfa16 = new DFA16(this);
-    	this.dfa33 = new DFA33(this);
-    	this.dfa34 = new DFA34(this);
     	this.dfa35 = new DFA35(this);
     	this.dfa36 = new DFA36(this);
-    	this.dfa43 = new DFA43(this);
-    	this.dfa48 = new DFA48(this);
+    	this.dfa37 = new DFA37(this);
+    	this.dfa38 = new DFA38(this);
+    	this.dfa45 = new DFA45(this);
     	this.dfa50 = new DFA50(this);
-    	this.dfa57 = new DFA57(this);
-    	this.dfa60 = new DFA60(this);
-    	this.dfa67 = new DFA67(this);
-    	this.dfa70 = new DFA70(this);
-    	this.dfa73 = new DFA73(this);
+    	this.dfa52 = new DFA52(this);
+    	this.dfa59 = new DFA59(this);
+    	this.dfa62 = new DFA62(this);
+    	this.dfa69 = new DFA69(this);
+    	this.dfa72 = new DFA72(this);
+    	this.dfa75 = new DFA75(this);
 
 
 
 
 
 
-	    this.dfa43.specialStateTransitionHandler = new DFA.SpecialStateTransitionHandler(DFA43_SpecialStateTransition);
-	    this.dfa48.specialStateTransitionHandler = new DFA.SpecialStateTransitionHandler(DFA48_SpecialStateTransition);
+	    this.dfa45.specialStateTransitionHandler = new DFA.SpecialStateTransitionHandler(DFA45_SpecialStateTransition);
 	    this.dfa50.specialStateTransitionHandler = new DFA.SpecialStateTransitionHandler(DFA50_SpecialStateTransition);
-	    this.dfa57.specialStateTransitionHandler = new DFA.SpecialStateTransitionHandler(DFA57_SpecialStateTransition);
+	    this.dfa52.specialStateTransitionHandler = new DFA.SpecialStateTransitionHandler(DFA52_SpecialStateTransition);
+	    this.dfa59.specialStateTransitionHandler = new DFA.SpecialStateTransitionHandler(DFA59_SpecialStateTransition);
 
 
 
@@ -11558,15 +11662,15 @@ public partial class simpletikzParser : Parser
     const string DFA10_minS =
         "\x02\x04\x02\uffff";
     const string DFA10_maxS =
-        "\x02\x5f\x02\uffff";
+        "\x02\x61\x02\uffff";
     const string DFA10_acceptS =
         "\x02\uffff\x01\x02\x01\x01";
     const string DFA10_specialS =
         "\x04\uffff}>";
     static readonly string[] DFA10_transitionS = {
-            "\x27\x01\x03\uffff\x01\x01\x04\uffff\x02\x01\x05\uffff\x26"+
+            "\x27\x01\x03\uffff\x01\x01\x04\uffff\x04\x01\x05\uffff\x26"+
             "\x01",
-            "\x27\x01\x03\x02\x01\x01\x01\x02\x01\uffff\x02\x03\x02\x01"+
+            "\x27\x01\x03\x02\x01\x01\x01\x02\x01\uffff\x02\x03\x04\x01"+
             "\x03\uffff\x01\x02\x01\uffff\x26\x01",
             "",
             ""
@@ -11608,109 +11712,109 @@ public partial class simpletikzParser : Parser
     const string DFA16_eofS =
         "\x39\uffff";
     const string DFA16_minS =
-        "\x01\x04\x01\x2b\x01\x04\x01\uffff\x01\x2b\x01\x1e\x01\uffff\x02"+
-        "\x04\x02\uffff\x10\x04\x01\uffff\x1d\x04";
+        "\x01\x04\x01\x2b\x01\x04\x01\uffff\x01\x2b\x01\x1e\x01\uffff\x01"+
+        "\x04\x01\uffff\x01\x04\x01\uffff\x0c\x04\x01\uffff\x21\x04";
     const string DFA16_maxS =
-        "\x01\x5f\x01\x3f\x01\x5f\x01\uffff\x01\x38\x01\x2b\x01\uffff\x02"+
-        "\x5f\x02\uffff\x10\x5f\x01\uffff\x1d\x5f";
+        "\x01\x61\x01\x41\x01\x61\x01\uffff\x01\x3a\x01\x2b\x01\uffff\x01"+
+        "\x61\x01\uffff\x01\x61\x01\uffff\x0c\x61\x01\uffff\x21\x61";
     const string DFA16_acceptS =
-        "\x03\uffff\x01\x04\x02\uffff\x01\x02\x02\uffff\x01\x05\x01\x01"+
-        "\x10\uffff\x01\x03\x1d\uffff";
+        "\x03\uffff\x01\x04\x02\uffff\x01\x02\x01\uffff\x01\x05\x01\uffff"+
+        "\x01\x01\x0c\uffff\x01\x03\x21\uffff";
     const string DFA16_specialS =
         "\x39\uffff}>";
     static readonly string[] DFA16_transitionS = {
             "\x1a\x03\x02\x01\x0b\x03\x01\x02\x02\uffff\x01\x03\x04\uffff"+
-            "\x02\x03\x05\uffff\x26\x03",
-            "\x02\x06\x02\uffff\x01\x06\x01\x05\x07\uffff\x01\x06\x01\uffff"+
+            "\x04\x03\x05\uffff\x26\x03",
+            "\x02\x06\x02\uffff\x01\x06\x01\x05\x09\uffff\x01\x06\x01\uffff"+
             "\x06\x04",
-            "\x31\x09\x01\x07\x24\x09\x02\x08\x04\x09",
+            "\x33\x08\x01\x07\x24\x08\x02\x09\x04\x08",
             "",
-            "\x02\x06\x02\uffff\x01\x06\x01\x0a\x07\uffff\x01\x06",
-            "\x02\x0a\x0b\uffff\x01\x09",
+            "\x02\x06\x02\uffff\x01\x06\x01\x0a\x09\uffff\x01\x06",
+            "\x02\x0a\x0b\uffff\x01\x08",
             "",
-            "\x1a\x0c\x02\x0b\x0b\x0c\x01\x0d\x02\x09\x01\x0c\x04\x09\x02"+
-            "\x0c\x05\x09\x26\x0c",
-            "\x31\x09\x01\x0e\x2a\x09",
+            "\x1a\x0d\x02\x0b\x0b\x0d\x01\x0c\x02\x08\x01\x0d\x04\x08\x04"+
+            "\x0d\x05\x08\x26\x0d",
             "",
+            "\x33\x08\x01\x0e\x2a\x08",
             "",
-            "\x27\x0c\x02\x09\x01\x0f\x01\x0c\x02\x11\x02\x09\x02\x0c\x01"+
-            "\x09\x01\x12\x03\x09\x06\x10\x20\x0c",
-            "\x27\x0c\x02\x09\x01\x0f\x01\x0c\x02\x13\x02\x09\x02\x0c\x01"+
-            "\x09\x01\x12\x03\x09\x26\x0c",
-            "\x27\x14\x03\x09\x01\x14\x04\x09\x02\x14\x05\x09\x26\x14",
-            "\x1a\x16\x02\x15\x0b\x16\x01\x0d\x02\x09\x01\x16\x04\x09\x02"+
-            "\x16\x05\x09\x26\x16",
-            "\x1a\x09\x02\x17\x40\x09",
-            "\x27\x0c\x02\x09\x01\x0f\x01\x0c\x02\x11\x02\x09\x02\x0c\x01"+
-            "\x09\x01\x12\x03\x09\x26\x0c",
-            "\x1a\x1a\x02\x18\x0b\x1a\x01\x19\x02\x09\x01\x1a\x04\x09\x02"+
-            "\x1a\x05\x09\x26\x1a",
-            "\x28\x09\x01\x1b\x33\x09",
-            "\x27\x1a\x01\x19\x02\x09\x01\x1a\x04\x09\x02\x1a\x05\x09\x26"+
+            "\x27\x0d\x02\x08\x01\x11\x01\x0d\x02\x12\x02\x08\x04\x0d\x01"+
+            "\x08\x01\x0f\x03\x08\x06\x10\x20\x0d",
+            "\x27\x13\x03\x08\x01\x13\x04\x08\x04\x13\x05\x08\x26\x13",
+            "\x27\x0d\x02\x08\x01\x11\x01\x0d\x02\x14\x02\x08\x04\x0d\x01"+
+            "\x08\x01\x0f\x03\x08\x26\x0d",
+            "\x1a\x16\x02\x15\x0b\x16\x01\x0c\x02\x08\x01\x16\x04\x08\x04"+
+            "\x16\x05\x08\x26\x16",
+            "\x28\x08\x01\x17\x35\x08",
+            "\x27\x0d\x02\x08\x01\x11\x01\x0d\x02\x12\x02\x08\x04\x0d\x01"+
+            "\x08\x01\x0f\x03\x08\x26\x0d",
+            "\x1a\x08\x02\x18\x42\x08",
+            "\x1a\x1a\x02\x19\x0b\x1a\x01\x1b\x02\x08\x01\x1a\x04\x08\x04"+
+            "\x1a\x05\x08\x26\x1a",
+            "\x27\x13\x01\x08\x01\x1c\x01\x08\x01\x13\x04\x08\x04\x13\x05"+
+            "\x08\x26\x13",
+            "\x27\x1a\x01\x1b\x02\x08\x01\x1a\x04\x08\x04\x1a\x05\x08\x26"+
             "\x1a",
-            "\x27\x14\x01\x09\x01\x1c\x01\x09\x01\x14\x04\x09\x02\x14\x05"+
-            "\x09\x26\x14",
-            "\x27\x16\x02\x09\x01\x0f\x01\x16\x02\x11\x02\x09\x02\x16\x05"+
-            "\x09\x06\x1d\x20\x16",
-            "\x27\x16\x02\x09\x01\x0f\x01\x16\x02\x13\x02\x09\x02\x16\x05"+
-            "\x09\x26\x16",
-            "\x27\x20\x03\x09\x01\x20\x01\x1f\x01\x13\x02\x09\x02\x20\x05"+
-            "\x09\x06\x1e\x20\x20",
-            "\x27\x1a\x02\x09\x01\x23\x01\x1a\x04\x09\x02\x1a\x01\x09\x01"+
-            "\x21\x03\x09\x06\x22\x20\x1a",
-            "\x27\x24\x03\x09\x01\x24\x04\x09\x02\x24\x05\x09\x26\x24",
-            "\x27\x1a\x02\x09\x01\x23\x01\x1a\x04\x09\x02\x1a\x01\x09\x01"+
-            "\x25\x03\x09\x26\x1a",
+            "\x27\x16\x02\x08\x01\x11\x01\x16\x02\x12\x02\x08\x04\x16\x05"+
+            "\x08\x06\x1d\x20\x16",
+            "\x27\x16\x02\x08\x01\x11\x01\x16\x02\x14\x02\x08\x04\x16\x05"+
+            "\x08\x26\x16",
             "",
-            "\x2b\x09\x02\x26\x2f\x09",
-            "\x27\x16\x02\x09\x01\x0f\x01\x16\x02\x11\x02\x09\x02\x16\x05"+
-            "\x09\x26\x16",
-            "\x27\x20\x02\x09\x01\x0f\x01\x20\x01\x1f\x01\x13\x02\x09\x02"+
-            "\x20\x05\x09\x26\x20",
-            "\x27\x27\x01\x19\x02\x09\x01\x27\x02\x13\x02\x09\x02\x27\x05"+
-            "\x09\x26\x27",
-            "\x27\x20\x02\x09\x01\x0f\x01\x20\x04\x09\x02\x20\x05\x09\x26"+
+            "\x27\x20\x03\x08\x01\x20\x01\x1f\x01\x14\x02\x08\x04\x20\x05"+
+            "\x08\x06\x1e\x20\x20",
+            "\x27\x1a\x02\x08\x01\x23\x01\x1a\x04\x08\x04\x1a\x01\x08\x01"+
+            "\x22\x03\x08\x06\x21\x20\x1a",
+            "\x27\x1a\x02\x08\x01\x23\x01\x1a\x04\x08\x04\x1a\x01\x08\x01"+
+            "\x24\x03\x08\x26\x1a",
+            "\x27\x25\x03\x08\x01\x25\x04\x08\x04\x25\x05\x08\x26\x25",
+            "\x2b\x08\x02\x26\x31\x08",
+            "\x27\x16\x02\x08\x01\x11\x01\x16\x02\x12\x02\x08\x04\x16\x05"+
+            "\x08\x26\x16",
+            "\x27\x20\x02\x08\x01\x11\x01\x20\x01\x1f\x01\x14\x02\x08\x04"+
+            "\x20\x05\x08\x26\x20",
+            "\x27\x27\x01\x1b\x02\x08\x01\x27\x02\x14\x02\x08\x04\x27\x05"+
+            "\x08\x26\x27",
+            "\x27\x20\x02\x08\x01\x11\x01\x20\x04\x08\x04\x20\x05\x08\x26"+
             "\x20",
-            "\x28\x09\x01\x1b\x33\x09",
-            "\x27\x1a\x02\x09\x01\x23\x01\x1a\x04\x09\x02\x1a\x01\x09\x01"+
-            "\x21\x03\x09\x26\x1a",
-            "\x1a\x09\x02\x28\x40\x09",
-            "\x27\x24\x01\x09\x01\x29\x01\x09\x01\x24\x04\x09\x02\x24\x05"+
-            "\x09\x26\x24",
-            "\x28\x09\x01\x1b\x33\x09",
-            "\x27\x2a\x01\x19\x02\x09\x01\x2a\x04\x09\x02\x2a\x05\x09\x26"+
+            "\x27\x1a\x02\x08\x01\x23\x01\x1a\x04\x08\x04\x1a\x01\x08\x01"+
+            "\x22\x03\x08\x26\x1a",
+            "\x28\x08\x01\x17\x35\x08",
+            "\x1a\x08\x02\x28\x42\x08",
+            "\x28\x08\x01\x17\x35\x08",
+            "\x27\x25\x01\x08\x01\x29\x01\x08\x01\x25\x04\x08\x04\x25\x05"+
+            "\x08\x26\x25",
+            "\x27\x2a\x01\x1b\x02\x08\x01\x2a\x04\x08\x04\x2a\x05\x08\x26"+
             "\x2a",
-            "\x27\x27\x02\x09\x01\x2b\x01\x27\x04\x09\x02\x27\x01\x09\x01"+
-            "\x25\x03\x09\x26\x27",
-            "\x27\x2e\x03\x09\x01\x2e\x01\x2d\x03\x09\x02\x2e\x01\x09\x01"+
-            "\x25\x03\x09\x06\x2c\x20\x2e",
-            "\x32\x09\x01\x2f\x29\x09",
-            "\x27\x2a\x02\x09\x01\x30\x01\x2a\x04\x09\x02\x2a\x01\x09\x01"+
-            "\x2f\x03\x09\x26\x2a",
-            "\x1a\x09\x02\x31\x40\x09",
-            "\x27\x2e\x02\x09\x01\x23\x01\x2e\x01\x2d\x03\x09\x02\x2e\x01"+
-            "\x09\x01\x25\x03\x09\x26\x2e",
-            "\x27\x2e\x03\x09\x01\x2e\x04\x09\x02\x2e\x01\x09\x01\x25\x03"+
-            "\x09\x26\x2e",
-            "\x27\x2e\x02\x09\x01\x23\x01\x2e\x04\x09\x02\x2e\x05\x09\x26"+
+            "\x27\x27\x02\x08\x01\x2b\x01\x27\x04\x08\x04\x27\x01\x08\x01"+
+            "\x24\x03\x08\x26\x27",
+            "\x27\x2e\x03\x08\x01\x2e\x01\x2d\x03\x08\x04\x2e\x01\x08\x01"+
+            "\x24\x03\x08\x06\x2c\x20\x2e",
+            "\x34\x08\x01\x2f\x29\x08",
+            "\x27\x2a\x02\x08\x01\x30\x01\x2a\x04\x08\x04\x2a\x01\x08\x01"+
+            "\x2f\x03\x08\x26\x2a",
+            "\x1a\x08\x02\x31\x42\x08",
+            "\x27\x2e\x02\x08\x01\x23\x01\x2e\x01\x2d\x03\x08\x04\x2e\x01"+
+            "\x08\x01\x24\x03\x08\x26\x2e",
+            "\x27\x2e\x03\x08\x01\x2e\x04\x08\x04\x2e\x01\x08\x01\x24\x03"+
+            "\x08\x26\x2e",
+            "\x27\x2e\x02\x08\x01\x23\x01\x2e\x04\x08\x04\x2e\x05\x08\x26"+
             "\x2e",
-            "\x28\x09\x01\x1b\x33\x09",
-            "\x1a\x09\x02\x32\x40\x09",
-            "\x27\x35\x03\x09\x01\x35\x01\x34\x01\x13\x02\x09\x02\x35\x01"+
-            "\x09\x01\x25\x03\x09\x06\x33\x20\x35",
-            "\x27\x38\x03\x09\x01\x38\x01\x37\x03\x09\x02\x38\x01\x09\x01"+
-            "\x2f\x03\x09\x06\x36\x20\x38",
-            "\x27\x35\x02\x09\x01\x2b\x01\x35\x01\x34\x01\x13\x02\x09\x02"+
-            "\x35\x01\x09\x01\x25\x03\x09\x26\x35",
-            "\x27\x27\x01\x19\x02\x09\x01\x27\x02\x13\x02\x09\x02\x27\x01"+
-            "\x09\x01\x25\x03\x09\x26\x27",
-            "\x27\x35\x02\x09\x01\x2b\x01\x35\x04\x09\x02\x35\x05\x09\x26"+
+            "\x28\x08\x01\x17\x35\x08",
+            "\x1a\x08\x02\x32\x42\x08",
+            "\x27\x35\x03\x08\x01\x35\x01\x34\x01\x14\x02\x08\x04\x35\x01"+
+            "\x08\x01\x24\x03\x08\x06\x33\x20\x35",
+            "\x27\x38\x03\x08\x01\x38\x01\x37\x03\x08\x04\x38\x01\x08\x01"+
+            "\x2f\x03\x08\x06\x36\x20\x38",
+            "\x27\x35\x02\x08\x01\x2b\x01\x35\x01\x34\x01\x14\x02\x08\x04"+
+            "\x35\x01\x08\x01\x24\x03\x08\x26\x35",
+            "\x27\x27\x01\x1b\x02\x08\x01\x27\x02\x14\x02\x08\x04\x27\x01"+
+            "\x08\x01\x24\x03\x08\x26\x27",
+            "\x27\x35\x02\x08\x01\x2b\x01\x35\x04\x08\x04\x35\x05\x08\x26"+
             "\x35",
-            "\x27\x38\x02\x09\x01\x30\x01\x38\x01\x37\x03\x09\x02\x38\x01"+
-            "\x09\x01\x2f\x03\x09\x26\x38",
-            "\x27\x38\x03\x09\x01\x38\x04\x09\x02\x38\x01\x09\x01\x2f\x03"+
-            "\x09\x26\x38",
-            "\x27\x38\x02\x09\x01\x30\x01\x38\x04\x09\x02\x38\x05\x09\x26"+
+            "\x27\x38\x02\x08\x01\x30\x01\x38\x01\x37\x03\x08\x04\x38\x01"+
+            "\x08\x01\x2f\x03\x08\x26\x38",
+            "\x27\x38\x03\x08\x01\x38\x04\x08\x04\x38\x01\x08\x01\x2f\x03"+
+            "\x08\x26\x38",
+            "\x27\x38\x02\x08\x01\x30\x01\x38\x04\x08\x04\x38\x05\x08\x26"+
             "\x38"
     };
 
@@ -11745,21 +11849,21 @@ public partial class simpletikzParser : Parser
 
     }
 
-    const string DFA33_eotS =
+    const string DFA35_eotS =
         "\x0e\uffff";
-    const string DFA33_eofS =
+    const string DFA35_eofS =
         "\x0e\uffff";
-    const string DFA33_minS =
+    const string DFA35_minS =
         "\x01\x04\x01\x2b\x09\uffff\x01\x1c\x02\uffff";
-    const string DFA33_maxS =
-        "\x01\x5f\x01\x2b\x09\uffff\x01\x5f\x02\uffff";
-    const string DFA33_acceptS =
+    const string DFA35_maxS =
+        "\x01\x61\x01\x2b\x09\uffff\x01\x61\x02\uffff";
+    const string DFA35_acceptS =
         "\x02\uffff\x01\x02\x01\x03\x01\x04\x01\x05\x01\x06\x01\x07\x01"+
         "\x08\x01\x0a\x01\x0b\x01\uffff\x01\x01\x01\x09";
-    const string DFA33_specialS =
+    const string DFA35_specialS =
         "\x0e\uffff}>";
-    static readonly string[] DFA33_transitionS = {
-            "\x23\x0a\x01\x01\x01\x08\x01\x07\x0d\x0a\x01\uffff\x08\x0a"+
+    static readonly string[] DFA35_transitionS = {
+            "\x23\x0a\x01\x01\x01\x08\x01\x07\x0f\x0a\x01\uffff\x08\x0a"+
             "\x01\x09\x01\x03\x01\x05\x01\x06\x02\x02\x01\x04\x07\x02\x12"+
             "\x0a",
             "\x01\x0b",
@@ -11772,135 +11876,7 @@ public partial class simpletikzParser : Parser
             "",
             "",
             "",
-            "\x01\x0d\x42\uffff\x01\x0c",
-            "",
-            ""
-    };
-
-    static readonly short[] DFA33_eot = DFA.UnpackEncodedString(DFA33_eotS);
-    static readonly short[] DFA33_eof = DFA.UnpackEncodedString(DFA33_eofS);
-    static readonly char[] DFA33_min = DFA.UnpackEncodedStringToUnsignedChars(DFA33_minS);
-    static readonly char[] DFA33_max = DFA.UnpackEncodedStringToUnsignedChars(DFA33_maxS);
-    static readonly short[] DFA33_accept = DFA.UnpackEncodedString(DFA33_acceptS);
-    static readonly short[] DFA33_special = DFA.UnpackEncodedString(DFA33_specialS);
-    static readonly short[][] DFA33_transition = DFA.UnpackEncodedStringArray(DFA33_transitionS);
-
-    protected class DFA33 : DFA
-    {
-        public DFA33(BaseRecognizer recognizer)
-        {
-            this.recognizer = recognizer;
-            this.decisionNumber = 33;
-            this.eot = DFA33_eot;
-            this.eof = DFA33_eof;
-            this.min = DFA33_min;
-            this.max = DFA33_max;
-            this.accept = DFA33_accept;
-            this.special = DFA33_special;
-            this.transition = DFA33_transition;
-
-        }
-
-        override public string Description
-        {
-            get { return "248:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr )"; }
-        }
-
-    }
-
-    const string DFA34_eotS =
-        "\x11\uffff";
-    const string DFA34_eofS =
-        "\x11\uffff";
-    const string DFA34_minS =
-        "\x01\x04\x02\x2b\x08\uffff\x02\x1c\x04\uffff";
-    const string DFA34_maxS =
-        "\x01\x5f\x02\x2b\x08\uffff\x02\x5f\x04\uffff";
-    const string DFA34_acceptS =
-        "\x03\uffff\x01\x02\x01\x03\x01\x04\x01\x05\x01\x06\x01\x07\x01"+
-        "\x08\x01\x0b\x02\uffff\x01\x0c\x01\x0a\x01\x01\x01\x09";
-    const string DFA34_specialS =
-        "\x11\uffff}>";
-    static readonly string[] DFA34_transitionS = {
-            "\x23\x0a\x01\x02\x01\x09\x01\x08\x16\x0a\x01\x01\x01\x04\x01"+
-            "\x06\x01\x07\x02\x03\x01\x05\x07\x03\x12\x0a",
-            "\x01\x0b",
-            "\x01\x0c",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "\x01\x0e\x41\uffff\x02\x0d",
-            "\x01\x10\x42\uffff\x01\x0f",
-            "",
-            "",
-            "",
-            ""
-    };
-
-    static readonly short[] DFA34_eot = DFA.UnpackEncodedString(DFA34_eotS);
-    static readonly short[] DFA34_eof = DFA.UnpackEncodedString(DFA34_eofS);
-    static readonly char[] DFA34_min = DFA.UnpackEncodedStringToUnsignedChars(DFA34_minS);
-    static readonly char[] DFA34_max = DFA.UnpackEncodedStringToUnsignedChars(DFA34_maxS);
-    static readonly short[] DFA34_accept = DFA.UnpackEncodedString(DFA34_acceptS);
-    static readonly short[] DFA34_special = DFA.UnpackEncodedString(DFA34_specialS);
-    static readonly short[][] DFA34_transition = DFA.UnpackEncodedStringArray(DFA34_transitionS);
-
-    protected class DFA34 : DFA
-    {
-        public DFA34(BaseRecognizer recognizer)
-        {
-            this.recognizer = recognizer;
-            this.decisionNumber = 34;
-            this.eot = DFA34_eot;
-            this.eof = DFA34_eof;
-            this.min = DFA34_min;
-            this.max = DFA34_max;
-            this.accept = DFA34_accept;
-            this.special = DFA34_special;
-            this.transition = DFA34_transition;
-
-        }
-
-        override public string Description
-        {
-            get { return "()* loopback of 249:3: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body )*"; }
-        }
-
-    }
-
-    const string DFA35_eotS =
-        "\x0e\uffff";
-    const string DFA35_eofS =
-        "\x0e\uffff";
-    const string DFA35_minS =
-        "\x01\x04\x01\x2b\x09\uffff\x01\x1c\x02\uffff";
-    const string DFA35_maxS =
-        "\x01\x5f\x01\x2b\x09\uffff\x01\x5f\x02\uffff";
-    const string DFA35_acceptS =
-        "\x02\uffff\x01\x02\x01\x03\x01\x04\x01\x05\x01\x06\x01\x07\x01"+
-        "\x08\x01\x0a\x01\x0b\x01\uffff\x01\x01\x01\x09";
-    const string DFA35_specialS =
-        "\x0e\uffff}>";
-    static readonly string[] DFA35_transitionS = {
-            "\x23\x0a\x01\x01\x01\x08\x01\x07\x01\x0a\x02\uffff\x0a\x0a"+
-            "\x01\uffff\x08\x0a\x01\x09\x01\x03\x01\x05\x01\x06\x02\x02\x01"+
-            "\x04\x07\x02\x12\x0a",
-            "\x01\x0b",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "\x01\x0d\x42\uffff\x01\x0c",
+            "\x01\x0d\x44\uffff\x01\x0c",
             "",
             ""
     };
@@ -11931,29 +11907,28 @@ public partial class simpletikzParser : Parser
 
         override public string Description
         {
-            get { return "252:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr2 )"; }
+            get { return "248:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr )"; }
         }
 
     }
 
     const string DFA36_eotS =
-        "\x0f\uffff";
+        "\x11\uffff";
     const string DFA36_eofS =
-        "\x0f\uffff";
+        "\x11\uffff";
     const string DFA36_minS =
-        "\x01\x04\x01\uffff\x01\x2b\x09\uffff\x01\x1c\x02\uffff";
+        "\x01\x04\x02\x2b\x08\uffff\x02\x1c\x04\uffff";
     const string DFA36_maxS =
-        "\x01\x5f\x01\uffff\x01\x2b\x09\uffff\x01\x5f\x02\uffff";
+        "\x01\x61\x02\x2b\x08\uffff\x02\x61\x04\uffff";
     const string DFA36_acceptS =
-        "\x01\uffff\x01\x0c\x01\uffff\x01\x02\x01\x03\x01\x04\x01\x05\x01"+
-        "\x06\x01\x07\x01\x08\x01\x0a\x01\x0b\x01\uffff\x01\x01\x01\x09";
+        "\x03\uffff\x01\x02\x01\x03\x01\x04\x01\x05\x01\x06\x01\x07\x01"+
+        "\x08\x01\x0b\x02\uffff\x01\x0c\x01\x0a\x01\x01\x01\x09";
     const string DFA36_specialS =
-        "\x0f\uffff}>";
+        "\x11\uffff}>";
     static readonly string[] DFA36_transitionS = {
-            "\x23\x0b\x01\x02\x01\x09\x01\x08\x01\x0b\x01\uffff\x01\x01"+
-            "\x13\x0b\x01\x0a\x01\x04\x01\x06\x01\x07\x02\x03\x01\x05\x07"+
-            "\x03\x12\x0b",
-            "",
+            "\x23\x0a\x01\x02\x01\x09\x01\x08\x18\x0a\x01\x01\x01\x04\x01"+
+            "\x06\x01\x07\x02\x03\x01\x05\x07\x03\x12\x0a",
+            "\x01\x0b",
             "\x01\x0c",
             "",
             "",
@@ -11963,8 +11938,10 @@ public partial class simpletikzParser : Parser
             "",
             "",
             "",
+            "\x01\x0e\x43\uffff\x02\x0d",
+            "\x01\x10\x44\uffff\x01\x0f",
             "",
-            "\x01\x0e\x42\uffff\x01\x0d",
+            "",
             "",
             ""
     };
@@ -11995,26 +11972,153 @@ public partial class simpletikzParser : Parser
 
         override public string Description
         {
+            get { return "()* loopback of 249:3: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body )*"; }
+        }
+
+    }
+
+    const string DFA37_eotS =
+        "\x0e\uffff";
+    const string DFA37_eofS =
+        "\x0e\uffff";
+    const string DFA37_minS =
+        "\x01\x04\x01\x2b\x09\uffff\x01\x1c\x02\uffff";
+    const string DFA37_maxS =
+        "\x01\x61\x01\x2b\x09\uffff\x01\x61\x02\uffff";
+    const string DFA37_acceptS =
+        "\x02\uffff\x01\x02\x01\x03\x01\x04\x01\x05\x01\x06\x01\x07\x01"+
+        "\x08\x01\x0a\x01\x0b\x01\uffff\x01\x01\x01\x09";
+    const string DFA37_specialS =
+        "\x0e\uffff}>";
+    static readonly string[] DFA37_transitionS = {
+            "\x23\x0a\x01\x01\x01\x08\x01\x07\x01\x0a\x02\uffff\x0c\x0a"+
+            "\x01\uffff\x08\x0a\x01\x09\x01\x03\x01\x05\x01\x06\x02\x02\x01"+
+            "\x04\x07\x02\x12\x0a",
+            "\x01\x0b",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "\x01\x0d\x44\uffff\x01\x0c",
+            "",
+            ""
+    };
+
+    static readonly short[] DFA37_eot = DFA.UnpackEncodedString(DFA37_eotS);
+    static readonly short[] DFA37_eof = DFA.UnpackEncodedString(DFA37_eofS);
+    static readonly char[] DFA37_min = DFA.UnpackEncodedStringToUnsignedChars(DFA37_minS);
+    static readonly char[] DFA37_max = DFA.UnpackEncodedStringToUnsignedChars(DFA37_maxS);
+    static readonly short[] DFA37_accept = DFA.UnpackEncodedString(DFA37_acceptS);
+    static readonly short[] DFA37_special = DFA.UnpackEncodedString(DFA37_specialS);
+    static readonly short[][] DFA37_transition = DFA.UnpackEncodedStringArray(DFA37_transitionS);
+
+    protected class DFA37 : DFA
+    {
+        public DFA37(BaseRecognizer recognizer)
+        {
+            this.recognizer = recognizer;
+            this.decisionNumber = 37;
+            this.eot = DFA37_eot;
+            this.eof = DFA37_eof;
+            this.min = DFA37_min;
+            this.max = DFA37_max;
+            this.accept = DFA37_accept;
+            this.special = DFA37_special;
+            this.transition = DFA37_transition;
+
+        }
+
+        override public string Description
+        {
+            get { return "252:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr2 )"; }
+        }
+
+    }
+
+    const string DFA38_eotS =
+        "\x0f\uffff";
+    const string DFA38_eofS =
+        "\x0f\uffff";
+    const string DFA38_minS =
+        "\x01\x04\x01\uffff\x01\x2b\x09\uffff\x01\x1c\x02\uffff";
+    const string DFA38_maxS =
+        "\x01\x61\x01\uffff\x01\x2b\x09\uffff\x01\x61\x02\uffff";
+    const string DFA38_acceptS =
+        "\x01\uffff\x01\x0c\x01\uffff\x01\x02\x01\x03\x01\x04\x01\x05\x01"+
+        "\x06\x01\x07\x01\x08\x01\x0a\x01\x0b\x01\uffff\x01\x01\x01\x09";
+    const string DFA38_specialS =
+        "\x0f\uffff}>";
+    static readonly string[] DFA38_transitionS = {
+            "\x23\x0b\x01\x02\x01\x09\x01\x08\x01\x0b\x01\uffff\x01\x01"+
+            "\x15\x0b\x01\x0a\x01\x04\x01\x06\x01\x07\x02\x03\x01\x05\x07"+
+            "\x03\x12\x0b",
+            "",
+            "\x01\x0c",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "\x01\x0e\x44\uffff\x01\x0d",
+            "",
+            ""
+    };
+
+    static readonly short[] DFA38_eot = DFA.UnpackEncodedString(DFA38_eotS);
+    static readonly short[] DFA38_eof = DFA.UnpackEncodedString(DFA38_eofS);
+    static readonly char[] DFA38_min = DFA.UnpackEncodedStringToUnsignedChars(DFA38_minS);
+    static readonly char[] DFA38_max = DFA.UnpackEncodedStringToUnsignedChars(DFA38_maxS);
+    static readonly short[] DFA38_accept = DFA.UnpackEncodedString(DFA38_acceptS);
+    static readonly short[] DFA38_special = DFA.UnpackEncodedString(DFA38_specialS);
+    static readonly short[][] DFA38_transition = DFA.UnpackEncodedStringArray(DFA38_transitionS);
+
+    protected class DFA38 : DFA
+    {
+        public DFA38(BaseRecognizer recognizer)
+        {
+            this.recognizer = recognizer;
+            this.decisionNumber = 38;
+            this.eot = DFA38_eot;
+            this.eof = DFA38_eof;
+            this.min = DFA38_min;
+            this.max = DFA38_max;
+            this.accept = DFA38_accept;
+            this.special = DFA38_special;
+            this.transition = DFA38_transition;
+
+        }
+
+        override public string Description
+        {
             get { return "()* loopback of 253:3: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body2 )*"; }
         }
 
     }
 
-    const string DFA43_eotS =
+    const string DFA45_eotS =
         "\x0e\uffff";
-    const string DFA43_eofS =
+    const string DFA45_eofS =
         "\x0e\uffff";
-    const string DFA43_minS =
+    const string DFA45_minS =
         "\x01\x1c\x04\uffff\x01\x00\x08\uffff";
-    const string DFA43_maxS =
-        "\x01\x5c\x04\uffff\x01\x00\x08\uffff";
-    const string DFA43_acceptS =
+    const string DFA45_maxS =
+        "\x01\x5e\x04\uffff\x01\x00\x08\uffff";
+    const string DFA45_acceptS =
         "\x01\uffff\x01\x01\x01\x02\x01\x03\x01\x04\x01\uffff\x01\x05\x01"+
         "\x06\x01\x07\x01\x08\x01\uffff\x01\x09\x01\x0b\x01\x0a";
-    const string DFA43_specialS =
+    const string DFA45_specialS =
         "\x01\x00\x04\uffff\x01\x01\x08\uffff}>";
-    static readonly string[] DFA43_transitionS = {
-            "\x01\x0c\x01\x02\x0d\uffff\x01\x0b\x01\uffff\x01\x02\x07\uffff"+
+    static readonly string[] DFA45_transitionS = {
+            "\x01\x0c\x01\x02\x0d\uffff\x01\x0b\x01\uffff\x01\x02\x09\uffff"+
             "\x01\x05\x01\uffff\x01\x01\x03\uffff\x01\x02\x12\uffff\x01\x02"+
             "\x01\uffff\x01\x08\x01\x07\x01\uffff\x02\x09\x01\x03\x04\x0c"+
             "\x02\x04\x01\x06",
@@ -12033,27 +12137,27 @@ public partial class simpletikzParser : Parser
             ""
     };
 
-    static readonly short[] DFA43_eot = DFA.UnpackEncodedString(DFA43_eotS);
-    static readonly short[] DFA43_eof = DFA.UnpackEncodedString(DFA43_eofS);
-    static readonly char[] DFA43_min = DFA.UnpackEncodedStringToUnsignedChars(DFA43_minS);
-    static readonly char[] DFA43_max = DFA.UnpackEncodedStringToUnsignedChars(DFA43_maxS);
-    static readonly short[] DFA43_accept = DFA.UnpackEncodedString(DFA43_acceptS);
-    static readonly short[] DFA43_special = DFA.UnpackEncodedString(DFA43_specialS);
-    static readonly short[][] DFA43_transition = DFA.UnpackEncodedStringArray(DFA43_transitionS);
+    static readonly short[] DFA45_eot = DFA.UnpackEncodedString(DFA45_eotS);
+    static readonly short[] DFA45_eof = DFA.UnpackEncodedString(DFA45_eofS);
+    static readonly char[] DFA45_min = DFA.UnpackEncodedStringToUnsignedChars(DFA45_minS);
+    static readonly char[] DFA45_max = DFA.UnpackEncodedStringToUnsignedChars(DFA45_maxS);
+    static readonly short[] DFA45_accept = DFA.UnpackEncodedString(DFA45_acceptS);
+    static readonly short[] DFA45_special = DFA.UnpackEncodedString(DFA45_specialS);
+    static readonly short[][] DFA45_transition = DFA.UnpackEncodedStringArray(DFA45_transitionS);
 
-    protected class DFA43 : DFA
+    protected class DFA45 : DFA
     {
-        public DFA43(BaseRecognizer recognizer)
+        public DFA45(BaseRecognizer recognizer)
         {
             this.recognizer = recognizer;
-            this.decisionNumber = 43;
-            this.eot = DFA43_eot;
-            this.eof = DFA43_eof;
-            this.min = DFA43_min;
-            this.max = DFA43_max;
-            this.accept = DFA43_accept;
-            this.special = DFA43_special;
-            this.transition = DFA43_transition;
+            this.decisionNumber = 45;
+            this.eot = DFA45_eot;
+            this.eof = DFA45_eof;
+            this.min = DFA45_min;
+            this.max = DFA45_max;
+            this.accept = DFA45_accept;
+            this.special = DFA45_special;
+            this.transition = DFA45_transition;
 
         }
 
@@ -12065,224 +12169,86 @@ public partial class simpletikzParser : Parser
     }
 
 
-    protected internal int DFA43_SpecialStateTransition(DFA dfa, int s, IIntStream _input) //throws NoViableAltException
+    protected internal int DFA45_SpecialStateTransition(DFA dfa, int s, IIntStream _input) //throws NoViableAltException
     {
             ITokenStream input = (ITokenStream)_input;
     	int _s = s;
         switch ( s )
         {
                	case 0 : 
-                   	int LA43_0 = input.LA(1);
+                   	int LA45_0 = input.LA(1);
 
                    	 
-                   	int index43_0 = input.Index();
+                   	int index45_0 = input.Index();
                    	input.Rewind();
                    	s = -1;
-                   	if ( (LA43_0 == 55) ) { s = 1; }
+                   	if ( (LA45_0 == 57) ) { s = 1; }
 
-                   	else if ( (LA43_0 == COMMAND || LA43_0 == 45 || LA43_0 == 59 || LA43_0 == 78) ) { s = 2; }
+                   	else if ( (LA45_0 == COMMAND || LA45_0 == 45 || LA45_0 == 61 || LA45_0 == 80) ) { s = 2; }
 
-                   	else if ( (LA43_0 == 85) ) { s = 3; }
+                   	else if ( (LA45_0 == 87) ) { s = 3; }
 
-                   	else if ( ((LA43_0 >= 90 && LA43_0 <= 91)) && (synpred1_simpletikz()) ) { s = 4; }
+                   	else if ( ((LA45_0 >= 92 && LA45_0 <= 93)) && (synpred2_simpletikz()) ) { s = 4; }
 
-                   	else if ( (LA43_0 == 53) ) { s = 5; }
+                   	else if ( (LA45_0 == 55) ) { s = 5; }
 
-                   	else if ( (LA43_0 == 92) ) { s = 6; }
+                   	else if ( (LA45_0 == 94) ) { s = 6; }
 
-                   	else if ( (LA43_0 == 81) ) { s = 7; }
+                   	else if ( (LA45_0 == 83) ) { s = 7; }
 
-                   	else if ( (LA43_0 == 80) ) { s = 8; }
+                   	else if ( (LA45_0 == 82) ) { s = 8; }
 
-                   	else if ( ((LA43_0 >= 83 && LA43_0 <= 84)) ) { s = 9; }
+                   	else if ( ((LA45_0 >= 85 && LA45_0 <= 86)) ) { s = 9; }
 
-                   	else if ( (LA43_0 == 43) ) { s = 11; }
+                   	else if ( (LA45_0 == 43) ) { s = 11; }
 
-                   	else if ( (LA43_0 == ID || (LA43_0 >= 86 && LA43_0 <= 89)) ) { s = 12; }
+                   	else if ( (LA45_0 == ID || (LA45_0 >= 88 && LA45_0 <= 91)) ) { s = 12; }
 
                    	 
-                   	input.Seek(index43_0);
+                   	input.Seek(index45_0);
                    	if ( s >= 0 ) return s;
                    	break;
                	case 1 : 
-                   	int LA43_5 = input.LA(1);
+                   	int LA45_5 = input.LA(1);
 
                    	 
-                   	int index43_5 = input.Index();
+                   	int index45_5 = input.Index();
                    	input.Rewind();
                    	s = -1;
-                   	if ( (synpred1_simpletikz()) ) { s = 4; }
+                   	if ( (synpred2_simpletikz()) ) { s = 4; }
 
                    	else if ( (true) ) { s = 13; }
 
                    	 
-                   	input.Seek(index43_5);
+                   	input.Seek(index45_5);
                    	if ( s >= 0 ) return s;
                    	break;
         }
         if (state.backtracking > 0) {state.failed = true; return -1;}
         NoViableAltException nvae =
-            new NoViableAltException(dfa.Description, 43, _s, input);
+            new NoViableAltException(dfa.Description, 45, _s, input);
         dfa.Error(nvae);
         throw nvae;
     }
-    const string DFA48_eotS =
+    const string DFA50_eotS =
         "\x12\uffff";
-    const string DFA48_eofS =
+    const string DFA50_eofS =
         "\x12\uffff";
-    const string DFA48_minS =
+    const string DFA50_minS =
         "\x01\x1c\x03\x00\x0e\uffff";
-    const string DFA48_maxS =
-        "\x01\x5c\x03\x00\x0e\uffff";
-    const string DFA48_acceptS =
+    const string DFA50_maxS =
+        "\x01\x5e\x03\x00\x0e\uffff";
+    const string DFA50_acceptS =
         "\x04\uffff\x01\x04\x0a\uffff\x01\x01\x01\x02\x01\x03";
-    const string DFA48_specialS =
+    const string DFA50_specialS =
         "\x01\uffff\x01\x00\x01\x01\x01\x02\x0e\uffff}>";
-    static readonly string[] DFA48_transitionS = {
-            "\x02\x04\x0d\uffff\x01\x04\x01\uffff\x01\x04\x07\uffff\x01"+
+    static readonly string[] DFA50_transitionS = {
+            "\x02\x04\x0d\uffff\x01\x04\x01\uffff\x01\x04\x09\uffff\x01"+
             "\x01\x01\uffff\x01\x03\x01\uffff\x01\x04\x01\uffff\x01\x04\x12"+
             "\uffff\x01\x04\x01\uffff\x02\x04\x01\x02\x0a\x04",
             "\x01\uffff",
             "\x01\uffff",
             "\x01\uffff",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            ""
-    };
-
-    static readonly short[] DFA48_eot = DFA.UnpackEncodedString(DFA48_eotS);
-    static readonly short[] DFA48_eof = DFA.UnpackEncodedString(DFA48_eofS);
-    static readonly char[] DFA48_min = DFA.UnpackEncodedStringToUnsignedChars(DFA48_minS);
-    static readonly char[] DFA48_max = DFA.UnpackEncodedStringToUnsignedChars(DFA48_maxS);
-    static readonly short[] DFA48_accept = DFA.UnpackEncodedString(DFA48_acceptS);
-    static readonly short[] DFA48_special = DFA.UnpackEncodedString(DFA48_specialS);
-    static readonly short[][] DFA48_transition = DFA.UnpackEncodedStringArray(DFA48_transitionS);
-
-    protected class DFA48 : DFA
-    {
-        public DFA48(BaseRecognizer recognizer)
-        {
-            this.recognizer = recognizer;
-            this.decisionNumber = 48;
-            this.eot = DFA48_eot;
-            this.eof = DFA48_eof;
-            this.min = DFA48_min;
-            this.max = DFA48_max;
-            this.accept = DFA48_accept;
-            this.special = DFA48_special;
-            this.transition = DFA48_transition;
-
-        }
-
-        override public string Description
-        {
-            get { return "359:5: ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )?"; }
-        }
-
-    }
-
-
-    protected internal int DFA48_SpecialStateTransition(DFA dfa, int s, IIntStream _input) //throws NoViableAltException
-    {
-            ITokenStream input = (ITokenStream)_input;
-    	int _s = s;
-        switch ( s )
-        {
-               	case 0 : 
-                   	int LA48_1 = input.LA(1);
-
-                   	 
-                   	int index48_1 = input.Index();
-                   	input.Rewind();
-                   	s = -1;
-                   	if ( (synpred2_simpletikz()) ) { s = 15; }
-
-                   	else if ( (synpred3_simpletikz()) ) { s = 16; }
-
-                   	else if ( (synpred4_simpletikz()) ) { s = 17; }
-
-                   	else if ( (true) ) { s = 4; }
-
-                   	 
-                   	input.Seek(index48_1);
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 1 : 
-                   	int LA48_2 = input.LA(1);
-
-                   	 
-                   	int index48_2 = input.Index();
-                   	input.Rewind();
-                   	s = -1;
-                   	if ( (synpred2_simpletikz()) ) { s = 15; }
-
-                   	else if ( (synpred3_simpletikz()) ) { s = 16; }
-
-                   	else if ( (synpred4_simpletikz()) ) { s = 17; }
-
-                   	 
-                   	input.Seek(index48_2);
-                   	if ( s >= 0 ) return s;
-                   	break;
-               	case 2 : 
-                   	int LA48_3 = input.LA(1);
-
-                   	 
-                   	int index48_3 = input.Index();
-                   	input.Rewind();
-                   	s = -1;
-                   	if ( (synpred2_simpletikz()) ) { s = 15; }
-
-                   	else if ( (synpred3_simpletikz()) ) { s = 16; }
-
-                   	else if ( (synpred4_simpletikz()) ) { s = 17; }
-
-                   	else if ( (true) ) { s = 4; }
-
-                   	 
-                   	input.Seek(index48_3);
-                   	if ( s >= 0 ) return s;
-                   	break;
-        }
-        if (state.backtracking > 0) {state.failed = true; return -1;}
-        NoViableAltException nvae =
-            new NoViableAltException(dfa.Description, 48, _s, input);
-        dfa.Error(nvae);
-        throw nvae;
-    }
-    const string DFA50_eotS =
-        "\x15\uffff";
-    const string DFA50_eofS =
-        "\x15\uffff";
-    const string DFA50_minS =
-        "\x01\x1c\x03\x00\x11\uffff";
-    const string DFA50_maxS =
-        "\x01\x5c\x03\x00\x11\uffff";
-    const string DFA50_acceptS =
-        "\x04\uffff\x01\x04\x0d\uffff\x01\x01\x01\x02\x01\x03";
-    const string DFA50_specialS =
-        "\x01\uffff\x01\x00\x01\x01\x01\x02\x11\uffff}>";
-    static readonly string[] DFA50_transitionS = {
-            "\x02\x04\x0d\uffff\x03\x04\x01\uffff\x01\x04\x05\uffff\x01"+
-            "\x01\x01\x04\x01\x03\x01\uffff\x01\x04\x01\uffff\x01\x04\x12"+
-            "\uffff\x01\x04\x01\uffff\x02\x04\x01\x02\x0a\x04",
-            "\x01\uffff",
-            "\x01\uffff",
-            "\x01\uffff",
-            "",
-            "",
-            "",
             "",
             "",
             "",
@@ -12325,7 +12291,7 @@ public partial class simpletikzParser : Parser
 
         override public string Description
         {
-            get { return "370:18: ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )?"; }
+            get { return "359:5: ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )?"; }
         }
 
     }
@@ -12344,11 +12310,11 @@ public partial class simpletikzParser : Parser
                    	int index50_1 = input.Index();
                    	input.Rewind();
                    	s = -1;
-                   	if ( (synpred5_simpletikz()) ) { s = 18; }
+                   	if ( (synpred3_simpletikz()) ) { s = 15; }
 
-                   	else if ( (synpred6_simpletikz()) ) { s = 19; }
+                   	else if ( (synpred4_simpletikz()) ) { s = 16; }
 
-                   	else if ( (synpred7_simpletikz()) ) { s = 20; }
+                   	else if ( (synpred5_simpletikz()) ) { s = 17; }
 
                    	else if ( (true) ) { s = 4; }
 
@@ -12363,11 +12329,11 @@ public partial class simpletikzParser : Parser
                    	int index50_2 = input.Index();
                    	input.Rewind();
                    	s = -1;
-                   	if ( (synpred5_simpletikz()) ) { s = 18; }
+                   	if ( (synpred3_simpletikz()) ) { s = 15; }
 
-                   	else if ( (synpred6_simpletikz()) ) { s = 19; }
+                   	else if ( (synpred4_simpletikz()) ) { s = 16; }
 
-                   	else if ( (synpred7_simpletikz()) ) { s = 20; }
+                   	else if ( (synpred5_simpletikz()) ) { s = 17; }
 
                    	 
                    	input.Seek(index50_2);
@@ -12380,11 +12346,11 @@ public partial class simpletikzParser : Parser
                    	int index50_3 = input.Index();
                    	input.Rewind();
                    	s = -1;
-                   	if ( (synpred5_simpletikz()) ) { s = 18; }
+                   	if ( (synpred3_simpletikz()) ) { s = 15; }
 
-                   	else if ( (synpred6_simpletikz()) ) { s = 19; }
+                   	else if ( (synpred4_simpletikz()) ) { s = 16; }
 
-                   	else if ( (synpred7_simpletikz()) ) { s = 20; }
+                   	else if ( (synpred5_simpletikz()) ) { s = 17; }
 
                    	else if ( (true) ) { s = 4; }
 
@@ -12399,62 +12365,200 @@ public partial class simpletikzParser : Parser
         dfa.Error(nvae);
         throw nvae;
     }
-    const string DFA57_eotS =
-        "\x0a\uffff";
-    const string DFA57_eofS =
-        "\x0a\uffff";
-    const string DFA57_minS =
-        "\x01\x1c\x01\x04\x01\uffff\x03\x04\x01\x00\x01\x04\x01\uffff\x01"+
-        "\x04";
-    const string DFA57_maxS =
-        "\x01\x5c\x01\x5f\x01\uffff\x03\x5f\x01\x00\x01\x5f\x01\uffff\x01"+
-        "\x5f";
-    const string DFA57_acceptS =
-        "\x02\uffff\x01\x02\x05\uffff\x01\x01\x01\uffff";
-    const string DFA57_specialS =
-        "\x06\uffff\x01\x00\x03\uffff}>";
-    static readonly string[] DFA57_transitionS = {
-            "\x02\x02\x0d\uffff\x03\x02\x01\uffff\x01\x02\x05\uffff\x01"+
-            "\x01\x02\x02\x01\uffff\x01\x02\x01\uffff\x01\x02\x12\uffff\x01"+
-            "\x02\x01\uffff\x02\x02\x01\uffff\x0a\x02",
-            "\x1a\x02\x02\x03\x0c\x02\x01\uffff\x02\x02\x04\uffff\x05\x02"+
-            "\x02\uffff\x26\x02",
-            "",
-            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x02\x02\x01\uffff\x01"+
-            "\x06\x03\uffff\x06\x04\x0f\x02\x01\x05\x10\x02",
-            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x02\x02\x01\uffff\x01"+
-            "\x06\x03\uffff\x15\x02\x01\x05\x10\x02",
-            "\x1a\x02\x02\x07\x0b\x02\x02\uffff\x04\x02\x02\uffff\x02\x02"+
-            "\x01\uffff\x01\x02\x03\uffff\x26\x02",
+    const string DFA52_eotS =
+        "\x15\uffff";
+    const string DFA52_eofS =
+        "\x15\uffff";
+    const string DFA52_minS =
+        "\x01\x1c\x03\x00\x11\uffff";
+    const string DFA52_maxS =
+        "\x01\x5e\x03\x00\x11\uffff";
+    const string DFA52_acceptS =
+        "\x04\uffff\x01\x04\x0d\uffff\x01\x01\x01\x02\x01\x03";
+    const string DFA52_specialS =
+        "\x01\uffff\x01\x00\x01\x01\x01\x02\x11\uffff}>";
+    static readonly string[] DFA52_transitionS = {
+            "\x02\x04\x0d\uffff\x03\x04\x01\uffff\x01\x04\x07\uffff\x01"+
+            "\x01\x01\x04\x01\x03\x01\uffff\x01\x04\x01\uffff\x01\x04\x12"+
+            "\uffff\x01\x04\x01\uffff\x02\x04\x01\x02\x0a\x04",
             "\x01\uffff",
-            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x02\x02\x01\uffff\x01"+
-            "\x06\x03\uffff\x06\x09\x20\x02",
+            "\x01\uffff",
+            "\x01\uffff",
             "",
-            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x02\x02\x01\uffff\x01"+
-            "\x06\x03\uffff\x26\x02"
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            ""
     };
 
-    static readonly short[] DFA57_eot = DFA.UnpackEncodedString(DFA57_eotS);
-    static readonly short[] DFA57_eof = DFA.UnpackEncodedString(DFA57_eofS);
-    static readonly char[] DFA57_min = DFA.UnpackEncodedStringToUnsignedChars(DFA57_minS);
-    static readonly char[] DFA57_max = DFA.UnpackEncodedStringToUnsignedChars(DFA57_maxS);
-    static readonly short[] DFA57_accept = DFA.UnpackEncodedString(DFA57_acceptS);
-    static readonly short[] DFA57_special = DFA.UnpackEncodedString(DFA57_specialS);
-    static readonly short[][] DFA57_transition = DFA.UnpackEncodedStringArray(DFA57_transitionS);
+    static readonly short[] DFA52_eot = DFA.UnpackEncodedString(DFA52_eotS);
+    static readonly short[] DFA52_eof = DFA.UnpackEncodedString(DFA52_eofS);
+    static readonly char[] DFA52_min = DFA.UnpackEncodedStringToUnsignedChars(DFA52_minS);
+    static readonly char[] DFA52_max = DFA.UnpackEncodedStringToUnsignedChars(DFA52_maxS);
+    static readonly short[] DFA52_accept = DFA.UnpackEncodedString(DFA52_acceptS);
+    static readonly short[] DFA52_special = DFA.UnpackEncodedString(DFA52_specialS);
+    static readonly short[][] DFA52_transition = DFA.UnpackEncodedStringArray(DFA52_transitionS);
 
-    protected class DFA57 : DFA
+    protected class DFA52 : DFA
     {
-        public DFA57(BaseRecognizer recognizer)
+        public DFA52(BaseRecognizer recognizer)
         {
             this.recognizer = recognizer;
-            this.decisionNumber = 57;
-            this.eot = DFA57_eot;
-            this.eof = DFA57_eof;
-            this.min = DFA57_min;
-            this.max = DFA57_max;
-            this.accept = DFA57_accept;
-            this.special = DFA57_special;
-            this.transition = DFA57_transition;
+            this.decisionNumber = 52;
+            this.eot = DFA52_eot;
+            this.eof = DFA52_eof;
+            this.min = DFA52_min;
+            this.max = DFA52_max;
+            this.accept = DFA52_accept;
+            this.special = DFA52_special;
+            this.transition = DFA52_transition;
+
+        }
+
+        override public string Description
+        {
+            get { return "370:18: ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )?"; }
+        }
+
+    }
+
+
+    protected internal int DFA52_SpecialStateTransition(DFA dfa, int s, IIntStream _input) //throws NoViableAltException
+    {
+            ITokenStream input = (ITokenStream)_input;
+    	int _s = s;
+        switch ( s )
+        {
+               	case 0 : 
+                   	int LA52_1 = input.LA(1);
+
+                   	 
+                   	int index52_1 = input.Index();
+                   	input.Rewind();
+                   	s = -1;
+                   	if ( (synpred6_simpletikz()) ) { s = 18; }
+
+                   	else if ( (synpred7_simpletikz()) ) { s = 19; }
+
+                   	else if ( (synpred8_simpletikz()) ) { s = 20; }
+
+                   	else if ( (true) ) { s = 4; }
+
+                   	 
+                   	input.Seek(index52_1);
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 1 : 
+                   	int LA52_2 = input.LA(1);
+
+                   	 
+                   	int index52_2 = input.Index();
+                   	input.Rewind();
+                   	s = -1;
+                   	if ( (synpred6_simpletikz()) ) { s = 18; }
+
+                   	else if ( (synpred7_simpletikz()) ) { s = 19; }
+
+                   	else if ( (synpred8_simpletikz()) ) { s = 20; }
+
+                   	 
+                   	input.Seek(index52_2);
+                   	if ( s >= 0 ) return s;
+                   	break;
+               	case 2 : 
+                   	int LA52_3 = input.LA(1);
+
+                   	 
+                   	int index52_3 = input.Index();
+                   	input.Rewind();
+                   	s = -1;
+                   	if ( (synpred6_simpletikz()) ) { s = 18; }
+
+                   	else if ( (synpred7_simpletikz()) ) { s = 19; }
+
+                   	else if ( (synpred8_simpletikz()) ) { s = 20; }
+
+                   	else if ( (true) ) { s = 4; }
+
+                   	 
+                   	input.Seek(index52_3);
+                   	if ( s >= 0 ) return s;
+                   	break;
+        }
+        if (state.backtracking > 0) {state.failed = true; return -1;}
+        NoViableAltException nvae =
+            new NoViableAltException(dfa.Description, 52, _s, input);
+        dfa.Error(nvae);
+        throw nvae;
+    }
+    const string DFA59_eotS =
+        "\x0a\uffff";
+    const string DFA59_eofS =
+        "\x0a\uffff";
+    const string DFA59_minS =
+        "\x01\x1c\x01\x04\x01\uffff\x01\x04\x01\x00\x02\x04\x01\uffff\x02"+
+        "\x04";
+    const string DFA59_maxS =
+        "\x01\x5e\x01\x61\x01\uffff\x01\x61\x01\x00\x02\x61\x01\uffff\x02"+
+        "\x61";
+    const string DFA59_acceptS =
+        "\x02\uffff\x01\x02\x04\uffff\x01\x01\x02\uffff";
+    const string DFA59_specialS =
+        "\x04\uffff\x01\x00\x05\uffff}>";
+    static readonly string[] DFA59_transitionS = {
+            "\x02\x02\x0d\uffff\x03\x02\x01\uffff\x01\x02\x07\uffff\x01"+
+            "\x01\x02\x02\x01\uffff\x01\x02\x01\uffff\x01\x02\x12\uffff\x01"+
+            "\x02\x01\uffff\x02\x02\x01\uffff\x0a\x02",
+            "\x1a\x02\x02\x03\x0c\x02\x01\uffff\x02\x02\x04\uffff\x07\x02"+
+            "\x02\uffff\x26\x02",
+            "",
+            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x04\x02\x01\uffff\x01"+
+            "\x04\x03\uffff\x06\x05\x0f\x02\x01\x06\x10\x02",
+            "\x01\uffff",
+            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x04\x02\x01\uffff\x01"+
+            "\x04\x03\uffff\x15\x02\x01\x06\x10\x02",
+            "\x1a\x02\x02\x08\x0b\x02\x02\uffff\x04\x02\x02\uffff\x04\x02"+
+            "\x01\uffff\x01\x02\x03\uffff\x26\x02",
+            "",
+            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x04\x02\x01\uffff\x01"+
+            "\x04\x03\uffff\x06\x09\x20\x02",
+            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x04\x02\x01\uffff\x01"+
+            "\x04\x03\uffff\x26\x02"
+    };
+
+    static readonly short[] DFA59_eot = DFA.UnpackEncodedString(DFA59_eotS);
+    static readonly short[] DFA59_eof = DFA.UnpackEncodedString(DFA59_eofS);
+    static readonly char[] DFA59_min = DFA.UnpackEncodedStringToUnsignedChars(DFA59_minS);
+    static readonly char[] DFA59_max = DFA.UnpackEncodedStringToUnsignedChars(DFA59_maxS);
+    static readonly short[] DFA59_accept = DFA.UnpackEncodedString(DFA59_acceptS);
+    static readonly short[] DFA59_special = DFA.UnpackEncodedString(DFA59_specialS);
+    static readonly short[][] DFA59_transition = DFA.UnpackEncodedStringArray(DFA59_transitionS);
+
+    protected class DFA59 : DFA
+    {
+        public DFA59(BaseRecognizer recognizer)
+        {
+            this.recognizer = recognizer;
+            this.decisionNumber = 59;
+            this.eot = DFA59_eot;
+            this.eof = DFA59_eof;
+            this.min = DFA59_min;
+            this.max = DFA59_max;
+            this.accept = DFA59_accept;
+            this.special = DFA59_special;
+            this.transition = DFA59_transition;
 
         }
 
@@ -12466,107 +12570,107 @@ public partial class simpletikzParser : Parser
     }
 
 
-    protected internal int DFA57_SpecialStateTransition(DFA dfa, int s, IIntStream _input) //throws NoViableAltException
+    protected internal int DFA59_SpecialStateTransition(DFA dfa, int s, IIntStream _input) //throws NoViableAltException
     {
             ITokenStream input = (ITokenStream)_input;
     	int _s = s;
         switch ( s )
         {
                	case 0 : 
-                   	int LA57_6 = input.LA(1);
+                   	int LA59_4 = input.LA(1);
 
                    	 
-                   	int index57_6 = input.Index();
+                   	int index59_4 = input.Index();
                    	input.Rewind();
                    	s = -1;
-                   	if ( (synpred8_simpletikz()) ) { s = 8; }
+                   	if ( (synpred9_simpletikz()) ) { s = 7; }
 
                    	else if ( (true) ) { s = 2; }
 
                    	 
-                   	input.Seek(index57_6);
+                   	input.Seek(index59_4);
                    	if ( s >= 0 ) return s;
                    	break;
         }
         if (state.backtracking > 0) {state.failed = true; return -1;}
         NoViableAltException nvae =
-            new NoViableAltException(dfa.Description, 57, _s, input);
+            new NoViableAltException(dfa.Description, 59, _s, input);
         dfa.Error(nvae);
         throw nvae;
     }
-    const string DFA60_eotS =
+    const string DFA62_eotS =
         "\x14\uffff";
-    const string DFA60_eofS =
+    const string DFA62_eofS =
         "\x14\uffff";
-    const string DFA60_minS =
-        "\x01\x55\x01\x35\x01\x04\x01\uffff\x01\x04\x01\uffff\x0a\x04\x01"+
-        "\uffff\x03\x04";
-    const string DFA60_maxS =
-        "\x01\x55\x01\x37\x01\x5f\x01\uffff\x01\x5f\x01\uffff\x0a\x5f\x01"+
-        "\uffff\x03\x5f";
-    const string DFA60_acceptS =
-        "\x03\uffff\x01\x03\x01\uffff\x01\x02\x0a\uffff\x01\x01\x03\uffff";
-    const string DFA60_specialS =
+    const string DFA62_minS =
+        "\x01\x57\x01\x37\x01\uffff\x02\x04\x01\uffff\x0a\x04\x01\uffff"+
+        "\x03\x04";
+    const string DFA62_maxS =
+        "\x01\x57\x01\x39\x01\uffff\x02\x61\x01\uffff\x0a\x61\x01\uffff"+
+        "\x03\x61";
+    const string DFA62_acceptS =
+        "\x02\uffff\x01\x03\x02\uffff\x01\x02\x0a\uffff\x01\x01\x03\uffff";
+    const string DFA62_specialS =
         "\x14\uffff}>";
-    static readonly string[] DFA60_transitionS = {
+    static readonly string[] DFA62_transitionS = {
             "\x01\x01",
-            "\x01\x02\x01\uffff\x01\x03",
-            "\x19\x05\x01\x06\x02\x04\x0c\x05\x02\uffff\x01\x05\x04\uffff"+
-            "\x02\x05\x05\uffff\x26\x05",
+            "\x01\x03\x01\uffff\x01\x02",
             "",
-            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x08\x02\uffff\x02"+
+            "\x19\x05\x01\x06\x02\x04\x0c\x05\x02\uffff\x01\x05\x04\uffff"+
+            "\x04\x05\x05\uffff\x26\x05",
+            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x08\x02\uffff\x04"+
             "\x05\x05\uffff\x06\x07\x20\x05",
             "",
-            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x08\x02\uffff\x02"+
+            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x08\x02\uffff\x04"+
             "\x05\x05\uffff\x26\x05",
-            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x08\x02\uffff\x02"+
+            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x08\x02\uffff\x04"+
             "\x05\x05\uffff\x26\x05",
             "\x19\x05\x01\x0a\x02\x09\x0c\x05\x02\uffff\x01\x05\x04\uffff"+
-            "\x02\x05\x05\uffff\x26\x05",
-            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x0c\x02\uffff\x02"+
+            "\x04\x05\x05\uffff\x26\x05",
+            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x0c\x02\uffff\x04"+
             "\x05\x05\uffff\x06\x0b\x20\x05",
-            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x0c\x02\uffff\x02"+
+            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x0c\x02\uffff\x04"+
             "\x05\x05\uffff\x26\x05",
-            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x0c\x02\uffff\x02"+
+            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x0c\x02\uffff\x04"+
             "\x05\x05\uffff\x26\x05",
             "\x19\x05\x01\x0e\x02\x0d\x0c\x05\x02\uffff\x01\x05\x04\uffff"+
-            "\x02\x05\x05\uffff\x26\x05",
-            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x02\x05\x01\uffff\x01"+
+            "\x04\x05\x05\uffff\x26\x05",
+            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x04\x05\x01\uffff\x01"+
             "\x10\x03\uffff\x06\x11\x0f\x05\x01\x0f\x10\x05",
-            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x02\x05\x01\uffff\x01"+
+            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x04\x05\x01\uffff\x01"+
             "\x10\x03\uffff\x15\x05\x01\x0f\x10\x05",
-            "\x1a\x05\x02\x12\x0b\x05\x02\uffff\x02\x05\x04\uffff\x02\x05"+
+            "\x1a\x05\x02\x12\x0b\x05\x02\uffff\x02\x05\x04\uffff\x04\x05"+
             "\x01\uffff\x01\x05\x03\uffff\x26\x05",
             "",
-            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x02\x05\x01\uffff\x01"+
+            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x04\x05\x01\uffff\x01"+
             "\x10\x03\uffff\x15\x05\x01\x0f\x10\x05",
-            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x02\x05\x01\uffff\x01"+
+            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x04\x05\x01\uffff\x01"+
             "\x10\x03\uffff\x06\x13\x20\x05",
-            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x02\x05\x01\uffff\x01"+
+            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x04\x05\x01\uffff\x01"+
             "\x10\x03\uffff\x26\x05"
     };
 
-    static readonly short[] DFA60_eot = DFA.UnpackEncodedString(DFA60_eotS);
-    static readonly short[] DFA60_eof = DFA.UnpackEncodedString(DFA60_eofS);
-    static readonly char[] DFA60_min = DFA.UnpackEncodedStringToUnsignedChars(DFA60_minS);
-    static readonly char[] DFA60_max = DFA.UnpackEncodedStringToUnsignedChars(DFA60_maxS);
-    static readonly short[] DFA60_accept = DFA.UnpackEncodedString(DFA60_acceptS);
-    static readonly short[] DFA60_special = DFA.UnpackEncodedString(DFA60_specialS);
-    static readonly short[][] DFA60_transition = DFA.UnpackEncodedStringArray(DFA60_transitionS);
+    static readonly short[] DFA62_eot = DFA.UnpackEncodedString(DFA62_eotS);
+    static readonly short[] DFA62_eof = DFA.UnpackEncodedString(DFA62_eofS);
+    static readonly char[] DFA62_min = DFA.UnpackEncodedStringToUnsignedChars(DFA62_minS);
+    static readonly char[] DFA62_max = DFA.UnpackEncodedStringToUnsignedChars(DFA62_maxS);
+    static readonly short[] DFA62_accept = DFA.UnpackEncodedString(DFA62_acceptS);
+    static readonly short[] DFA62_special = DFA.UnpackEncodedString(DFA62_specialS);
+    static readonly short[][] DFA62_transition = DFA.UnpackEncodedStringArray(DFA62_transitionS);
 
-    protected class DFA60 : DFA
+    protected class DFA62 : DFA
     {
-        public DFA60(BaseRecognizer recognizer)
+        public DFA62(BaseRecognizer recognizer)
         {
             this.recognizer = recognizer;
-            this.decisionNumber = 60;
-            this.eot = DFA60_eot;
-            this.eof = DFA60_eof;
-            this.min = DFA60_min;
-            this.max = DFA60_max;
-            this.accept = DFA60_accept;
-            this.special = DFA60_special;
-            this.transition = DFA60_transition;
+            this.decisionNumber = 62;
+            this.eot = DFA62_eot;
+            this.eof = DFA62_eof;
+            this.min = DFA62_min;
+            this.max = DFA62_max;
+            this.accept = DFA62_accept;
+            this.special = DFA62_special;
+            this.transition = DFA62_transition;
 
         }
 
@@ -12577,63 +12681,63 @@ public partial class simpletikzParser : Parser
 
     }
 
-    const string DFA67_eotS =
+    const string DFA69_eotS =
         "\x0d\uffff";
-    const string DFA67_eofS =
+    const string DFA69_eofS =
         "\x0d\uffff";
-    const string DFA67_minS =
-        "\x02\x35\x01\x04\x01\uffff\x02\x04\x02\uffff\x04\x04\x01\uffff";
-    const string DFA67_maxS =
-        "\x01\x5b\x01\x35\x01\x5f\x01\uffff\x02\x5f\x02\uffff\x04\x5f\x01"+
+    const string DFA69_minS =
+        "\x02\x37\x01\x04\x02\uffff\x02\x04\x01\uffff\x04\x04\x01\uffff";
+    const string DFA69_maxS =
+        "\x01\x5d\x01\x37\x01\x61\x02\uffff\x02\x61\x01\uffff\x04\x61\x01"+
         "\uffff";
-    const string DFA67_acceptS =
-        "\x03\uffff\x01\x04\x02\uffff\x01\x03\x01\x01\x04\uffff\x01\x02";
-    const string DFA67_specialS =
+    const string DFA69_acceptS =
+        "\x03\uffff\x01\x04\x01\x01\x02\uffff\x01\x03\x04\uffff\x01\x02";
+    const string DFA69_specialS =
         "\x0d\uffff}>";
-    static readonly string[] DFA67_transitionS = {
+    static readonly string[] DFA69_transitionS = {
             "\x01\x02\x24\uffff\x02\x01",
             "\x01\x02",
-            "\x1a\x05\x02\x04\x0b\x05\x01\x06\x02\uffff\x01\x05\x04\uffff"+
-            "\x02\x05\x01\uffff\x01\x03\x01\x07\x02\uffff\x26\x05",
-            "",
-            "\x27\x05\x02\uffff\x01\x06\x01\x05\x02\x09\x02\uffff\x02\x05"+
-            "\x01\uffff\x01\x07\x03\uffff\x06\x08\x20\x05",
-            "\x27\x05\x02\uffff\x01\x06\x01\x05\x02\x06\x02\uffff\x02\x05"+
-            "\x01\uffff\x01\x07\x03\uffff\x26\x05",
+            "\x1a\x06\x02\x05\x0b\x06\x01\x07\x02\uffff\x01\x06\x04\uffff"+
+            "\x04\x06\x01\uffff\x01\x03\x01\x04\x02\uffff\x26\x06",
             "",
             "",
-            "\x27\x05\x02\uffff\x01\x06\x01\x05\x02\x09\x02\uffff\x02\x05"+
-            "\x01\uffff\x01\x07\x03\uffff\x26\x05",
-            "\x1a\x06\x02\x0a\x0c\x06\x02\uffff\x01\x06\x04\uffff\x02\x06"+
-            "\x05\uffff\x26\x06",
-            "\x27\x06\x02\uffff\x02\x06\x04\uffff\x02\x06\x01\uffff\x01"+
-            "\x0c\x03\uffff\x06\x0b\x20\x06",
-            "\x27\x06\x02\uffff\x02\x06\x04\uffff\x02\x06\x01\uffff\x01"+
-            "\x0c\x03\uffff\x26\x06",
+            "\x27\x06\x02\uffff\x01\x07\x01\x06\x02\x09\x02\uffff\x04\x06"+
+            "\x01\uffff\x01\x04\x03\uffff\x06\x08\x20\x06",
+            "\x27\x06\x02\uffff\x01\x07\x01\x06\x02\x07\x02\uffff\x04\x06"+
+            "\x01\uffff\x01\x04\x03\uffff\x26\x06",
+            "",
+            "\x27\x06\x02\uffff\x01\x07\x01\x06\x02\x09\x02\uffff\x04\x06"+
+            "\x01\uffff\x01\x04\x03\uffff\x26\x06",
+            "\x1a\x07\x02\x0a\x0c\x07\x02\uffff\x01\x07\x04\uffff\x04\x07"+
+            "\x05\uffff\x26\x07",
+            "\x27\x07\x02\uffff\x02\x07\x04\uffff\x04\x07\x01\uffff\x01"+
+            "\x0c\x03\uffff\x06\x0b\x20\x07",
+            "\x27\x07\x02\uffff\x02\x07\x04\uffff\x04\x07\x01\uffff\x01"+
+            "\x0c\x03\uffff\x26\x07",
             ""
     };
 
-    static readonly short[] DFA67_eot = DFA.UnpackEncodedString(DFA67_eotS);
-    static readonly short[] DFA67_eof = DFA.UnpackEncodedString(DFA67_eofS);
-    static readonly char[] DFA67_min = DFA.UnpackEncodedStringToUnsignedChars(DFA67_minS);
-    static readonly char[] DFA67_max = DFA.UnpackEncodedStringToUnsignedChars(DFA67_maxS);
-    static readonly short[] DFA67_accept = DFA.UnpackEncodedString(DFA67_acceptS);
-    static readonly short[] DFA67_special = DFA.UnpackEncodedString(DFA67_specialS);
-    static readonly short[][] DFA67_transition = DFA.UnpackEncodedStringArray(DFA67_transitionS);
+    static readonly short[] DFA69_eot = DFA.UnpackEncodedString(DFA69_eotS);
+    static readonly short[] DFA69_eof = DFA.UnpackEncodedString(DFA69_eofS);
+    static readonly char[] DFA69_min = DFA.UnpackEncodedStringToUnsignedChars(DFA69_minS);
+    static readonly char[] DFA69_max = DFA.UnpackEncodedStringToUnsignedChars(DFA69_maxS);
+    static readonly short[] DFA69_accept = DFA.UnpackEncodedString(DFA69_acceptS);
+    static readonly short[] DFA69_special = DFA.UnpackEncodedString(DFA69_specialS);
+    static readonly short[][] DFA69_transition = DFA.UnpackEncodedStringArray(DFA69_transitionS);
 
-    protected class DFA67 : DFA
+    protected class DFA69 : DFA
     {
-        public DFA67(BaseRecognizer recognizer)
+        public DFA69(BaseRecognizer recognizer)
         {
             this.recognizer = recognizer;
-            this.decisionNumber = 67;
-            this.eot = DFA67_eot;
-            this.eof = DFA67_eof;
-            this.min = DFA67_min;
-            this.max = DFA67_max;
-            this.accept = DFA67_accept;
-            this.special = DFA67_special;
-            this.transition = DFA67_transition;
+            this.decisionNumber = 69;
+            this.eot = DFA69_eot;
+            this.eof = DFA69_eof;
+            this.min = DFA69_min;
+            this.max = DFA69_max;
+            this.accept = DFA69_accept;
+            this.special = DFA69_special;
+            this.transition = DFA69_transition;
 
         }
 
@@ -12644,69 +12748,69 @@ public partial class simpletikzParser : Parser
 
     }
 
-    const string DFA70_eotS =
+    const string DFA72_eotS =
         "\x0f\uffff";
-    const string DFA70_eofS =
+    const string DFA72_eofS =
         "\x0f\uffff";
-    const string DFA70_minS =
-        "\x01\x35\x01\x04\x01\x35\x01\x04\x01\uffff\x02\x04\x01\uffff\x06"+
+    const string DFA72_minS =
+        "\x01\x37\x01\x04\x01\x37\x02\x04\x01\uffff\x03\x04\x01\uffff\x04"+
         "\x04\x01\uffff";
-    const string DFA70_maxS =
-        "\x01\x5b\x01\x5f\x01\x35\x01\x5f\x01\uffff\x02\x5f\x01\uffff\x06"+
-        "\x5f\x01\uffff";
-    const string DFA70_acceptS =
-        "\x04\uffff\x01\x03\x02\uffff\x01\x01\x06\uffff\x01\x02";
-    const string DFA70_specialS =
+    const string DFA72_maxS =
+        "\x01\x5d\x01\x61\x01\x37\x02\x61\x01\uffff\x03\x61\x01\uffff\x04"+
+        "\x61\x01\uffff";
+    const string DFA72_acceptS =
+        "\x05\uffff\x01\x03\x03\uffff\x01\x01\x04\uffff\x01\x02";
+    const string DFA72_specialS =
         "\x0f\uffff}>";
-    static readonly string[] DFA70_transitionS = {
+    static readonly string[] DFA72_transitionS = {
             "\x01\x01\x24\uffff\x02\x02",
-            "\x1a\x05\x02\x03\x0b\x05\x01\x04\x02\uffff\x01\x05\x04\uffff"+
-            "\x02\x05\x05\uffff\x26\x05",
+            "\x1a\x04\x02\x03\x0b\x04\x01\x05\x02\uffff\x01\x04\x04\uffff"+
+            "\x04\x04\x05\uffff\x26\x04",
             "\x01\x06",
-            "\x27\x05\x02\uffff\x01\x04\x01\x05\x02\x09\x02\uffff\x02\x05"+
-            "\x01\uffff\x01\x07\x03\uffff\x06\x08\x20\x05",
+            "\x27\x04\x02\uffff\x01\x05\x01\x04\x02\x08\x02\uffff\x04\x04"+
+            "\x01\uffff\x01\x09\x03\uffff\x06\x07\x20\x04",
+            "\x27\x04\x02\uffff\x01\x05\x01\x04\x02\x05\x02\uffff\x04\x04"+
+            "\x01\uffff\x01\x09\x03\uffff\x26\x04",
             "",
-            "\x27\x05\x02\uffff\x01\x04\x01\x05\x02\x04\x02\uffff\x02\x05"+
-            "\x01\uffff\x01\x07\x03\uffff\x26\x05",
-            "\x1a\x04\x02\x0a\x0c\x04\x02\uffff\x01\x04\x04\uffff\x02\x04"+
-            "\x05\uffff\x26\x04",
+            "\x1a\x05\x02\x0a\x0c\x05\x02\uffff\x01\x05\x04\uffff\x04\x05"+
+            "\x05\uffff\x26\x05",
+            "\x27\x04\x02\uffff\x01\x05\x01\x04\x02\x08\x02\uffff\x04\x04"+
+            "\x01\uffff\x01\x09\x03\uffff\x26\x04",
+            "\x1a\x05\x02\x0b\x0c\x05\x02\uffff\x01\x05\x04\uffff\x04\x05"+
+            "\x05\uffff\x26\x05",
             "",
-            "\x27\x05\x02\uffff\x01\x04\x01\x05\x02\x09\x02\uffff\x02\x05"+
-            "\x01\uffff\x01\x07\x03\uffff\x26\x05",
-            "\x1a\x04\x02\x0b\x0c\x04\x02\uffff\x01\x04\x04\uffff\x02\x04"+
-            "\x05\uffff\x26\x04",
-            "\x27\x04\x02\uffff\x02\x04\x02\x09\x02\uffff\x02\x04\x05\uffff"+
-            "\x06\x0c\x20\x04",
-            "\x27\x04\x02\uffff\x02\x04\x04\uffff\x02\x04\x01\uffff\x01"+
-            "\x0e\x03\uffff\x06\x0d\x20\x04",
-            "\x27\x04\x02\uffff\x02\x04\x02\x09\x02\uffff\x02\x04\x05\uffff"+
-            "\x26\x04",
-            "\x27\x04\x02\uffff\x02\x04\x04\uffff\x02\x04\x01\uffff\x01"+
-            "\x0e\x03\uffff\x26\x04",
+            "\x27\x05\x02\uffff\x02\x05\x02\x08\x02\uffff\x04\x05\x05\uffff"+
+            "\x06\x0c\x20\x05",
+            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x04\x05\x01\uffff\x01"+
+            "\x0e\x03\uffff\x06\x0d\x20\x05",
+            "\x27\x05\x02\uffff\x02\x05\x02\x08\x02\uffff\x04\x05\x05\uffff"+
+            "\x26\x05",
+            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x04\x05\x01\uffff\x01"+
+            "\x0e\x03\uffff\x26\x05",
             ""
     };
 
-    static readonly short[] DFA70_eot = DFA.UnpackEncodedString(DFA70_eotS);
-    static readonly short[] DFA70_eof = DFA.UnpackEncodedString(DFA70_eofS);
-    static readonly char[] DFA70_min = DFA.UnpackEncodedStringToUnsignedChars(DFA70_minS);
-    static readonly char[] DFA70_max = DFA.UnpackEncodedStringToUnsignedChars(DFA70_maxS);
-    static readonly short[] DFA70_accept = DFA.UnpackEncodedString(DFA70_acceptS);
-    static readonly short[] DFA70_special = DFA.UnpackEncodedString(DFA70_specialS);
-    static readonly short[][] DFA70_transition = DFA.UnpackEncodedStringArray(DFA70_transitionS);
+    static readonly short[] DFA72_eot = DFA.UnpackEncodedString(DFA72_eotS);
+    static readonly short[] DFA72_eof = DFA.UnpackEncodedString(DFA72_eofS);
+    static readonly char[] DFA72_min = DFA.UnpackEncodedStringToUnsignedChars(DFA72_minS);
+    static readonly char[] DFA72_max = DFA.UnpackEncodedStringToUnsignedChars(DFA72_maxS);
+    static readonly short[] DFA72_accept = DFA.UnpackEncodedString(DFA72_acceptS);
+    static readonly short[] DFA72_special = DFA.UnpackEncodedString(DFA72_specialS);
+    static readonly short[][] DFA72_transition = DFA.UnpackEncodedStringArray(DFA72_transitionS);
 
-    protected class DFA70 : DFA
+    protected class DFA72 : DFA
     {
-        public DFA70(BaseRecognizer recognizer)
+        public DFA72(BaseRecognizer recognizer)
         {
             this.recognizer = recognizer;
-            this.decisionNumber = 70;
-            this.eot = DFA70_eot;
-            this.eof = DFA70_eof;
-            this.min = DFA70_min;
-            this.max = DFA70_max;
-            this.accept = DFA70_accept;
-            this.special = DFA70_special;
-            this.transition = DFA70_transition;
+            this.decisionNumber = 72;
+            this.eot = DFA72_eot;
+            this.eof = DFA72_eof;
+            this.min = DFA72_min;
+            this.max = DFA72_max;
+            this.accept = DFA72_accept;
+            this.special = DFA72_special;
+            this.transition = DFA72_transition;
 
         }
 
@@ -12717,56 +12821,56 @@ public partial class simpletikzParser : Parser
 
     }
 
-    const string DFA73_eotS =
+    const string DFA75_eotS =
         "\x08\uffff";
-    const string DFA73_eofS =
+    const string DFA75_eofS =
         "\x08\uffff";
-    const string DFA73_minS =
+    const string DFA75_minS =
         "\x02\x04\x02\uffff\x01\x04\x01\uffff\x02\x04";
-    const string DFA73_maxS =
-        "\x02\x5f\x02\uffff\x01\x5f\x01\uffff\x02\x5f";
-    const string DFA73_acceptS =
-        "\x02\uffff\x01\x02\x01\x03\x01\uffff\x01\x01\x02\uffff";
-    const string DFA73_specialS =
+    const string DFA75_maxS =
+        "\x02\x61\x02\uffff\x01\x61\x01\uffff\x02\x61";
+    const string DFA75_acceptS =
+        "\x02\uffff\x01\x02\x01\x01\x01\uffff\x01\x03\x02\uffff";
+    const string DFA75_specialS =
         "\x08\uffff}>";
-    static readonly string[] DFA73_transitionS = {
-            "\x27\x01\x01\x02\x02\uffff\x01\x01\x04\uffff\x02\x01\x05\uffff"+
+    static readonly string[] DFA75_transitionS = {
+            "\x27\x01\x01\x02\x02\uffff\x01\x01\x04\uffff\x04\x01\x05\uffff"+
             "\x26\x01",
-            "\x27\x01\x02\uffff\x01\x03\x01\x01\x02\x05\x02\uffff\x02\x01"+
-            "\x01\uffff\x01\x05\x03\uffff\x15\x01\x01\x04\x10\x01",
+            "\x27\x01\x02\uffff\x01\x05\x01\x01\x02\x03\x02\uffff\x04\x01"+
+            "\x01\uffff\x01\x03\x03\uffff\x15\x01\x01\x04\x10\x01",
             "",
             "",
-            "\x1a\x01\x02\x06\x0b\x01\x02\uffff\x01\x03\x01\x01\x02\x05"+
-            "\x02\uffff\x02\x01\x01\uffff\x01\x05\x03\uffff\x15\x01\x01\x04"+
+            "\x1a\x01\x02\x06\x0b\x01\x02\uffff\x01\x05\x01\x01\x02\x03"+
+            "\x02\uffff\x04\x01\x01\uffff\x01\x03\x03\uffff\x15\x01\x01\x04"+
             "\x10\x01",
             "",
-            "\x27\x01\x02\uffff\x01\x03\x01\x01\x02\x05\x02\uffff\x02\x01"+
-            "\x01\uffff\x01\x05\x03\uffff\x06\x07\x0f\x01\x01\x04\x10\x01",
-            "\x27\x01\x02\uffff\x01\x03\x01\x01\x02\x05\x02\uffff\x02\x01"+
-            "\x01\uffff\x01\x05\x03\uffff\x15\x01\x01\x04\x10\x01"
+            "\x27\x01\x02\uffff\x01\x05\x01\x01\x02\x03\x02\uffff\x04\x01"+
+            "\x01\uffff\x01\x03\x03\uffff\x06\x07\x0f\x01\x01\x04\x10\x01",
+            "\x27\x01\x02\uffff\x01\x05\x01\x01\x02\x03\x02\uffff\x04\x01"+
+            "\x01\uffff\x01\x03\x03\uffff\x15\x01\x01\x04\x10\x01"
     };
 
-    static readonly short[] DFA73_eot = DFA.UnpackEncodedString(DFA73_eotS);
-    static readonly short[] DFA73_eof = DFA.UnpackEncodedString(DFA73_eofS);
-    static readonly char[] DFA73_min = DFA.UnpackEncodedStringToUnsignedChars(DFA73_minS);
-    static readonly char[] DFA73_max = DFA.UnpackEncodedStringToUnsignedChars(DFA73_maxS);
-    static readonly short[] DFA73_accept = DFA.UnpackEncodedString(DFA73_acceptS);
-    static readonly short[] DFA73_special = DFA.UnpackEncodedString(DFA73_specialS);
-    static readonly short[][] DFA73_transition = DFA.UnpackEncodedStringArray(DFA73_transitionS);
+    static readonly short[] DFA75_eot = DFA.UnpackEncodedString(DFA75_eotS);
+    static readonly short[] DFA75_eof = DFA.UnpackEncodedString(DFA75_eofS);
+    static readonly char[] DFA75_min = DFA.UnpackEncodedStringToUnsignedChars(DFA75_minS);
+    static readonly char[] DFA75_max = DFA.UnpackEncodedStringToUnsignedChars(DFA75_maxS);
+    static readonly short[] DFA75_accept = DFA.UnpackEncodedString(DFA75_acceptS);
+    static readonly short[] DFA75_special = DFA.UnpackEncodedString(DFA75_specialS);
+    static readonly short[][] DFA75_transition = DFA.UnpackEncodedStringArray(DFA75_transitionS);
 
-    protected class DFA73 : DFA
+    protected class DFA75 : DFA
     {
-        public DFA73(BaseRecognizer recognizer)
+        public DFA75(BaseRecognizer recognizer)
         {
             this.recognizer = recognizer;
-            this.decisionNumber = 73;
-            this.eot = DFA73_eot;
-            this.eof = DFA73_eof;
-            this.min = DFA73_min;
-            this.max = DFA73_max;
-            this.accept = DFA73_accept;
-            this.special = DFA73_special;
-            this.transition = DFA73_transition;
+            this.decisionNumber = 75;
+            this.eot = DFA75_eot;
+            this.eof = DFA75_eof;
+            this.min = DFA75_min;
+            this.max = DFA75_max;
+            this.accept = DFA75_accept;
+            this.special = DFA75_special;
+            this.transition = DFA75_transition;
 
         }
 
@@ -12779,13 +12883,13 @@ public partial class simpletikzParser : Parser
 
  
 
-    public static readonly BitSet FOLLOW_dontcare_preamble_in_tikzdocument257 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_styleorsetorcmd_in_tikzdocument261 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherbegin_in_tikzdocument265 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpicture_in_tikzdocument270 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_dontcare_preamble_in_tikzdocument_wo_tikzpicture296 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_styleorsetorcmd_in_tikzdocument_wo_tikzpicture300 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherbegin_in_tikzdocument_wo_tikzpicture304 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_dontcare_preamble_in_tikzdocument257 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_styleorsetorcmd_in_tikzdocument261 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherbegin_in_tikzdocument265 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpicture_in_tikzdocument270 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_dontcare_preamble_in_tikzdocument_wo_tikzpicture296 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_styleorsetorcmd_in_tikzdocument_wo_tikzpicture300 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherbegin_in_tikzdocument_wo_tikzpicture304 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
     public static readonly BitSet FOLLOW_EOF_in_tikzdocument_wo_tikzpicture309 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_TIKZEDT_CMD_COMMENT_in_tikz_cmd_comment330 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_tikz_style_in_tikz_styleorsetorcmd352 = new BitSet(new ulong[]{0x0000000000000002UL});
@@ -12797,28 +12901,28 @@ public partial class simpletikzParser : Parser
     public static readonly BitSet FOLLOW_idd2_in_otherbegin404 = new BitSet(new ulong[]{0x0000100000000000UL});
     public static readonly BitSet FOLLOW_44_in_otherbegin406 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_40_in_tikz_style418 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikz_style420 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_43_in_tikz_style420 = new BitSet(new ulong[]{0xF07847FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
     public static readonly BitSet FOLLOW_idd_in_tikz_style422 = new BitSet(new ulong[]{0x0000100000000000UL});
     public static readonly BitSet FOLLOW_44_in_tikz_style424 = new BitSet(new ulong[]{0x0000600000000000UL});
-    public static readonly BitSet FOLLOW_45_in_tikz_style427 = new BitSet(new ulong[]{0x0080000000000000UL});
-    public static readonly BitSet FOLLOW_46_in_tikz_style431 = new BitSet(new ulong[]{0x0080000000000000UL});
+    public static readonly BitSet FOLLOW_45_in_tikz_style427 = new BitSet(new ulong[]{0x0200000000000000UL});
+    public static readonly BitSet FOLLOW_46_in_tikz_style431 = new BitSet(new ulong[]{0x0200000000000000UL});
     public static readonly BitSet FOLLOW_tikz_options_in_tikz_style434 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_squarebr_start_in_tikz_options456 = new BitSet(new ulong[]{0xFD184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_option_in_tikz_options459 = new BitSet(new ulong[]{0xFD18CFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_47_in_tikz_options462 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_option_in_tikz_options464 = new BitSet(new ulong[]{0xFD18CFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_47_in_tikz_options468 = new BitSet(new ulong[]{0xFD184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzstring_in_tikz_options473 = new BitSet(new ulong[]{0xFD184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_squarebr_start_in_tikz_options456 = new BitSet(new ulong[]{0xF4784FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_option_in_tikz_options459 = new BitSet(new ulong[]{0xF478CFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_47_in_tikz_options462 = new BitSet(new ulong[]{0xF07847FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_option_in_tikz_options464 = new BitSet(new ulong[]{0xF478CFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_47_in_tikz_options468 = new BitSet(new ulong[]{0xF4784FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzstring_in_tikz_options473 = new BitSet(new ulong[]{0xF4784FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
     public static readonly BitSet FOLLOW_squarebr_end_in_tikz_options476 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_option_style_in_option501 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_option_kv_in_option510 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_idd_in_option_kv524 = new BitSet(new ulong[]{0x0000200000000002UL});
-    public static readonly BitSet FOLLOW_45_in_option_kv527 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_45_in_option_kv527 = new BitSet(new ulong[]{0xF0784FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
     public static readonly BitSet FOLLOW_iddornumberunitorstringorrange_in_option_kv529 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_43_in_tikzstring557 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_no_rlbrace_in_tikzstring559 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzstring_in_tikzstring563 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_no_rlbrace_in_tikzstring565 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_43_in_tikzstring557 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_no_rlbrace_in_tikzstring559 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzstring_in_tikzstring563 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_no_rlbrace_in_tikzstring565 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
     public static readonly BitSet FOLLOW_44_in_tikzstring570 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_set_in_no_rlbrace593 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_range_in_iddornumberunitorstringorrange611 = new BitSet(new ulong[]{0x0000000000000002UL});
@@ -12828,296 +12932,303 @@ public partial class simpletikzParser : Parser
     public static readonly BitSet FOLLOW_number_in_iddornumberunitorstringorrange630 = new BitSet(new ulong[]{0x0001000000000000UL});
     public static readonly BitSet FOLLOW_48_in_iddornumberunitorstringorrange633 = new BitSet(new ulong[]{0x0000080000000000UL});
     public static readonly BitSet FOLLOW_tikzstring_in_iddornumberunitorstringorrange638 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_43_in_bracedcoord652 = new BitSet(new ulong[]{0x0020000000000000UL,0x000000000C000000UL});
+    public static readonly BitSet FOLLOW_43_in_bracedcoord652 = new BitSet(new ulong[]{0x0080000000000000UL,0x0000000030000000UL});
     public static readonly BitSet FOLLOW_coord_nooption_in_bracedcoord656 = new BitSet(new ulong[]{0x0000100000000000UL});
     public static readonly BitSet FOLLOW_44_in_bracedcoord658 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_numberunit_in_range669 = new BitSet(new ulong[]{0x0001000000000000UL});
     public static readonly BitSet FOLLOW_48_in_range671 = new BitSet(new ulong[]{0x00000000C0000000UL});
     public static readonly BitSet FOLLOW_numberunit_in_range673 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_idd_in_option_style697 = new BitSet(new ulong[]{0x0006000000000000UL});
-    public static readonly BitSet FOLLOW_49_in_option_style700 = new BitSet(new ulong[]{0x0000200000000000UL});
+    public static readonly BitSet FOLLOW_49_in_option_style700 = new BitSet(new ulong[]{0x0050200000000000UL});
     public static readonly BitSet FOLLOW_50_in_option_style705 = new BitSet(new ulong[]{0x0008000000000000UL});
-    public static readonly BitSet FOLLOW_51_in_option_style707 = new BitSet(new ulong[]{0x0000200000000000UL});
-    public static readonly BitSet FOLLOW_49_in_option_style714 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_number_in_option_style716 = new BitSet(new ulong[]{0x0010000000000000UL});
-    public static readonly BitSet FOLLOW_52_in_option_style718 = new BitSet(new ulong[]{0x0000200000000000UL});
-    public static readonly BitSet FOLLOW_45_in_option_style722 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_option_style724 = new BitSet(new ulong[]{0xFC18D7FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_option_kv_in_option_style727 = new BitSet(new ulong[]{0x0000900000000000UL});
-    public static readonly BitSet FOLLOW_47_in_option_style730 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_option_kv_in_option_style732 = new BitSet(new ulong[]{0x0000900000000000UL});
-    public static readonly BitSet FOLLOW_47_in_option_style739 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_option_style742 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_idd_heavenknowswhythisisnecessary_in_idd777 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_set_in_idd_heavenknowswhythisisnecessary797 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_ID_in_idd2857 = new BitSet(new ulong[]{0x0000000010000002UL});
-    public static readonly BitSet FOLLOW_numberunit_in_numberunitorvariable876 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_COMMAND_in_numberunitorvariable881 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_number_in_numberunit894 = new BitSet(new ulong[]{0xFC00000000000002UL});
-    public static readonly BitSet FOLLOW_unit_in_numberunit896 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_set_in_number922 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_51_in_option_style707 = new BitSet(new ulong[]{0x0050200000000000UL});
+    public static readonly BitSet FOLLOW_52_in_option_style722 = new BitSet(new ulong[]{0x0020000000000000UL});
+    public static readonly BitSet FOLLOW_53_in_option_style724 = new BitSet(new ulong[]{0x0000200000000000UL});
+    public static readonly BitSet FOLLOW_45_in_option_style727 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_option_style729 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_number_in_option_style731 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_option_style733 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_54_in_option_style740 = new BitSet(new ulong[]{0x0020000000000000UL});
+    public static readonly BitSet FOLLOW_53_in_option_style742 = new BitSet(new ulong[]{0x0000200000000000UL});
+    public static readonly BitSet FOLLOW_45_in_option_style746 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_option_style749 = new BitSet(new ulong[]{0xF078D7FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_option_kv_in_option_style752 = new BitSet(new ulong[]{0x0000900000000000UL});
+    public static readonly BitSet FOLLOW_47_in_option_style755 = new BitSet(new ulong[]{0xF07847FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_option_kv_in_option_style757 = new BitSet(new ulong[]{0x0000900000000000UL});
+    public static readonly BitSet FOLLOW_47_in_option_style764 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_option_style767 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_idd_heavenknowswhythisisnecessary_in_idd802 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_set_in_idd_heavenknowswhythisisnecessary822 = new BitSet(new ulong[]{0xF07847FFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_ID_in_idd2882 = new BitSet(new ulong[]{0x0000000010000002UL});
+    public static readonly BitSet FOLLOW_numberunit_in_numberunitorvariable901 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_COMMAND_in_numberunitorvariable906 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_number_in_numberunit919 = new BitSet(new ulong[]{0xF000000000000002UL,0x0000000000000003UL});
+    public static readonly BitSet FOLLOW_unit_in_numberunit921 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_set_in_number947 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_set_in_unit0 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikz_set_start_in_tikz_set977 = new BitSet(new ulong[]{0xFC1857FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_option_in_tikz_set980 = new BitSet(new ulong[]{0xFC18D7FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_47_in_tikz_set983 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_option_in_tikz_set985 = new BitSet(new ulong[]{0xFC18D7FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_47_in_tikz_set989 = new BitSet(new ulong[]{0xFC1857FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_roundbr_end_in_tikz_set994 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzpicture_start_in_tikzpicture1026 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_options_in_tikzpicture1028 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzbody_in_tikzpicture1031 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpicture_end_in_tikzpicture1034 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikz_start_in_tikzpicture1059 = new BitSet(new ulong[]{0x0080080000000000UL});
-    public static readonly BitSet FOLLOW_tikz_options_in_tikzpicture1062 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikzpicture1065 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzbody2_in_tikzpicture1067 = new BitSet(new ulong[]{0xFC1857FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_roundbr_end_in_tikzpicture1070 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody1102 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody1106 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody1110 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody1114 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody1118 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody1122 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody1126 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody1130 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody1134 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherend_in_tikzbody1139 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_dontcare_body_nobr_in_tikzbody1144 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody1155 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody1159 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody1163 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody1167 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody1171 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody1175 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody1179 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody1183 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody1187 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherend_in_tikzbody1192 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_dontcare_body_in_tikzbody1197 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody21213 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody21217 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody21221 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody21225 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody21229 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody21233 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody21237 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody21241 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody21245 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherend_in_tikzbody21250 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_dontcare_body_nobr2_in_tikzbody21255 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody21266 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody21270 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody21274 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody21278 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody21282 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody21286 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody21290 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody21294 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody21298 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherend_in_tikzbody21303 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_dontcare_body2_in_tikzbody21308 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_set_in_dontcare_body_nobr21325 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_set_in_dontcare_body21419 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_set_in_dontcare_body_nobr1509 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_set_in_dontcare_body1596 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_64_in_otherend1679 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_otherend1681 = new BitSet(new ulong[]{0x0000000010000000UL});
-    public static readonly BitSet FOLLOW_idd2_in_otherend1683 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_otherend1685 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzscope_start_in_tikzscope1712 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_options_in_tikzscope1714 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzbody_in_tikzscope1717 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzscope_end_in_tikzscope1720 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_path_start_in_tikzpath1776 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzpath1778 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_semicolon_end_in_tikzpath1781 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikz_set_start_in_tikz_set1002 = new BitSet(new ulong[]{0xF07857FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_option_in_tikz_set1005 = new BitSet(new ulong[]{0xF078D7FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_47_in_tikz_set1008 = new BitSet(new ulong[]{0xF07847FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_option_in_tikz_set1010 = new BitSet(new ulong[]{0xF078D7FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_47_in_tikz_set1014 = new BitSet(new ulong[]{0xF07857FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_roundbr_end_in_tikz_set1019 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzpicture_start_in_tikzpicture1051 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_options_in_tikzpicture1053 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzbody_in_tikzpicture1056 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpicture_end_in_tikzpicture1059 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikz_start_in_tikzpicture1084 = new BitSet(new ulong[]{0x0200080000000000UL});
+    public static readonly BitSet FOLLOW_tikz_options_in_tikzpicture1087 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_tikzpicture1090 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzbody2_in_tikzpicture1092 = new BitSet(new ulong[]{0xF07857FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_roundbr_end_in_tikzpicture1095 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody1127 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody1131 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody1135 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody1139 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody1143 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody1147 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody1151 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody1155 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody1159 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherend_in_tikzbody1164 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_dontcare_body_nobr_in_tikzbody1169 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody1180 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody1184 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody1188 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody1192 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody1196 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody1200 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody1204 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody1208 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody1212 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherend_in_tikzbody1217 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_dontcare_body_in_tikzbody1222 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody21238 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody21242 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody21246 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody21250 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody21254 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody21258 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody21262 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody21266 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody21270 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherend_in_tikzbody21275 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_dontcare_body_nobr2_in_tikzbody21280 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody21291 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody21295 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody21299 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody21303 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody21307 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody21311 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody21315 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody21319 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody21323 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherend_in_tikzbody21328 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_dontcare_body2_in_tikzbody21333 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_set_in_dontcare_body_nobr21350 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_set_in_dontcare_body21444 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_set_in_dontcare_body_nobr1534 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_set_in_dontcare_body1621 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_66_in_otherend1704 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_otherend1706 = new BitSet(new ulong[]{0x0000000010000000UL});
+    public static readonly BitSet FOLLOW_idd2_in_otherend1708 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_otherend1710 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzscope_start_in_tikzscope1737 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_options_in_tikzscope1739 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzbody_in_tikzscope1742 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzscope_end_in_tikzscope1745 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_path_start_in_tikzpath1801 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzpath1803 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_semicolon_end_in_tikzpath1806 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_set_in_let_cmd_parts0 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_single_in_tikzpath_element1837 = new BitSet(new ulong[]{0x0000800000000002UL});
-    public static readonly BitSet FOLLOW_47_in_tikzpath_element1839 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikz_options_in_tikzpath_element_single1857 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_let_cmd_parts_in_tikzpath_element_single1864 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_arc_in_tikzpath_element_single1882 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_in_tikzpath_element_single1892 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_controls_in_tikzpath_element_single1898 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikznode_int_in_tikzpath_element_single1904 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_int_in_tikzpath_element_single1910 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_circle_in_tikzpath_element_single1916 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_roundbr_start_in_tikzpath_element_single1923 = new BitSet(new ulong[]{0xFCB87FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzpath_element_single1925 = new BitSet(new ulong[]{0xFCB87FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_roundbr_end_in_tikzpath_element_single1928 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_53_in_tikzpath_element_single1948 = new BitSet(new ulong[]{0x08E0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzpath_element_single1950 = new BitSet(new ulong[]{0x08E0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_54_in_tikzpath_element_single1953 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_edgeop_in_tikzpath_element_single1972 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_controls_start_in_controls1987 = new BitSet(new ulong[]{0x0020000000000000UL,0x000000000C000000UL});
-    public static readonly BitSet FOLLOW_coord_in_controls1989 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000010008000UL});
-    public static readonly BitSet FOLLOW_79_in_controls1992 = new BitSet(new ulong[]{0x0020000000000000UL,0x000000000C000000UL});
-    public static readonly BitSet FOLLOW_coord_in_controls1994 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000010008000UL});
-    public static readonly BitSet FOLLOW_controls_end_in_controls1998 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_node_start_in_tikznode_ext2024 = new BitSet(new ulong[]{0x00A0080000000000UL,0x0000000000040000UL});
-    public static readonly BitSet FOLLOW_tikznode_core_in_tikznode_ext2026 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikznode_ext2028 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_semicolon_end_in_tikznode_ext2031 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_def_start_in_tikzdef_ext2056 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzdef_ext2058 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_semicolon_end_in_tikzdef_ext2061 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_matrix_start_in_tikzmatrix_ext2086 = new BitSet(new ulong[]{0x00A0080000000000UL,0x0000000000040000UL});
-    public static readonly BitSet FOLLOW_tikznode_core_in_tikzmatrix_ext2088 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzmatrix_ext2090 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_semicolon_end_in_tikzmatrix_ext2093 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coordinate_start_in_tikzcoordinate_ext2121 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFF4000UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_ext2136 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_ext2155 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_ext2175 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzcoordinate_ext2186 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
-    public static readonly BitSet FOLLOW_semicolon_end_in_tikzcoordinate_ext2189 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_80_in_tikzcoordinate_int2249 = new BitSet(new ulong[]{0x00A0000000000002UL,0x0000000000040000UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_int2260 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_int2279 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_int2299 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_81_in_tikznode_int2315 = new BitSet(new ulong[]{0x00A0080000000000UL,0x0000000000040000UL});
-    public static readonly BitSet FOLLOW_tikznode_core_in_tikznode_int2318 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikznode_core2328 = new BitSet(new ulong[]{0x00A0080000000000UL,0x0000000000040000UL});
-    public static readonly BitSet FOLLOW_tikzstring_in_tikznode_core2331 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core32356 = new BitSet(new ulong[]{0x00A0000000000000UL,0x0000000000040000UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core32358 = new BitSet(new ulong[]{0x00A0000000000000UL,0x0000000000040000UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core32360 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core22394 = new BitSet(new ulong[]{0x00A0000000000000UL,0x0000000000040000UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core22396 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core12429 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_nodename_in_tikznode_decorator2466 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_82_in_tikznode_decorator2473 = new BitSet(new ulong[]{0x0000000020000000UL});
-    public static readonly BitSet FOLLOW_COMMAND_in_tikznode_decorator2476 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_82_in_tikznode_decorator2482 = new BitSet(new ulong[]{0x0020000000000000UL,0x000000000C000000UL});
-    public static readonly BitSet FOLLOW_coord_in_tikznode_decorator2485 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikz_options_dontcare_in_tikznode_decorator2491 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_55_in_tikz_options_dontcare2501 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_no_rlbracket_in_tikz_options_dontcare2503 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_options_dontcare_in_tikz_options_dontcare2507 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_no_rlbracket_in_tikz_options_dontcare2509 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_56_in_tikz_options_dontcare2514 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_set_in_no_rlbracket2532 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_53_in_nodename2549 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_idd_in_nodename2551 = new BitSet(new ulong[]{0x0040000000000000UL});
-    public static readonly BitSet FOLLOW_54_in_nodename2553 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_83_in_circle2578 = new BitSet(new ulong[]{0x0020000000000002UL});
-    public static readonly BitSet FOLLOW_84_in_circle2582 = new BitSet(new ulong[]{0x0020000000000002UL});
-    public static readonly BitSet FOLLOW_size_in_circle2591 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_85_in_arc2606 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_arc2609 = new BitSet(new ulong[]{0x00000000E0000000UL});
-    public static readonly BitSet FOLLOW_numberunitorvariable_in_arc2611 = new BitSet(new ulong[]{0x0001000000000000UL});
-    public static readonly BitSet FOLLOW_48_in_arc2613 = new BitSet(new ulong[]{0x00000000E0000000UL});
-    public static readonly BitSet FOLLOW_numberunitorvariable_in_arc2615 = new BitSet(new ulong[]{0x0001000000000000UL});
-    public static readonly BitSet FOLLOW_48_in_arc2617 = new BitSet(new ulong[]{0x00000000E0000000UL});
-    public static readonly BitSet FOLLOW_numberunitorvariable_in_arc2619 = new BitSet(new ulong[]{0x0040000000000000UL,0x0000000000008000UL});
-    public static readonly BitSet FOLLOW_79_in_arc2622 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_arc2624 = new BitSet(new ulong[]{0x0040000000000000UL});
-    public static readonly BitSet FOLLOW_54_in_arc2628 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_85_in_arc2646 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_arc2649 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_arc2651 = new BitSet(new ulong[]{0x0001000000000000UL});
-    public static readonly BitSet FOLLOW_48_in_arc2653 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_arc2655 = new BitSet(new ulong[]{0x0001000000000000UL});
-    public static readonly BitSet FOLLOW_48_in_arc2657 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_arc2659 = new BitSet(new ulong[]{0x0040000000000000UL,0x0000000000008000UL});
-    public static readonly BitSet FOLLOW_79_in_arc2662 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_arc2664 = new BitSet(new ulong[]{0x0040000000000000UL});
-    public static readonly BitSet FOLLOW_54_in_arc2668 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_85_in_arc2686 = new BitSet(new ulong[]{0x0080000000000000UL});
-    public static readonly BitSet FOLLOW_tikz_options_in_arc2688 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_53_in_size2713 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_size2715 = new BitSet(new ulong[]{0x0040000000000000UL,0x0000000000008000UL});
-    public static readonly BitSet FOLLOW_79_in_size2718 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_size2720 = new BitSet(new ulong[]{0x0040000000000000UL});
-    public static readonly BitSet FOLLOW_54_in_size2724 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_53_in_coord_nodename2752 = new BitSet(new ulong[]{0xFC9847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_options_in_coord_nodename2754 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_idd_in_coord_nodename2757 = new BitSet(new ulong[]{0x0040000000000000UL});
-    public static readonly BitSet FOLLOW_54_in_coord_nodename2760 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_modifier_in_coord2786 = new BitSet(new ulong[]{0x0020000000000000UL,0x000000000C000000UL});
-    public static readonly BitSet FOLLOW_coord_nodename_in_coord2789 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_modifier_in_coord2815 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_coord2818 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_coord2820 = new BitSet(new ulong[]{0x0001800000000000UL});
-    public static readonly BitSet FOLLOW_coord_sep_in_coord2822 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_coord2824 = new BitSet(new ulong[]{0x0040000000000000UL});
-    public static readonly BitSet FOLLOW_54_in_coord2826 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_modifier_in_coord2850 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_coord2853 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_coord2855 = new BitSet(new ulong[]{0x0001800000000000UL});
-    public static readonly BitSet FOLLOW_coord_sep_in_coord2857 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_coord2859 = new BitSet(new ulong[]{0x0040000000000000UL});
-    public static readonly BitSet FOLLOW_54_in_coord2861 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_modifier_in_coord2885 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_coord2888 = new BitSet(new ulong[]{0x0040000000000000UL});
-    public static readonly BitSet FOLLOW_54_in_coord2890 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_nodename_in_coord_nooption2918 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_modifier_in_coord_nooption2942 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_coord_nooption2945 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_coord_nooption2947 = new BitSet(new ulong[]{0x0001800000000000UL});
-    public static readonly BitSet FOLLOW_coord_sep_in_coord_nooption2949 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_coord_nooption2951 = new BitSet(new ulong[]{0x0040000000000000UL});
-    public static readonly BitSet FOLLOW_54_in_coord_nooption2953 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_modifier_in_coord_nooption2977 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_coord_nooption2980 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_coord_nooption2982 = new BitSet(new ulong[]{0x0001800000000000UL});
-    public static readonly BitSet FOLLOW_coord_sep_in_coord_nooption2984 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_coord_nooption2986 = new BitSet(new ulong[]{0x0040000000000000UL});
-    public static readonly BitSet FOLLOW_54_in_coord_nooption2988 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_idd_in_coord_part3021 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_43_in_coord_part3036 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_idd_in_coord_part3038 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_coord_part3040 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_idd_in_coord_part3058 = new BitSet(new ulong[]{0x0000200000000000UL});
-    public static readonly BitSet FOLLOW_45_in_coord_part3060 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_coord_part3062 = new BitSet(new ulong[]{0xFC18C7FFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_47_in_coord_part3064 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF2UL,0x00000000FFFFFFFFUL});
-    public static readonly BitSet FOLLOW_set_in_coord_sep3096 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_single_in_tikzpath_element1862 = new BitSet(new ulong[]{0x0000800000000002UL});
+    public static readonly BitSet FOLLOW_47_in_tikzpath_element1864 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikz_options_in_tikzpath_element_single1882 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_let_cmd_parts_in_tikzpath_element_single1889 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_arc_in_tikzpath_element_single1907 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_in_tikzpath_element_single1917 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_controls_in_tikzpath_element_single1923 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikznode_int_in_tikzpath_element_single1929 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_int_in_tikzpath_element_single1935 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_circle_in_tikzpath_element_single1941 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_roundbr_start_in_tikzpath_element_single1948 = new BitSet(new ulong[]{0xF2F87FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzpath_element_single1950 = new BitSet(new ulong[]{0xF2F87FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_roundbr_end_in_tikzpath_element_single1953 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_55_in_tikzpath_element_single1973 = new BitSet(new ulong[]{0x2380280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzpath_element_single1975 = new BitSet(new ulong[]{0x2380280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_56_in_tikzpath_element_single1978 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_edgeop_in_tikzpath_element_single1997 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_controls_start_in_controls2012 = new BitSet(new ulong[]{0x0080000000000000UL,0x0000000030000000UL});
+    public static readonly BitSet FOLLOW_coord_in_controls2014 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000040020000UL});
+    public static readonly BitSet FOLLOW_81_in_controls2017 = new BitSet(new ulong[]{0x0080000000000000UL,0x0000000030000000UL});
+    public static readonly BitSet FOLLOW_coord_in_controls2019 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000040020000UL});
+    public static readonly BitSet FOLLOW_controls_end_in_controls2023 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_node_start_in_tikznode_ext2049 = new BitSet(new ulong[]{0x0280080000000000UL,0x0000000000100000UL});
+    public static readonly BitSet FOLLOW_tikznode_core_in_tikznode_ext2051 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikznode_ext2053 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_semicolon_end_in_tikznode_ext2056 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_def_start_in_tikzdef_ext2081 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzdef_ext2083 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_semicolon_end_in_tikzdef_ext2086 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_matrix_start_in_tikzmatrix_ext2111 = new BitSet(new ulong[]{0x0280080000000000UL,0x0000000000100000UL});
+    public static readonly BitSet FOLLOW_tikznode_core_in_tikzmatrix_ext2113 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzmatrix_ext2115 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_semicolon_end_in_tikzmatrix_ext2118 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coordinate_start_in_tikzcoordinate_ext2146 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FFD0000UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_ext2161 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_ext2180 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_ext2200 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzcoordinate_ext2211 = new BitSet(new ulong[]{0x2A80280030000000UL,0x000000007FED0000UL});
+    public static readonly BitSet FOLLOW_semicolon_end_in_tikzcoordinate_ext2214 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_82_in_tikzcoordinate_int2274 = new BitSet(new ulong[]{0x0280000000000002UL,0x0000000000100000UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_int2285 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_int2304 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_int2324 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_83_in_tikznode_int2340 = new BitSet(new ulong[]{0x0280080000000000UL,0x0000000000100000UL});
+    public static readonly BitSet FOLLOW_tikznode_core_in_tikznode_int2343 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikznode_core2353 = new BitSet(new ulong[]{0x0280080000000000UL,0x0000000000100000UL});
+    public static readonly BitSet FOLLOW_tikzstring_in_tikznode_core2356 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core32381 = new BitSet(new ulong[]{0x0280000000000000UL,0x0000000000100000UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core32383 = new BitSet(new ulong[]{0x0280000000000000UL,0x0000000000100000UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core32385 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core22419 = new BitSet(new ulong[]{0x0280000000000000UL,0x0000000000100000UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core22421 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core12454 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_nodename_in_tikznode_decorator2491 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_84_in_tikznode_decorator2498 = new BitSet(new ulong[]{0x0000000020000000UL});
+    public static readonly BitSet FOLLOW_COMMAND_in_tikznode_decorator2501 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_84_in_tikznode_decorator2507 = new BitSet(new ulong[]{0x0080000000000000UL,0x0000000030000000UL});
+    public static readonly BitSet FOLLOW_coord_in_tikznode_decorator2510 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikz_options_dontcare_in_tikznode_decorator2516 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_57_in_tikz_options_dontcare2526 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_no_rlbracket_in_tikz_options_dontcare2528 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_options_dontcare_in_tikz_options_dontcare2532 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_no_rlbracket_in_tikz_options_dontcare2534 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_58_in_tikz_options_dontcare2539 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_set_in_no_rlbracket2557 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_55_in_nodename2574 = new BitSet(new ulong[]{0xF07847FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_idd_in_nodename2576 = new BitSet(new ulong[]{0x0100000000000000UL});
+    public static readonly BitSet FOLLOW_56_in_nodename2578 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_85_in_circle2603 = new BitSet(new ulong[]{0x0080000000000002UL});
+    public static readonly BitSet FOLLOW_86_in_circle2607 = new BitSet(new ulong[]{0x0080000000000002UL});
+    public static readonly BitSet FOLLOW_size_in_circle2616 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_87_in_arc2631 = new BitSet(new ulong[]{0x0080000000000000UL});
+    public static readonly BitSet FOLLOW_55_in_arc2634 = new BitSet(new ulong[]{0x00000000E0000000UL});
+    public static readonly BitSet FOLLOW_numberunitorvariable_in_arc2636 = new BitSet(new ulong[]{0x0001000000000000UL});
+    public static readonly BitSet FOLLOW_48_in_arc2638 = new BitSet(new ulong[]{0x00000000E0000000UL});
+    public static readonly BitSet FOLLOW_numberunitorvariable_in_arc2640 = new BitSet(new ulong[]{0x0001000000000000UL});
+    public static readonly BitSet FOLLOW_48_in_arc2642 = new BitSet(new ulong[]{0x00000000E0000000UL});
+    public static readonly BitSet FOLLOW_numberunitorvariable_in_arc2644 = new BitSet(new ulong[]{0x0100000000000000UL,0x0000000000020000UL});
+    public static readonly BitSet FOLLOW_81_in_arc2647 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_arc2649 = new BitSet(new ulong[]{0x0100000000000000UL});
+    public static readonly BitSet FOLLOW_56_in_arc2653 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_87_in_arc2671 = new BitSet(new ulong[]{0x0080000000000000UL});
+    public static readonly BitSet FOLLOW_55_in_arc2674 = new BitSet(new ulong[]{0xF0784FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_arc2676 = new BitSet(new ulong[]{0x0001000000000000UL});
+    public static readonly BitSet FOLLOW_48_in_arc2678 = new BitSet(new ulong[]{0xF0784FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_arc2680 = new BitSet(new ulong[]{0x0001000000000000UL});
+    public static readonly BitSet FOLLOW_48_in_arc2682 = new BitSet(new ulong[]{0xF0784FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_arc2684 = new BitSet(new ulong[]{0x0100000000000000UL,0x0000000000020000UL});
+    public static readonly BitSet FOLLOW_81_in_arc2687 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_arc2689 = new BitSet(new ulong[]{0x0100000000000000UL});
+    public static readonly BitSet FOLLOW_56_in_arc2693 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_87_in_arc2711 = new BitSet(new ulong[]{0x0200000000000000UL});
+    public static readonly BitSet FOLLOW_tikz_options_in_arc2713 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_55_in_size2738 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_size2740 = new BitSet(new ulong[]{0x0100000000000000UL,0x0000000000020000UL});
+    public static readonly BitSet FOLLOW_81_in_size2743 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_size2745 = new BitSet(new ulong[]{0x0100000000000000UL});
+    public static readonly BitSet FOLLOW_56_in_size2749 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_55_in_coord_nodename2777 = new BitSet(new ulong[]{0xF27847FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_options_in_coord_nodename2779 = new BitSet(new ulong[]{0xF07847FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_idd_in_coord_nodename2782 = new BitSet(new ulong[]{0x0100000000000000UL});
+    public static readonly BitSet FOLLOW_56_in_coord_nodename2785 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_modifier_in_coord2811 = new BitSet(new ulong[]{0x0080000000000000UL,0x0000000030000000UL});
+    public static readonly BitSet FOLLOW_coord_nodename_in_coord2814 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_modifier_in_coord2840 = new BitSet(new ulong[]{0x0080000000000000UL});
+    public static readonly BitSet FOLLOW_55_in_coord2843 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_coord2845 = new BitSet(new ulong[]{0x0001800000000000UL});
+    public static readonly BitSet FOLLOW_coord_sep_in_coord2847 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_coord2849 = new BitSet(new ulong[]{0x0100000000000000UL});
+    public static readonly BitSet FOLLOW_56_in_coord2851 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_modifier_in_coord2875 = new BitSet(new ulong[]{0x0080000000000000UL});
+    public static readonly BitSet FOLLOW_55_in_coord2878 = new BitSet(new ulong[]{0xF0784FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_coord2880 = new BitSet(new ulong[]{0x0001800000000000UL});
+    public static readonly BitSet FOLLOW_coord_sep_in_coord2882 = new BitSet(new ulong[]{0xF0784FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_coord2884 = new BitSet(new ulong[]{0x0100000000000000UL});
+    public static readonly BitSet FOLLOW_56_in_coord2886 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_modifier_in_coord2910 = new BitSet(new ulong[]{0x0080000000000000UL});
+    public static readonly BitSet FOLLOW_55_in_coord2913 = new BitSet(new ulong[]{0x0100000000000000UL});
+    public static readonly BitSet FOLLOW_56_in_coord2915 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_nodename_in_coord_nooption2943 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_modifier_in_coord_nooption2967 = new BitSet(new ulong[]{0x0080000000000000UL});
+    public static readonly BitSet FOLLOW_55_in_coord_nooption2970 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_coord_nooption2972 = new BitSet(new ulong[]{0x0001800000000000UL});
+    public static readonly BitSet FOLLOW_coord_sep_in_coord_nooption2974 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_coord_nooption2976 = new BitSet(new ulong[]{0x0100000000000000UL});
+    public static readonly BitSet FOLLOW_56_in_coord_nooption2978 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_modifier_in_coord_nooption3002 = new BitSet(new ulong[]{0x0080000000000000UL});
+    public static readonly BitSet FOLLOW_55_in_coord_nooption3005 = new BitSet(new ulong[]{0xF0784FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_coord_nooption3007 = new BitSet(new ulong[]{0x0001800000000000UL});
+    public static readonly BitSet FOLLOW_coord_sep_in_coord_nooption3009 = new BitSet(new ulong[]{0xF0784FFFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_coord_nooption3011 = new BitSet(new ulong[]{0x0100000000000000UL});
+    public static readonly BitSet FOLLOW_56_in_coord_nooption3013 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_idd_in_coord_part3046 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_43_in_coord_part3061 = new BitSet(new ulong[]{0xF07847FFFFFFFFF0UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_idd_in_coord_part3063 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_coord_part3065 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_idd_in_coord_part3083 = new BitSet(new ulong[]{0x0000200000000000UL});
+    public static readonly BitSet FOLLOW_45_in_coord_part3085 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_coord_part3087 = new BitSet(new ulong[]{0xF078C7FFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_47_in_coord_part3089 = new BitSet(new ulong[]{0xF07847FFFFFFFFF2UL,0x00000003FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_set_in_coord_sep3121 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_set_in_edgeop0 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_set_in_coord_modifier0 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_55_in_squarebr_start3170 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_56_in_squarebr_end3188 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_57_in_semicolon_end3207 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_43_in_roundbr_start3225 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_44_in_roundbr_end3243 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_92_in_controls_start3261 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000020000000UL});
-    public static readonly BitSet FOLLOW_93_in_controls_start3263 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_92_in_controls_end3281 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_41_in_tikz_set_start3299 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikz_set_start3301 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_39_in_tikzpicture_start3320 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikzpicture_start3322 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000040000000UL});
-    public static readonly BitSet FOLLOW_94_in_tikzpicture_start3324 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_tikzpicture_start3326 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_42_in_tikz_start3344 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_64_in_tikzpicture_end3362 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikzpicture_end3364 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000040000000UL});
-    public static readonly BitSet FOLLOW_94_in_tikzpicture_end3366 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_tikzpicture_end3368 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_39_in_tikzscope_start3386 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikzscope_start3388 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000080000000UL});
-    public static readonly BitSet FOLLOW_95_in_tikzscope_start3390 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_tikzscope_start3392 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_64_in_tikzscope_end3410 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikzscope_end3412 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000080000000UL});
-    public static readonly BitSet FOLLOW_95_in_tikzscope_end3414 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_tikzscope_end3416 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_path_start_tag_in_path_start3435 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_node_start_tag_in_node_start3453 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_def_start_tag_in_def_start3471 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_matrix_start_tag_in_matrix_start3489 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_65_in_node_start_tag3507 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_70_in_def_start_tag3517 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_66_in_matrix_start_tag3527 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_67_in_coordinate_start3537 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_57_in_squarebr_start3195 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_58_in_squarebr_end3213 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_59_in_semicolon_end3232 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_43_in_roundbr_start3250 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_44_in_roundbr_end3268 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_94_in_controls_start3286 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000080000000UL});
+    public static readonly BitSet FOLLOW_95_in_controls_start3288 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_94_in_controls_end3306 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_41_in_tikz_set_start3324 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_tikz_set_start3326 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_39_in_tikzpicture_start3345 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_tikzpicture_start3347 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000100000000UL});
+    public static readonly BitSet FOLLOW_96_in_tikzpicture_start3349 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_tikzpicture_start3351 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_42_in_tikz_start3369 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_66_in_tikzpicture_end3387 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_tikzpicture_end3389 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000100000000UL});
+    public static readonly BitSet FOLLOW_96_in_tikzpicture_end3391 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_tikzpicture_end3393 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_39_in_tikzscope_start3411 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_tikzscope_start3413 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000200000000UL});
+    public static readonly BitSet FOLLOW_97_in_tikzscope_start3415 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_tikzscope_start3417 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_66_in_tikzscope_end3435 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_tikzscope_end3437 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000200000000UL});
+    public static readonly BitSet FOLLOW_97_in_tikzscope_end3439 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_tikzscope_end3441 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_path_start_tag_in_path_start3460 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_node_start_tag_in_node_start3478 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_def_start_tag_in_def_start3496 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_matrix_start_tag_in_matrix_start3514 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_67_in_node_start_tag3532 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_72_in_def_start_tag3542 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_68_in_matrix_start_tag3552 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_69_in_coordinate_start3562 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_set_in_path_start_tag0 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_in_synpred1_simpletikz1889 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_synpred2_simpletikz2132 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_synpred3_simpletikz2151 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_synpred4_simpletikz2171 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_synpred5_simpletikz2256 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_synpred6_simpletikz2275 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_synpred7_simpletikz2295 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_size_in_synpred8_simpletikz2587 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_52_in_synpred1_simpletikz715 = new BitSet(new ulong[]{0x0020000000000000UL});
+    public static readonly BitSet FOLLOW_53_in_synpred1_simpletikz717 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_in_synpred2_simpletikz1914 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_synpred3_simpletikz2157 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_synpred4_simpletikz2176 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_synpred5_simpletikz2196 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_synpred6_simpletikz2281 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_synpred7_simpletikz2300 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_synpred8_simpletikz2320 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_size_in_synpred9_simpletikz2612 = new BitSet(new ulong[]{0x0000000000000002UL});
 
 }

--- a/TikzParser/output/simpletikzParser.cs
+++ b/TikzParser/output/simpletikzParser.cs
@@ -1,4 +1,4 @@
-// $ANTLR 3.1.1 C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g 2013-07-01 14:00:49
+// $ANTLR 3.1.1 E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g 2016-09-21 11:07:05
 
 using System;
 using Antlr.Runtime;
@@ -68,6 +68,7 @@ public partial class simpletikzParser : Parser
 		"'/.style'", 
 		"'/.append'", 
 		"'style'", 
+		"'args'", 
 		"'('", 
 		"')'", 
 		"'['", 
@@ -113,98 +114,99 @@ public partial class simpletikzParser : Parser
 		"'scope'"
     };
 
-    public const int EXPONENT = 34;
-    public const int TIKZEDT_CMD_COMMENT = 27;
-    public const int IM_PATH = 4;
-    public const int IM_ID = 18;
-    public const int IM_DONTCARE = 25;
-    public const int SOMETHING = 37;
-    public const int EOF = -1;
-    public const int IM_ARC = 26;
-    public const int COMMAND = 29;
-    public const int IM_ENDTAG = 14;
-    public const int T__93 = 93;
-    public const int T__94 = 94;
-    public const int T__91 = 91;
-    public const int T__92 = 92;
-    public const int IM_DOCUMENT = 11;
-    public const int IM_STRING = 21;
-    public const int T__90 = 90;
-    public const int IM_TIKZSET = 19;
-    public const int COMMENT = 33;
-    public const int SOMETHING1 = 38;
-    public const int T__80 = 80;
+    public const int T__50 = 50;
+    public const int IM_NUMBERUNIT = 9;
     public const int IM_OPTIONS = 15;
-    public const int T__81 = 81;
-    public const int T__82 = 82;
-    public const int IM_OPTION_STYLE = 16;
-    public const int T__83 = 83;
-    public const int IM_COORD = 6;
-    public const int INT = 31;
-    public const int T__85 = 85;
-    public const int T__84 = 84;
-    public const int T__87 = 87;
-    public const int T__86 = 86;
-    public const int T__89 = 89;
-    public const int T__88 = 88;
-    public const int IM_NODE = 5;
-    public const int IM_STYLE = 22;
-    public const int T__71 = 71;
-    public const int WS = 32;
-    public const int T__72 = 72;
-    public const int T__70 = 70;
-    public const int T__76 = 76;
-    public const int T__75 = 75;
-    public const int T__74 = 74;
-    public const int T__73 = 73;
-    public const int T__79 = 79;
-    public const int T__78 = 78;
-    public const int T__77 = 77;
-    public const int T__68 = 68;
-    public const int T__69 = 69;
-    public const int T__66 = 66;
-    public const int T__67 = 67;
-    public const int T__64 = 64;
-    public const int T__65 = 65;
-    public const int IM_STARTTAG = 13;
-    public const int T__62 = 62;
-    public const int T__63 = 63;
-    public const int IM_CONTROLS = 23;
-    public const int T__61 = 61;
-    public const int ID = 28;
-    public const int T__60 = 60;
-    public const int MATHSTRING = 36;
+    public const int IM_PATH = 4;
+    public const int T__59 = 59;
     public const int T__55 = 55;
-    public const int IM_USETIKZLIB = 20;
+    public const int IM_TIKZEDT_CMD = 24;
     public const int T__56 = 56;
     public const int T__57 = 57;
+    public const int IM_SCOPE = 12;
     public const int T__58 = 58;
-    public const int ESC_SEQ = 35;
+    public const int ID = 28;
     public const int T__51 = 51;
     public const int T__52 = 52;
+    public const int IM_NODENAME = 8;
     public const int T__53 = 53;
     public const int T__54 = 54;
-    public const int T__59 = 59;
-    public const int IM_OPTION_KV = 17;
-    public const int T__50 = 50;
-    public const int IM_TIKZEDT_CMD = 24;
-    public const int T__42 = 42;
-    public const int T__43 = 43;
-    public const int T__40 = 40;
-    public const int T__41 = 41;
-    public const int T__46 = 46;
-    public const int T__47 = 47;
-    public const int T__44 = 44;
-    public const int T__45 = 45;
+    public const int T__60 = 60;
+    public const int T__61 = 61;
+    public const int SOMETHING1 = 38;
+    public const int SOMETHING = 37;
+    public const int T__66 = 66;
+    public const int T__67 = 67;
+    public const int T__68 = 68;
+    public const int T__69 = 69;
+    public const int T__62 = 62;
+    public const int T__63 = 63;
+    public const int T__64 = 64;
+    public const int T__65 = 65;
+    public const int IM_ID = 18;
+    public const int COMMENT = 33;
+    public const int IM_SIZE = 7;
+    public const int T__39 = 39;
+    public const int IM_NODE = 5;
+    public const int COMMAND = 29;
+    public const int IM_DOCUMENT = 11;
+    public const int IM_STARTTAG = 13;
+    public const int IM_ARC = 26;
     public const int T__48 = 48;
     public const int T__49 = 49;
-    public const int IM_PICTURE = 10;
-    public const int IM_NUMBERUNIT = 9;
-    public const int IM_SCOPE = 12;
-    public const int T__39 = 39;
-    public const int IM_SIZE = 7;
-    public const int IM_NODENAME = 8;
+    public const int T__44 = 44;
+    public const int T__45 = 45;
+    public const int EXPONENT = 34;
+    public const int T__46 = 46;
+    public const int T__47 = 47;
+    public const int T__40 = 40;
+    public const int T__41 = 41;
+    public const int IM_TIKZSET = 19;
+    public const int T__42 = 42;
+    public const int T__43 = 43;
+    public const int T__91 = 91;
+    public const int T__92 = 92;
+    public const int T__93 = 93;
+    public const int T__94 = 94;
+    public const int T__90 = 90;
+    public const int IM_ENDTAG = 14;
+    public const int IM_STRING = 21;
+    public const int MATHSTRING = 36;
+    public const int T__95 = 95;
+    public const int IM_COORD = 6;
+    public const int IM_USETIKZLIB = 20;
     public const int FLOAT_WO_EXP = 30;
+    public const int IM_PICTURE = 10;
+    public const int IM_DONTCARE = 25;
+    public const int T__70 = 70;
+    public const int T__71 = 71;
+    public const int T__72 = 72;
+    public const int IM_OPTION_STYLE = 16;
+    public const int INT = 31;
+    public const int IM_OPTION_KV = 17;
+    public const int T__77 = 77;
+    public const int T__78 = 78;
+    public const int ESC_SEQ = 35;
+    public const int T__79 = 79;
+    public const int T__73 = 73;
+    public const int WS = 32;
+    public const int EOF = -1;
+    public const int T__74 = 74;
+    public const int T__75 = 75;
+    public const int T__76 = 76;
+    public const int T__80 = 80;
+    public const int T__81 = 81;
+    public const int T__82 = 82;
+    public const int T__83 = 83;
+    public const int TIKZEDT_CMD_COMMENT = 27;
+    public const int T__88 = 88;
+    public const int T__89 = 89;
+    public const int T__84 = 84;
+    public const int T__85 = 85;
+    public const int IM_STYLE = 22;
+    public const int T__86 = 86;
+    public const int T__87 = 87;
+    public const int IM_CONTROLS = 23;
 
     // delegates
     // delegators
@@ -237,7 +239,7 @@ public partial class simpletikzParser : Parser
     }
 
     override public string GrammarFileName {
-		get { return "C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g"; }
+		get { return "E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g"; }
     }
 
 
@@ -266,7 +268,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzdocument"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:140:1: tikzdocument : ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )* tikzpicture ( . )* -> ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* tikzpicture ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:140:1: tikzdocument : ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )* tikzpicture ( . )* -> ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* tikzpicture ) ;
     public simpletikzParser.tikzdocument_return tikzdocument() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzdocument_return retval = new simpletikzParser.tikzdocument_return();
@@ -285,16 +287,16 @@ public partial class simpletikzParser : Parser
 
 
         object wildcard5_tree=null;
-        RewriteRuleSubtreeStream stream_dontcare_preamble = new RewriteRuleSubtreeStream(adaptor,"rule dontcare_preamble");
         RewriteRuleSubtreeStream stream_tikzpicture = new RewriteRuleSubtreeStream(adaptor,"rule tikzpicture");
-        RewriteRuleSubtreeStream stream_otherbegin = new RewriteRuleSubtreeStream(adaptor,"rule otherbegin");
+        RewriteRuleSubtreeStream stream_dontcare_preamble = new RewriteRuleSubtreeStream(adaptor,"rule dontcare_preamble");
         RewriteRuleSubtreeStream stream_tikz_styleorsetorcmd = new RewriteRuleSubtreeStream(adaptor,"rule tikz_styleorsetorcmd");
+        RewriteRuleSubtreeStream stream_otherbegin = new RewriteRuleSubtreeStream(adaptor,"rule otherbegin");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:141:2: ( ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )* tikzpicture ( . )* -> ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* tikzpicture ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:141:4: ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )* tikzpicture ( . )*
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:141:2: ( ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )* tikzpicture ( . )* -> ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* tikzpicture ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:141:4: ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )* tikzpicture ( . )*
             {
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:141:4: ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:141:4: ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )*
             	do 
             	{
             	    int alt1 = 4;
@@ -405,6 +407,7 @@ public partial class simpletikzParser : Parser
             	    case 92:
             	    case 93:
             	    case 94:
+            	    case 95:
             	    	{
             	        alt1 = 1;
             	        }
@@ -422,7 +425,7 @@ public partial class simpletikzParser : Parser
             	    switch (alt1) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:141:5: dontcare_preamble
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:141:5: dontcare_preamble
             			    {
             			    	PushFollow(FOLLOW_dontcare_preamble_in_tikzdocument257);
             			    	dontcare_preamble1 = dontcare_preamble();
@@ -433,7 +436,7 @@ public partial class simpletikzParser : Parser
             			    }
             			    break;
             			case 2 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:141:25: tikz_styleorsetorcmd
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:141:25: tikz_styleorsetorcmd
             			    {
             			    	PushFollow(FOLLOW_tikz_styleorsetorcmd_in_tikzdocument261);
             			    	tikz_styleorsetorcmd2 = tikz_styleorsetorcmd();
@@ -444,7 +447,7 @@ public partial class simpletikzParser : Parser
             			    }
             			    break;
             			case 3 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:141:48: otherbegin
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:141:48: otherbegin
             			    {
             			    	PushFollow(FOLLOW_otherbegin_in_tikzdocument265);
             			    	otherbegin3 = otherbegin();
@@ -468,13 +471,13 @@ public partial class simpletikzParser : Parser
             	state.followingStackPointer--;
             	if (state.failed) return retval;
             	if ( state.backtracking==0 ) stream_tikzpicture.Add(tikzpicture4.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:141:74: ( . )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:141:74: ( . )*
             	do 
             	{
             	    int alt2 = 2;
             	    int LA2_0 = input.LA(1);
 
-            	    if ( ((LA2_0 >= IM_PATH && LA2_0 <= 94)) )
+            	    if ( ((LA2_0 >= IM_PATH && LA2_0 <= 95)) )
             	    {
             	        alt2 = 1;
             	    }
@@ -487,7 +490,7 @@ public partial class simpletikzParser : Parser
             	    switch (alt2) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:141:74: .
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:141:74: .
             			    {
             			    	wildcard5 = (IToken)input.LT(1);
             			    	MatchAny(input); if (state.failed) return retval;
@@ -518,12 +521,12 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 141:77: -> ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* tikzpicture )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:141:80: ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* tikzpicture )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:141:80: ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* tikzpicture )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_DOCUMENT, "IM_DOCUMENT"), root_1);
 
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:141:94: ( tikz_styleorsetorcmd )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:141:94: ( tikz_styleorsetorcmd )*
             	    while ( stream_tikz_styleorsetorcmd.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikz_styleorsetorcmd.NextTree());
@@ -568,7 +571,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzdocument_wo_tikzpicture"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:144:1: tikzdocument_wo_tikzpicture : ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )* EOF -> ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:144:1: tikzdocument_wo_tikzpicture : ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )* EOF -> ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* ) ;
     public simpletikzParser.tikzdocument_wo_tikzpicture_return tikzdocument_wo_tikzpicture() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzdocument_wo_tikzpicture_return retval = new simpletikzParser.tikzdocument_wo_tikzpicture_return();
@@ -587,14 +590,14 @@ public partial class simpletikzParser : Parser
         object EOF9_tree=null;
         RewriteRuleTokenStream stream_EOF = new RewriteRuleTokenStream(adaptor,"token EOF");
         RewriteRuleSubtreeStream stream_dontcare_preamble = new RewriteRuleSubtreeStream(adaptor,"rule dontcare_preamble");
-        RewriteRuleSubtreeStream stream_otherbegin = new RewriteRuleSubtreeStream(adaptor,"rule otherbegin");
         RewriteRuleSubtreeStream stream_tikz_styleorsetorcmd = new RewriteRuleSubtreeStream(adaptor,"rule tikz_styleorsetorcmd");
+        RewriteRuleSubtreeStream stream_otherbegin = new RewriteRuleSubtreeStream(adaptor,"rule otherbegin");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:145:2: ( ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )* EOF -> ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:145:4: ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )* EOF
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:145:2: ( ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )* EOF -> ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:145:4: ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )* EOF
             {
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:145:4: ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:145:4: ( dontcare_preamble | tikz_styleorsetorcmd | otherbegin )*
             	do 
             	{
             	    int alt3 = 4;
@@ -686,6 +689,7 @@ public partial class simpletikzParser : Parser
             	    case 92:
             	    case 93:
             	    case 94:
+            	    case 95:
             	    	{
             	        alt3 = 1;
             	        }
@@ -708,7 +712,7 @@ public partial class simpletikzParser : Parser
             	    switch (alt3) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:145:5: dontcare_preamble
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:145:5: dontcare_preamble
             			    {
             			    	PushFollow(FOLLOW_dontcare_preamble_in_tikzdocument_wo_tikzpicture296);
             			    	dontcare_preamble6 = dontcare_preamble();
@@ -719,7 +723,7 @@ public partial class simpletikzParser : Parser
             			    }
             			    break;
             			case 2 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:145:25: tikz_styleorsetorcmd
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:145:25: tikz_styleorsetorcmd
             			    {
             			    	PushFollow(FOLLOW_tikz_styleorsetorcmd_in_tikzdocument_wo_tikzpicture300);
             			    	tikz_styleorsetorcmd7 = tikz_styleorsetorcmd();
@@ -730,7 +734,7 @@ public partial class simpletikzParser : Parser
             			    }
             			    break;
             			case 3 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:145:48: otherbegin
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:145:48: otherbegin
             			    {
             			    	PushFollow(FOLLOW_otherbegin_in_tikzdocument_wo_tikzpicture304);
             			    	otherbegin8 = otherbegin();
@@ -767,12 +771,12 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 145:66: -> ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:145:69: ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:145:69: ^( IM_DOCUMENT ( tikz_styleorsetorcmd )* )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_DOCUMENT, "IM_DOCUMENT"), root_1);
 
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:145:83: ( tikz_styleorsetorcmd )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:145:83: ( tikz_styleorsetorcmd )*
             	    while ( stream_tikz_styleorsetorcmd.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikz_styleorsetorcmd.NextTree());
@@ -816,7 +820,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikz_cmd_comment"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:148:1: tikz_cmd_comment : TIKZEDT_CMD_COMMENT -> ^( IM_TIKZEDT_CMD TIKZEDT_CMD_COMMENT ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:148:1: tikz_cmd_comment : TIKZEDT_CMD_COMMENT -> ^( IM_TIKZEDT_CMD TIKZEDT_CMD_COMMENT ) ;
     public simpletikzParser.tikz_cmd_comment_return tikz_cmd_comment() // throws RecognitionException [1]
     {   
         simpletikzParser.tikz_cmd_comment_return retval = new simpletikzParser.tikz_cmd_comment_return();
@@ -831,8 +835,8 @@ public partial class simpletikzParser : Parser
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:149:2: ( TIKZEDT_CMD_COMMENT -> ^( IM_TIKZEDT_CMD TIKZEDT_CMD_COMMENT ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:149:4: TIKZEDT_CMD_COMMENT
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:149:2: ( TIKZEDT_CMD_COMMENT -> ^( IM_TIKZEDT_CMD TIKZEDT_CMD_COMMENT ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:149:4: TIKZEDT_CMD_COMMENT
             {
             	TIKZEDT_CMD_COMMENT10=(IToken)Match(input,TIKZEDT_CMD_COMMENT,FOLLOW_TIKZEDT_CMD_COMMENT_in_tikz_cmd_comment330); if (state.failed) return retval; 
             	if ( state.backtracking==0 ) stream_TIKZEDT_CMD_COMMENT.Add(TIKZEDT_CMD_COMMENT10);
@@ -852,7 +856,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 149:27: -> ^( IM_TIKZEDT_CMD TIKZEDT_CMD_COMMENT )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:149:30: ^( IM_TIKZEDT_CMD TIKZEDT_CMD_COMMENT )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:149:30: ^( IM_TIKZEDT_CMD TIKZEDT_CMD_COMMENT )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_TIKZEDT_CMD, "IM_TIKZEDT_CMD"), root_1);
@@ -895,7 +899,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikz_styleorsetorcmd"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:152:1: tikz_styleorsetorcmd : ( tikz_style | tikz_set | tikz_cmd_comment );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:152:1: tikz_styleorsetorcmd : ( tikz_style | tikz_set | tikz_cmd_comment );
     public simpletikzParser.tikz_styleorsetorcmd_return tikz_styleorsetorcmd() // throws RecognitionException [1]
     {   
         simpletikzParser.tikz_styleorsetorcmd_return retval = new simpletikzParser.tikz_styleorsetorcmd_return();
@@ -913,7 +917,7 @@ public partial class simpletikzParser : Parser
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:153:2: ( tikz_style | tikz_set | tikz_cmd_comment )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:153:2: ( tikz_style | tikz_set | tikz_cmd_comment )
             int alt4 = 3;
             switch ( input.LA(1) ) 
             {
@@ -943,7 +947,7 @@ public partial class simpletikzParser : Parser
             switch (alt4) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:153:4: tikz_style
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:153:4: tikz_style
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
@@ -956,7 +960,7 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:153:17: tikz_set
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:153:17: tikz_set
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
@@ -969,7 +973,7 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 3 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:153:28: tikz_cmd_comment
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:153:28: tikz_cmd_comment
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
@@ -1011,7 +1015,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "dontcare_preamble"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:156:1: dontcare_preamble : ~ ( '\\\\begin' | '\\\\tikzstyle' | '\\\\tikzset' | '\\\\tikz' | TIKZEDT_CMD_COMMENT ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:156:1: dontcare_preamble : ~ ( '\\\\begin' | '\\\\tikzstyle' | '\\\\tikzset' | '\\\\tikz' | TIKZEDT_CMD_COMMENT ) ;
     public simpletikzParser.dontcare_preamble_return dontcare_preamble() // throws RecognitionException [1]
     {   
         simpletikzParser.dontcare_preamble_return retval = new simpletikzParser.dontcare_preamble_return();
@@ -1025,13 +1029,13 @@ public partial class simpletikzParser : Parser
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:157:2: (~ ( '\\\\begin' | '\\\\tikzstyle' | '\\\\tikzset' | '\\\\tikz' | TIKZEDT_CMD_COMMENT ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:157:4: ~ ( '\\\\begin' | '\\\\tikzstyle' | '\\\\tikzset' | '\\\\tikz' | TIKZEDT_CMD_COMMENT )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:157:2: (~ ( '\\\\begin' | '\\\\tikzstyle' | '\\\\tikzset' | '\\\\tikz' | TIKZEDT_CMD_COMMENT ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:157:4: ~ ( '\\\\begin' | '\\\\tikzstyle' | '\\\\tikzset' | '\\\\tikz' | TIKZEDT_CMD_COMMENT )
             {
             	root_0 = (object)adaptor.GetNilNode();
 
             	set14 = (IToken)input.LT(1);
-            	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= IM_ARC) || (input.LA(1) >= ID && input.LA(1) <= SOMETHING1) || (input.LA(1) >= 43 && input.LA(1) <= 94) ) 
+            	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= IM_ARC) || (input.LA(1) >= ID && input.LA(1) <= SOMETHING1) || (input.LA(1) >= 43 && input.LA(1) <= 95) ) 
             	{
             	    input.Consume();
             	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set14));
@@ -1075,7 +1079,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "otherbegin"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:159:1: otherbegin : '\\\\begin' '{' idd2 '}' ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:159:1: otherbegin : '\\\\begin' '{' idd2 '}' ;
     public simpletikzParser.otherbegin_return otherbegin() // throws RecognitionException [1]
     {   
         simpletikzParser.otherbegin_return retval = new simpletikzParser.otherbegin_return();
@@ -1095,8 +1099,8 @@ public partial class simpletikzParser : Parser
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:160:2: ( '\\\\begin' '{' idd2 '}' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:160:4: '\\\\begin' '{' idd2 '}'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:160:2: ( '\\\\begin' '{' idd2 '}' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:160:4: '\\\\begin' '{' idd2 '}'
             {
             	root_0 = (object)adaptor.GetNilNode();
 
@@ -1151,7 +1155,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikz_style"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:163:1: tikz_style : '\\\\tikzstyle' '{' idd '}' ( '=' | '+=' ) tikz_options -> ^( IM_STYLE idd tikz_options ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:163:1: tikz_style : '\\\\tikzstyle' '{' idd '}' ( '=' | '+=' ) tikz_options -> ^( IM_STYLE idd tikz_options ) ;
     public simpletikzParser.tikz_style_return tikz_style() // throws RecognitionException [1]
     {   
         simpletikzParser.tikz_style_return retval = new simpletikzParser.tikz_style_return();
@@ -1174,17 +1178,17 @@ public partial class simpletikzParser : Parser
         object char_literal22_tree=null;
         object char_literal23_tree=null;
         object string_literal24_tree=null;
-        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
-        RewriteRuleTokenStream stream_45 = new RewriteRuleTokenStream(adaptor,"token 45");
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
+        RewriteRuleTokenStream stream_45 = new RewriteRuleTokenStream(adaptor,"token 45");
         RewriteRuleTokenStream stream_46 = new RewriteRuleTokenStream(adaptor,"token 46");
         RewriteRuleTokenStream stream_40 = new RewriteRuleTokenStream(adaptor,"token 40");
-        RewriteRuleSubtreeStream stream_idd = new RewriteRuleSubtreeStream(adaptor,"rule idd");
+        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
         RewriteRuleSubtreeStream stream_tikz_options = new RewriteRuleSubtreeStream(adaptor,"rule tikz_options");
+        RewriteRuleSubtreeStream stream_idd = new RewriteRuleSubtreeStream(adaptor,"rule idd");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:164:2: ( '\\\\tikzstyle' '{' idd '}' ( '=' | '+=' ) tikz_options -> ^( IM_STYLE idd tikz_options ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:164:4: '\\\\tikzstyle' '{' idd '}' ( '=' | '+=' ) tikz_options
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:164:2: ( '\\\\tikzstyle' '{' idd '}' ( '=' | '+=' ) tikz_options -> ^( IM_STYLE idd tikz_options ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:164:4: '\\\\tikzstyle' '{' idd '}' ( '=' | '+=' ) tikz_options
             {
             	string_literal19=(IToken)Match(input,40,FOLLOW_40_in_tikz_style418); if (state.failed) return retval; 
             	if ( state.backtracking==0 ) stream_40.Add(string_literal19);
@@ -1200,7 +1204,7 @@ public partial class simpletikzParser : Parser
             	char_literal22=(IToken)Match(input,44,FOLLOW_44_in_tikz_style424); if (state.failed) return retval; 
             	if ( state.backtracking==0 ) stream_44.Add(char_literal22);
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:164:30: ( '=' | '+=' )
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:164:30: ( '=' | '+=' )
             	int alt5 = 2;
             	int LA5_0 = input.LA(1);
 
@@ -1223,7 +1227,7 @@ public partial class simpletikzParser : Parser
             	switch (alt5) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:164:31: '='
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:164:31: '='
             	        {
             	        	char_literal23=(IToken)Match(input,45,FOLLOW_45_in_tikz_style427); if (state.failed) return retval; 
             	        	if ( state.backtracking==0 ) stream_45.Add(char_literal23);
@@ -1232,7 +1236,7 @@ public partial class simpletikzParser : Parser
             	        }
             	        break;
             	    case 2 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:164:37: '+='
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:164:37: '+='
             	        {
             	        	string_literal24=(IToken)Match(input,46,FOLLOW_46_in_tikz_style431); if (state.failed) return retval; 
             	        	if ( state.backtracking==0 ) stream_46.Add(string_literal24);
@@ -1263,7 +1267,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 164:56: -> ^( IM_STYLE idd tikz_options )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:164:59: ^( IM_STYLE idd tikz_options )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:164:59: ^( IM_STYLE idd tikz_options )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STYLE, "IM_STYLE"), root_1);
@@ -1307,7 +1311,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikz_options"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:167:1: tikz_options : squarebr_start ( option ( ',' option )* ( ',' )? )? ( tikzstring )? squarebr_end -> ^( IM_OPTIONS squarebr_start ( option )* squarebr_end ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:167:1: tikz_options : squarebr_start ( option ( ',' option )* ( ',' )? )? ( tikzstring )? squarebr_end -> ^( IM_OPTIONS squarebr_start ( option )* squarebr_end ) ;
     public simpletikzParser.tikz_options_return tikz_options() // throws RecognitionException [1]
     {   
         simpletikzParser.tikz_options_return retval = new simpletikzParser.tikz_options_return();
@@ -1331,39 +1335,39 @@ public partial class simpletikzParser : Parser
         object char_literal28_tree=null;
         object char_literal30_tree=null;
         RewriteRuleTokenStream stream_47 = new RewriteRuleTokenStream(adaptor,"token 47");
-        RewriteRuleSubtreeStream stream_squarebr_start = new RewriteRuleSubtreeStream(adaptor,"rule squarebr_start");
         RewriteRuleSubtreeStream stream_tikzstring = new RewriteRuleSubtreeStream(adaptor,"rule tikzstring");
         RewriteRuleSubtreeStream stream_squarebr_end = new RewriteRuleSubtreeStream(adaptor,"rule squarebr_end");
+        RewriteRuleSubtreeStream stream_squarebr_start = new RewriteRuleSubtreeStream(adaptor,"rule squarebr_start");
         RewriteRuleSubtreeStream stream_option = new RewriteRuleSubtreeStream(adaptor,"rule option");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:168:2: ( squarebr_start ( option ( ',' option )* ( ',' )? )? ( tikzstring )? squarebr_end -> ^( IM_OPTIONS squarebr_start ( option )* squarebr_end ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:168:5: squarebr_start ( option ( ',' option )* ( ',' )? )? ( tikzstring )? squarebr_end
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:168:2: ( squarebr_start ( option ( ',' option )* ( ',' )? )? ( tikzstring )? squarebr_end -> ^( IM_OPTIONS squarebr_start ( option )* squarebr_end ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:168:5: squarebr_start ( option ( ',' option )* ( ',' )? )? ( tikzstring )? squarebr_end
             {
             	PushFollow(FOLLOW_squarebr_start_in_tikz_options456);
             	squarebr_start26 = squarebr_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
             	if ( state.backtracking==0 ) stream_squarebr_start.Add(squarebr_start26.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:168:20: ( option ( ',' option )* ( ',' )? )?
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:168:20: ( option ( ',' option )* ( ',' )? )?
             	int alt8 = 2;
             	int LA8_0 = input.LA(1);
 
-            	if ( ((LA8_0 >= IM_PATH && LA8_0 <= 42) || LA8_0 == 46 || LA8_0 == 51 || (LA8_0 >= 57 && LA8_0 <= 94)) )
+            	if ( ((LA8_0 >= IM_PATH && LA8_0 <= 42) || LA8_0 == 46 || (LA8_0 >= 51 && LA8_0 <= 52) || (LA8_0 >= 58 && LA8_0 <= 95)) )
             	{
             	    alt8 = 1;
             	}
             	switch (alt8) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:168:21: option ( ',' option )* ( ',' )?
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:168:21: option ( ',' option )* ( ',' )?
             	        {
             	        	PushFollow(FOLLOW_option_in_tikz_options459);
             	        	option27 = option();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
             	        	if ( state.backtracking==0 ) stream_option.Add(option27.Tree);
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:168:28: ( ',' option )*
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:168:28: ( ',' option )*
             	        	do 
             	        	{
             	        	    int alt6 = 2;
@@ -1373,7 +1377,7 @@ public partial class simpletikzParser : Parser
             	        	    {
             	        	        int LA6_1 = input.LA(2);
 
-            	        	        if ( ((LA6_1 >= IM_PATH && LA6_1 <= 42) || LA6_1 == 46 || LA6_1 == 51 || (LA6_1 >= 57 && LA6_1 <= 94)) )
+            	        	        if ( ((LA6_1 >= IM_PATH && LA6_1 <= 42) || LA6_1 == 46 || (LA6_1 >= 51 && LA6_1 <= 52) || (LA6_1 >= 58 && LA6_1 <= 95)) )
             	        	        {
             	        	            alt6 = 1;
             	        	        }
@@ -1385,7 +1389,7 @@ public partial class simpletikzParser : Parser
             	        	    switch (alt6) 
             	        		{
             	        			case 1 :
-            	        			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:168:29: ',' option
+            	        			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:168:29: ',' option
             	        			    {
             	        			    	char_literal28=(IToken)Match(input,47,FOLLOW_47_in_tikz_options462); if (state.failed) return retval; 
             	        			    	if ( state.backtracking==0 ) stream_47.Add(char_literal28);
@@ -1407,7 +1411,7 @@ public partial class simpletikzParser : Parser
             	        	loop6:
             	        		;	// Stops C# compiler whining that label 'loop6' has no statements
 
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:168:42: ( ',' )?
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:168:42: ( ',' )?
             	        	int alt7 = 2;
             	        	int LA7_0 = input.LA(1);
 
@@ -1418,7 +1422,7 @@ public partial class simpletikzParser : Parser
             	        	switch (alt7) 
             	        	{
             	        	    case 1 :
-            	        	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:168:42: ','
+            	        	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:168:42: ','
             	        	        {
             	        	        	char_literal30=(IToken)Match(input,47,FOLLOW_47_in_tikz_options468); if (state.failed) return retval; 
             	        	        	if ( state.backtracking==0 ) stream_47.Add(char_literal30);
@@ -1435,7 +1439,7 @@ public partial class simpletikzParser : Parser
 
             	}
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:168:49: ( tikzstring )?
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:168:49: ( tikzstring )?
             	int alt9 = 2;
             	int LA9_0 = input.LA(1);
 
@@ -1446,7 +1450,7 @@ public partial class simpletikzParser : Parser
             	switch (alt9) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:168:49: tikzstring
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:168:49: tikzstring
             	        {
             	        	PushFollow(FOLLOW_tikzstring_in_tikz_options473);
             	        	tikzstring31 = tikzstring();
@@ -1467,7 +1471,7 @@ public partial class simpletikzParser : Parser
 
 
             	// AST REWRITE
-            	// elements:          squarebr_end, squarebr_start, option
+            	// elements:          option, squarebr_end, squarebr_start
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -1479,13 +1483,13 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 168:75: -> ^( IM_OPTIONS squarebr_start ( option )* squarebr_end )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:168:78: ^( IM_OPTIONS squarebr_start ( option )* squarebr_end )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:168:78: ^( IM_OPTIONS squarebr_start ( option )* squarebr_end )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_OPTIONS, "IM_OPTIONS"), root_1);
 
             	    adaptor.AddChild(root_1, stream_squarebr_start.NextTree());
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:168:106: ( option )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:168:106: ( option )*
             	    while ( stream_option.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_option.NextTree());
@@ -1530,7 +1534,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "option"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:171:1: option : ( option_style | option_kv );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:171:1: option : ( option_style | option_kv );
     public simpletikzParser.option_return option() // throws RecognitionException [1]
     {   
         simpletikzParser.option_return retval = new simpletikzParser.option_return();
@@ -1546,13 +1550,13 @@ public partial class simpletikzParser : Parser
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:172:2: ( option_style | option_kv )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:172:2: ( option_style | option_kv )
             int alt10 = 2;
             alt10 = dfa10.Predict(input);
             switch (alt10) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:172:4: option_style
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:172:4: option_style
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
@@ -1565,7 +1569,7 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:173:5: option_kv
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:173:5: option_kv
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
@@ -1607,7 +1611,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "option_kv"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:176:1: option_kv : idd ( '=' iddornumberunitorstringorrange )? -> ^( IM_OPTION_KV idd ( iddornumberunitorstringorrange )? ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:176:1: option_kv : idd ( '=' iddornumberunitorstringorrange )? -> ^( IM_OPTION_KV idd ( iddornumberunitorstringorrange )? ) ;
     public simpletikzParser.option_kv_return option_kv() // throws RecognitionException [1]
     {   
         simpletikzParser.option_kv_return retval = new simpletikzParser.option_kv_return();
@@ -1627,15 +1631,15 @@ public partial class simpletikzParser : Parser
         RewriteRuleSubtreeStream stream_idd = new RewriteRuleSubtreeStream(adaptor,"rule idd");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:177:2: ( idd ( '=' iddornumberunitorstringorrange )? -> ^( IM_OPTION_KV idd ( iddornumberunitorstringorrange )? ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:177:4: idd ( '=' iddornumberunitorstringorrange )?
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:177:2: ( idd ( '=' iddornumberunitorstringorrange )? -> ^( IM_OPTION_KV idd ( iddornumberunitorstringorrange )? ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:177:4: idd ( '=' iddornumberunitorstringorrange )?
             {
             	PushFollow(FOLLOW_idd_in_option_kv524);
             	idd35 = idd();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
             	if ( state.backtracking==0 ) stream_idd.Add(idd35.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:177:8: ( '=' iddornumberunitorstringorrange )?
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:177:8: ( '=' iddornumberunitorstringorrange )?
             	int alt11 = 2;
             	int LA11_0 = input.LA(1);
 
@@ -1646,7 +1650,7 @@ public partial class simpletikzParser : Parser
             	switch (alt11) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:177:9: '=' iddornumberunitorstringorrange
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:177:9: '=' iddornumberunitorstringorrange
             	        {
             	        	char_literal36=(IToken)Match(input,45,FOLLOW_45_in_option_kv527); if (state.failed) return retval; 
             	        	if ( state.backtracking==0 ) stream_45.Add(char_literal36);
@@ -1665,7 +1669,7 @@ public partial class simpletikzParser : Parser
 
 
             	// AST REWRITE
-            	// elements:          idd, iddornumberunitorstringorrange
+            	// elements:          iddornumberunitorstringorrange, idd
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -1677,13 +1681,13 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 177:47: -> ^( IM_OPTION_KV idd ( iddornumberunitorstringorrange )? )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:177:50: ^( IM_OPTION_KV idd ( iddornumberunitorstringorrange )? )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:177:50: ^( IM_OPTION_KV idd ( iddornumberunitorstringorrange )? )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_OPTION_KV, "IM_OPTION_KV"), root_1);
 
             	    adaptor.AddChild(root_1, stream_idd.NextTree());
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:177:69: ( iddornumberunitorstringorrange )?
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:177:69: ( iddornumberunitorstringorrange )?
             	    if ( stream_iddornumberunitorstringorrange.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_iddornumberunitorstringorrange.NextTree());
@@ -1727,7 +1731,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzstring"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:180:1: tikzstring : '{' ( no_rlbrace )* ( tikzstring ( no_rlbrace )* )* '}' -> ^( IM_STRING '{' '}' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:180:1: tikzstring : '{' ( no_rlbrace )* ( tikzstring ( no_rlbrace )* )* '}' -> ^( IM_STRING '{' '}' ) ;
     public simpletikzParser.tikzstring_return tikzstring() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzstring_return retval = new simpletikzParser.tikzstring_return();
@@ -1746,25 +1750,25 @@ public partial class simpletikzParser : Parser
 
         object char_literal38_tree=null;
         object char_literal42_tree=null;
-        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
+        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
         RewriteRuleSubtreeStream stream_tikzstring = new RewriteRuleSubtreeStream(adaptor,"rule tikzstring");
         RewriteRuleSubtreeStream stream_no_rlbrace = new RewriteRuleSubtreeStream(adaptor,"rule no_rlbrace");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:181:2: ( '{' ( no_rlbrace )* ( tikzstring ( no_rlbrace )* )* '}' -> ^( IM_STRING '{' '}' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:181:4: '{' ( no_rlbrace )* ( tikzstring ( no_rlbrace )* )* '}'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:181:2: ( '{' ( no_rlbrace )* ( tikzstring ( no_rlbrace )* )* '}' -> ^( IM_STRING '{' '}' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:181:4: '{' ( no_rlbrace )* ( tikzstring ( no_rlbrace )* )* '}'
             {
             	char_literal38=(IToken)Match(input,43,FOLLOW_43_in_tikzstring557); if (state.failed) return retval; 
             	if ( state.backtracking==0 ) stream_43.Add(char_literal38);
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:181:8: ( no_rlbrace )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:181:8: ( no_rlbrace )*
             	do 
             	{
             	    int alt12 = 2;
             	    int LA12_0 = input.LA(1);
 
-            	    if ( ((LA12_0 >= IM_PATH && LA12_0 <= 42) || (LA12_0 >= 45 && LA12_0 <= 94)) )
+            	    if ( ((LA12_0 >= IM_PATH && LA12_0 <= 42) || (LA12_0 >= 45 && LA12_0 <= 95)) )
             	    {
             	        alt12 = 1;
             	    }
@@ -1773,7 +1777,7 @@ public partial class simpletikzParser : Parser
             	    switch (alt12) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:181:8: no_rlbrace
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:181:8: no_rlbrace
             			    {
             			    	PushFollow(FOLLOW_no_rlbrace_in_tikzstring559);
             			    	no_rlbrace39 = no_rlbrace();
@@ -1792,7 +1796,7 @@ public partial class simpletikzParser : Parser
             	loop12:
             		;	// Stops C# compiler whining that label 'loop12' has no statements
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:181:20: ( tikzstring ( no_rlbrace )* )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:181:20: ( tikzstring ( no_rlbrace )* )*
             	do 
             	{
             	    int alt14 = 2;
@@ -1807,20 +1811,20 @@ public partial class simpletikzParser : Parser
             	    switch (alt14) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:181:21: tikzstring ( no_rlbrace )*
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:181:21: tikzstring ( no_rlbrace )*
             			    {
             			    	PushFollow(FOLLOW_tikzstring_in_tikzstring563);
             			    	tikzstring40 = tikzstring();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
             			    	if ( state.backtracking==0 ) stream_tikzstring.Add(tikzstring40.Tree);
-            			    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:181:32: ( no_rlbrace )*
+            			    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:181:32: ( no_rlbrace )*
             			    	do 
             			    	{
             			    	    int alt13 = 2;
             			    	    int LA13_0 = input.LA(1);
 
-            			    	    if ( ((LA13_0 >= IM_PATH && LA13_0 <= 42) || (LA13_0 >= 45 && LA13_0 <= 94)) )
+            			    	    if ( ((LA13_0 >= IM_PATH && LA13_0 <= 42) || (LA13_0 >= 45 && LA13_0 <= 95)) )
             			    	    {
             			    	        alt13 = 1;
             			    	    }
@@ -1829,7 +1833,7 @@ public partial class simpletikzParser : Parser
             			    	    switch (alt13) 
             			    		{
             			    			case 1 :
-            			    			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:181:32: no_rlbrace
+            			    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:181:32: no_rlbrace
             			    			    {
             			    			    	PushFollow(FOLLOW_no_rlbrace_in_tikzstring565);
             			    			    	no_rlbrace41 = no_rlbrace();
@@ -1866,7 +1870,7 @@ public partial class simpletikzParser : Parser
 
 
             	// AST REWRITE
-            	// elements:          43, 44
+            	// elements:          44, 43
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -1878,7 +1882,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 181:50: -> ^( IM_STRING '{' '}' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:181:53: ^( IM_STRING '{' '}' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:181:53: ^( IM_STRING '{' '}' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STRING, "IM_STRING"), root_1);
@@ -1922,7 +1926,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "no_rlbrace"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:184:1: no_rlbrace : ~ ( '{' | '}' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:184:1: no_rlbrace : ~ ( '{' | '}' ) ;
     public simpletikzParser.no_rlbrace_return no_rlbrace() // throws RecognitionException [1]
     {   
         simpletikzParser.no_rlbrace_return retval = new simpletikzParser.no_rlbrace_return();
@@ -1936,13 +1940,13 @@ public partial class simpletikzParser : Parser
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:185:2: (~ ( '{' | '}' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:185:4: ~ ( '{' | '}' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:185:2: (~ ( '{' | '}' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:185:4: ~ ( '{' | '}' )
             {
             	root_0 = (object)adaptor.GetNilNode();
 
             	set43 = (IToken)input.LT(1);
-            	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= 42) || (input.LA(1) >= 45 && input.LA(1) <= 94) ) 
+            	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= 42) || (input.LA(1) >= 45 && input.LA(1) <= 95) ) 
             	{
             	    input.Consume();
             	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set43));
@@ -1986,7 +1990,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "iddornumberunitorstringorrange"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:187:1: iddornumberunitorstringorrange : ( range | numberunit | bracedcoord | idd | ( ( number ':' )? tikzstring ) );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:187:1: iddornumberunitorstringorrange : ( range | numberunit | bracedcoord | idd | ( ( number ':' )? tikzstring ) );
     public simpletikzParser.iddornumberunitorstringorrange_return iddornumberunitorstringorrange() // throws RecognitionException [1]
     {   
         simpletikzParser.iddornumberunitorstringorrange_return retval = new simpletikzParser.iddornumberunitorstringorrange_return();
@@ -2012,13 +2016,13 @@ public partial class simpletikzParser : Parser
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:188:2: ( range | numberunit | bracedcoord | idd | ( ( number ':' )? tikzstring ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:188:2: ( range | numberunit | bracedcoord | idd | ( ( number ':' )? tikzstring ) )
             int alt16 = 5;
             alt16 = dfa16.Predict(input);
             switch (alt16) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:188:5: range
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:188:5: range
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
@@ -2031,7 +2035,7 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:188:13: numberunit
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:188:13: numberunit
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
@@ -2044,7 +2048,7 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 3 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:188:26: bracedcoord
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:188:26: bracedcoord
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
@@ -2057,7 +2061,7 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 4 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:188:40: idd
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:188:40: idd
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
@@ -2070,14 +2074,14 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 5 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:188:46: ( ( number ':' )? tikzstring )
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:188:46: ( ( number ':' )? tikzstring )
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:188:46: ( ( number ':' )? tikzstring )
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:188:47: ( number ':' )? tikzstring
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:188:46: ( ( number ':' )? tikzstring )
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:188:47: ( number ':' )? tikzstring
                     	{
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:188:47: ( number ':' )?
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:188:47: ( number ':' )?
                     		int alt15 = 2;
                     		int LA15_0 = input.LA(1);
 
@@ -2088,7 +2092,7 @@ public partial class simpletikzParser : Parser
                     		switch (alt15) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:188:49: number ':'
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:188:49: number ':'
                     		        {
                     		        	PushFollow(FOLLOW_number_in_iddornumberunitorstringorrange630);
                     		        	number48 = number();
@@ -2142,7 +2146,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "bracedcoord"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:190:1: bracedcoord : '{' coord_nooption '}' ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:190:1: bracedcoord : '{' coord_nooption '}' ;
     public simpletikzParser.bracedcoord_return bracedcoord() // throws RecognitionException [1]
     {   
         simpletikzParser.bracedcoord_return retval = new simpletikzParser.bracedcoord_return();
@@ -2160,8 +2164,8 @@ public partial class simpletikzParser : Parser
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:191:2: ( '{' coord_nooption '}' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:191:4: '{' coord_nooption '}'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:191:2: ( '{' coord_nooption '}' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:191:4: '{' coord_nooption '}'
             {
             	root_0 = (object)adaptor.GetNilNode();
 
@@ -2203,7 +2207,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "range"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:193:1: range : numberunit ':' numberunit -> ^( IM_STRING numberunit ':' numberunit ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:193:1: range : numberunit ':' numberunit -> ^( IM_STRING numberunit ':' numberunit ) ;
     public simpletikzParser.range_return range() // throws RecognitionException [1]
     {   
         simpletikzParser.range_return retval = new simpletikzParser.range_return();
@@ -2222,8 +2226,8 @@ public partial class simpletikzParser : Parser
         RewriteRuleSubtreeStream stream_numberunit = new RewriteRuleSubtreeStream(adaptor,"rule numberunit");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:194:2: ( numberunit ':' numberunit -> ^( IM_STRING numberunit ':' numberunit ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:194:4: numberunit ':' numberunit
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:194:2: ( numberunit ':' numberunit -> ^( IM_STRING numberunit ':' numberunit ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:194:4: numberunit ':' numberunit
             {
             	PushFollow(FOLLOW_numberunit_in_range669);
             	numberunit54 = numberunit();
@@ -2241,7 +2245,7 @@ public partial class simpletikzParser : Parser
 
 
             	// AST REWRITE
-            	// elements:          numberunit, numberunit, 48
+            	// elements:          48, numberunit, numberunit
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -2253,7 +2257,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 194:30: -> ^( IM_STRING numberunit ':' numberunit )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:194:33: ^( IM_STRING numberunit ':' numberunit )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:194:33: ^( IM_STRING numberunit ':' numberunit )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STRING, "IM_STRING"), root_1);
@@ -2298,7 +2302,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "option_style"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:196:1: option_style : idd ( '/.style' | ( '/.append' 'style' ) ) '=' '{' ( option_kv ( ',' option_kv )* )? ( ',' )? '}' -> ^( IM_OPTION_STYLE idd ( option_kv )* ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:196:1: option_style : idd ( '/.style' | ( '/.append' 'style' ) | ( '/.style' number 'args' ) ) '=' '{' ( option_kv ( ',' option_kv )* )? ( ',' )? '}' -> ^( IM_OPTION_STYLE idd ( option_kv )* ) ;
     public simpletikzParser.option_style_return option_style() // throws RecognitionException [1]
     {   
         simpletikzParser.option_style_return retval = new simpletikzParser.option_style_return();
@@ -2309,52 +2313,77 @@ public partial class simpletikzParser : Parser
         IToken string_literal58 = null;
         IToken string_literal59 = null;
         IToken string_literal60 = null;
-        IToken char_literal61 = null;
-        IToken char_literal62 = null;
+        IToken string_literal61 = null;
+        IToken string_literal63 = null;
         IToken char_literal64 = null;
-        IToken char_literal66 = null;
+        IToken char_literal65 = null;
         IToken char_literal67 = null;
+        IToken char_literal69 = null;
+        IToken char_literal70 = null;
         simpletikzParser.idd_return idd57 = default(simpletikzParser.idd_return);
 
-        simpletikzParser.option_kv_return option_kv63 = default(simpletikzParser.option_kv_return);
+        simpletikzParser.number_return number62 = default(simpletikzParser.number_return);
 
-        simpletikzParser.option_kv_return option_kv65 = default(simpletikzParser.option_kv_return);
+        simpletikzParser.option_kv_return option_kv66 = default(simpletikzParser.option_kv_return);
+
+        simpletikzParser.option_kv_return option_kv68 = default(simpletikzParser.option_kv_return);
 
 
         object string_literal58_tree=null;
         object string_literal59_tree=null;
         object string_literal60_tree=null;
-        object char_literal61_tree=null;
-        object char_literal62_tree=null;
+        object string_literal61_tree=null;
+        object string_literal63_tree=null;
         object char_literal64_tree=null;
-        object char_literal66_tree=null;
+        object char_literal65_tree=null;
         object char_literal67_tree=null;
-        RewriteRuleTokenStream stream_49 = new RewriteRuleTokenStream(adaptor,"token 49");
-        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
-        RewriteRuleTokenStream stream_45 = new RewriteRuleTokenStream(adaptor,"token 45");
+        object char_literal69_tree=null;
+        object char_literal70_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
+        RewriteRuleTokenStream stream_45 = new RewriteRuleTokenStream(adaptor,"token 45");
         RewriteRuleTokenStream stream_47 = new RewriteRuleTokenStream(adaptor,"token 47");
-        RewriteRuleTokenStream stream_51 = new RewriteRuleTokenStream(adaptor,"token 51");
+        RewriteRuleTokenStream stream_49 = new RewriteRuleTokenStream(adaptor,"token 49");
         RewriteRuleTokenStream stream_50 = new RewriteRuleTokenStream(adaptor,"token 50");
+        RewriteRuleTokenStream stream_51 = new RewriteRuleTokenStream(adaptor,"token 51");
+        RewriteRuleTokenStream stream_52 = new RewriteRuleTokenStream(adaptor,"token 52");
+        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
+        RewriteRuleSubtreeStream stream_number = new RewriteRuleSubtreeStream(adaptor,"rule number");
         RewriteRuleSubtreeStream stream_idd = new RewriteRuleSubtreeStream(adaptor,"rule idd");
         RewriteRuleSubtreeStream stream_option_kv = new RewriteRuleSubtreeStream(adaptor,"rule option_kv");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:2: ( idd ( '/.style' | ( '/.append' 'style' ) ) '=' '{' ( option_kv ( ',' option_kv )* )? ( ',' )? '}' -> ^( IM_OPTION_STYLE idd ( option_kv )* ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:4: idd ( '/.style' | ( '/.append' 'style' ) ) '=' '{' ( option_kv ( ',' option_kv )* )? ( ',' )? '}'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:2: ( idd ( '/.style' | ( '/.append' 'style' ) | ( '/.style' number 'args' ) ) '=' '{' ( option_kv ( ',' option_kv )* )? ( ',' )? '}' -> ^( IM_OPTION_STYLE idd ( option_kv )* ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:4: idd ( '/.style' | ( '/.append' 'style' ) | ( '/.style' number 'args' ) ) '=' '{' ( option_kv ( ',' option_kv )* )? ( ',' )? '}'
             {
             	PushFollow(FOLLOW_idd_in_option_style697);
             	idd57 = idd();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
             	if ( state.backtracking==0 ) stream_idd.Add(idd57.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:8: ( '/.style' | ( '/.append' 'style' ) )
-            	int alt17 = 2;
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:8: ( '/.style' | ( '/.append' 'style' ) | ( '/.style' number 'args' ) )
+            	int alt17 = 3;
             	int LA17_0 = input.LA(1);
 
             	if ( (LA17_0 == 49) )
             	{
-            	    alt17 = 1;
+            	    int LA17_1 = input.LA(2);
+
+            	    if ( ((LA17_1 >= FLOAT_WO_EXP && LA17_1 <= INT)) )
+            	    {
+            	        alt17 = 3;
+            	    }
+            	    else if ( (LA17_1 == 45) )
+            	    {
+            	        alt17 = 1;
+            	    }
+            	    else 
+            	    {
+            	        if ( state.backtracking > 0 ) {state.failed = true; return retval;}
+            	        NoViableAltException nvae_d17s1 =
+            	            new NoViableAltException("", 17, 1, input);
+
+            	        throw nvae_d17s1;
+            	    }
             	}
             	else if ( (LA17_0 == 50) )
             	{
@@ -2371,7 +2400,7 @@ public partial class simpletikzParser : Parser
             	switch (alt17) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:9: '/.style'
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:9: '/.style'
             	        {
             	        	string_literal58=(IToken)Match(input,49,FOLLOW_49_in_option_style700); if (state.failed) return retval; 
             	        	if ( state.backtracking==0 ) stream_49.Add(string_literal58);
@@ -2380,10 +2409,10 @@ public partial class simpletikzParser : Parser
             	        }
             	        break;
             	    case 2 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:21: ( '/.append' 'style' )
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:21: ( '/.append' 'style' )
             	        {
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:21: ( '/.append' 'style' )
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:22: '/.append' 'style'
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:21: ( '/.append' 'style' )
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:22: '/.append' 'style'
             	        	{
             	        		string_literal59=(IToken)Match(input,50,FOLLOW_50_in_option_style705); if (state.failed) return retval; 
             	        		if ( state.backtracking==0 ) stream_50.Add(string_literal59);
@@ -2397,34 +2426,57 @@ public partial class simpletikzParser : Parser
 
             	        }
             	        break;
+            	    case 3 :
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:45: ( '/.style' number 'args' )
+            	        {
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:45: ( '/.style' number 'args' )
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:46: '/.style' number 'args'
+            	        	{
+            	        		string_literal61=(IToken)Match(input,49,FOLLOW_49_in_option_style714); if (state.failed) return retval; 
+            	        		if ( state.backtracking==0 ) stream_49.Add(string_literal61);
+
+            	        		PushFollow(FOLLOW_number_in_option_style716);
+            	        		number62 = number();
+            	        		state.followingStackPointer--;
+            	        		if (state.failed) return retval;
+            	        		if ( state.backtracking==0 ) stream_number.Add(number62.Tree);
+            	        		string_literal63=(IToken)Match(input,52,FOLLOW_52_in_option_style718); if (state.failed) return retval; 
+            	        		if ( state.backtracking==0 ) stream_52.Add(string_literal63);
+
+
+            	        	}
+
+
+            	        }
+            	        break;
 
             	}
 
-            	char_literal61=(IToken)Match(input,45,FOLLOW_45_in_option_style711); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_45.Add(char_literal61);
+            	char_literal64=(IToken)Match(input,45,FOLLOW_45_in_option_style722); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_45.Add(char_literal64);
 
-            	char_literal62=(IToken)Match(input,43,FOLLOW_43_in_option_style713); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal62);
+            	char_literal65=(IToken)Match(input,43,FOLLOW_43_in_option_style724); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal65);
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:51: ( option_kv ( ',' option_kv )* )?
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:80: ( option_kv ( ',' option_kv )* )?
             	int alt19 = 2;
             	int LA19_0 = input.LA(1);
 
-            	if ( ((LA19_0 >= IM_PATH && LA19_0 <= 42) || LA19_0 == 46 || LA19_0 == 51 || (LA19_0 >= 57 && LA19_0 <= 94)) )
+            	if ( ((LA19_0 >= IM_PATH && LA19_0 <= 42) || LA19_0 == 46 || (LA19_0 >= 51 && LA19_0 <= 52) || (LA19_0 >= 58 && LA19_0 <= 95)) )
             	{
             	    alt19 = 1;
             	}
             	switch (alt19) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:52: option_kv ( ',' option_kv )*
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:81: option_kv ( ',' option_kv )*
             	        {
-            	        	PushFollow(FOLLOW_option_kv_in_option_style716);
-            	        	option_kv63 = option_kv();
+            	        	PushFollow(FOLLOW_option_kv_in_option_style727);
+            	        	option_kv66 = option_kv();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_option_kv.Add(option_kv63.Tree);
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:62: ( ',' option_kv )*
+            	        	if ( state.backtracking==0 ) stream_option_kv.Add(option_kv66.Tree);
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:91: ( ',' option_kv )*
             	        	do 
             	        	{
             	        	    int alt18 = 2;
@@ -2434,7 +2486,7 @@ public partial class simpletikzParser : Parser
             	        	    {
             	        	        int LA18_1 = input.LA(2);
 
-            	        	        if ( ((LA18_1 >= IM_PATH && LA18_1 <= 42) || LA18_1 == 46 || LA18_1 == 51 || (LA18_1 >= 57 && LA18_1 <= 94)) )
+            	        	        if ( ((LA18_1 >= IM_PATH && LA18_1 <= 42) || LA18_1 == 46 || (LA18_1 >= 51 && LA18_1 <= 52) || (LA18_1 >= 58 && LA18_1 <= 95)) )
             	        	        {
             	        	            alt18 = 1;
             	        	        }
@@ -2446,16 +2498,16 @@ public partial class simpletikzParser : Parser
             	        	    switch (alt18) 
             	        		{
             	        			case 1 :
-            	        			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:63: ',' option_kv
+            	        			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:92: ',' option_kv
             	        			    {
-            	        			    	char_literal64=(IToken)Match(input,47,FOLLOW_47_in_option_style719); if (state.failed) return retval; 
-            	        			    	if ( state.backtracking==0 ) stream_47.Add(char_literal64);
+            	        			    	char_literal67=(IToken)Match(input,47,FOLLOW_47_in_option_style730); if (state.failed) return retval; 
+            	        			    	if ( state.backtracking==0 ) stream_47.Add(char_literal67);
 
-            	        			    	PushFollow(FOLLOW_option_kv_in_option_style721);
-            	        			    	option_kv65 = option_kv();
+            	        			    	PushFollow(FOLLOW_option_kv_in_option_style732);
+            	        			    	option_kv68 = option_kv();
             	        			    	state.followingStackPointer--;
             	        			    	if (state.failed) return retval;
-            	        			    	if ( state.backtracking==0 ) stream_option_kv.Add(option_kv65.Tree);
+            	        			    	if ( state.backtracking==0 ) stream_option_kv.Add(option_kv68.Tree);
 
             	        			    }
             	        			    break;
@@ -2474,7 +2526,7 @@ public partial class simpletikzParser : Parser
 
             	}
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:82: ( ',' )?
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:111: ( ',' )?
             	int alt20 = 2;
             	int LA20_0 = input.LA(1);
 
@@ -2485,10 +2537,10 @@ public partial class simpletikzParser : Parser
             	switch (alt20) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:82: ','
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:111: ','
             	        {
-            	        	char_literal66=(IToken)Match(input,47,FOLLOW_47_in_option_style728); if (state.failed) return retval; 
-            	        	if ( state.backtracking==0 ) stream_47.Add(char_literal66);
+            	        	char_literal69=(IToken)Match(input,47,FOLLOW_47_in_option_style739); if (state.failed) return retval; 
+            	        	if ( state.backtracking==0 ) stream_47.Add(char_literal69);
 
 
             	        }
@@ -2496,13 +2548,13 @@ public partial class simpletikzParser : Parser
 
             	}
 
-            	char_literal67=(IToken)Match(input,44,FOLLOW_44_in_option_style731); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_44.Add(char_literal67);
+            	char_literal70=(IToken)Match(input,44,FOLLOW_44_in_option_style742); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_44.Add(char_literal70);
 
 
 
             	// AST REWRITE
-            	// elements:          idd, option_kv
+            	// elements:          option_kv, idd
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -2512,15 +2564,15 @@ public partial class simpletikzParser : Parser
             	RewriteRuleSubtreeStream stream_retval = new RewriteRuleSubtreeStream(adaptor, "token retval", (retval!=null ? retval.Tree : null));
 
             	root_0 = (object)adaptor.GetNilNode();
-            	// 197:92: -> ^( IM_OPTION_STYLE idd ( option_kv )* )
+            	// 197:121: -> ^( IM_OPTION_STYLE idd ( option_kv )* )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:95: ^( IM_OPTION_STYLE idd ( option_kv )* )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:124: ^( IM_OPTION_STYLE idd ( option_kv )* )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_OPTION_STYLE, "IM_OPTION_STYLE"), root_1);
 
             	    adaptor.AddChild(root_1, stream_idd.NextTree());
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:197:117: ( option_kv )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:197:146: ( option_kv )*
             	    while ( stream_option_kv.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_option_kv.NextTree());
@@ -2564,7 +2616,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "idd"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:209:1: idd : idd_heavenknowswhythisisnecessary -> ^( IM_ID ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:209:1: idd : idd_heavenknowswhythisisnecessary -> ^( IM_ID ) ;
     public simpletikzParser.idd_return idd() // throws RecognitionException [1]
     {   
         simpletikzParser.idd_return retval = new simpletikzParser.idd_return();
@@ -2572,20 +2624,20 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.idd_heavenknowswhythisisnecessary_return idd_heavenknowswhythisisnecessary68 = default(simpletikzParser.idd_heavenknowswhythisisnecessary_return);
+        simpletikzParser.idd_heavenknowswhythisisnecessary_return idd_heavenknowswhythisisnecessary71 = default(simpletikzParser.idd_heavenknowswhythisisnecessary_return);
 
 
         RewriteRuleSubtreeStream stream_idd_heavenknowswhythisisnecessary = new RewriteRuleSubtreeStream(adaptor,"rule idd_heavenknowswhythisisnecessary");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:210:2: ( idd_heavenknowswhythisisnecessary -> ^( IM_ID ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:210:4: idd_heavenknowswhythisisnecessary
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:210:2: ( idd_heavenknowswhythisisnecessary -> ^( IM_ID ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:210:4: idd_heavenknowswhythisisnecessary
             {
-            	PushFollow(FOLLOW_idd_heavenknowswhythisisnecessary_in_idd766);
-            	idd_heavenknowswhythisisnecessary68 = idd_heavenknowswhythisisnecessary();
+            	PushFollow(FOLLOW_idd_heavenknowswhythisisnecessary_in_idd777);
+            	idd_heavenknowswhythisisnecessary71 = idd_heavenknowswhythisisnecessary();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_idd_heavenknowswhythisisnecessary.Add(idd_heavenknowswhythisisnecessary68.Tree);
+            	if ( state.backtracking==0 ) stream_idd_heavenknowswhythisisnecessary.Add(idd_heavenknowswhythisisnecessary71.Tree);
 
 
             	// AST REWRITE
@@ -2601,7 +2653,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 210:39: -> ^( IM_ID )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:210:42: ^( IM_ID )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:210:42: ^( IM_ID )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ID, "IM_ID"), root_1);
@@ -2642,7 +2694,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "idd_heavenknowswhythisisnecessary"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:212:1: idd_heavenknowswhythisisnecessary : (~ ( '(' | ')' | '[' | ']' | '{' | '}' | ',' | '=' | ';' | ':' | '/.style' | '/.append' ) )+ ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:212:1: idd_heavenknowswhythisisnecessary : (~ ( '(' | ')' | '[' | ']' | '{' | '}' | ',' | '=' | ';' | ':' | '/.style' | '/.append' ) )+ ;
     public simpletikzParser.idd_heavenknowswhythisisnecessary_return idd_heavenknowswhythisisnecessary() // throws RecognitionException [1]
     {   
         simpletikzParser.idd_heavenknowswhythisisnecessary_return retval = new simpletikzParser.idd_heavenknowswhythisisnecessary_return();
@@ -2650,40 +2702,40 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set69 = null;
+        IToken set72 = null;
 
-        object set69_tree=null;
+        object set72_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:213:3: ( (~ ( '(' | ')' | '[' | ']' | '{' | '}' | ',' | '=' | ';' | ':' | '/.style' | '/.append' ) )+ )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:213:6: (~ ( '(' | ')' | '[' | ']' | '{' | '}' | ',' | '=' | ';' | ':' | '/.style' | '/.append' ) )+
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:213:3: ( (~ ( '(' | ')' | '[' | ']' | '{' | '}' | ',' | '=' | ';' | ':' | '/.style' | '/.append' ) )+ )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:213:6: (~ ( '(' | ')' | '[' | ']' | '{' | '}' | ',' | '=' | ';' | ':' | '/.style' | '/.append' ) )+
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:213:6: (~ ( '(' | ')' | '[' | ']' | '{' | '}' | ',' | '=' | ';' | ':' | '/.style' | '/.append' ) )+
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:213:6: (~ ( '(' | ')' | '[' | ']' | '{' | '}' | ',' | '=' | ';' | ':' | '/.style' | '/.append' ) )+
             	int cnt21 = 0;
             	do 
             	{
             	    int alt21 = 2;
             	    int LA21_0 = input.LA(1);
 
-            	    if ( (LA21_0 == 78) )
+            	    if ( (LA21_0 == 79) )
             	    {
             	        int LA21_2 = input.LA(2);
 
-            	        if ( ((LA21_2 >= FLOAT_WO_EXP && LA21_2 <= INT) || (LA21_2 >= 43 && LA21_2 <= 45) || (LA21_2 >= 47 && LA21_2 <= 50) || LA21_2 == 53 || LA21_2 == 55 || LA21_2 == 78) )
+            	        if ( ((LA21_2 >= FLOAT_WO_EXP && LA21_2 <= INT) || (LA21_2 >= 43 && LA21_2 <= 45) || (LA21_2 >= 47 && LA21_2 <= 50) || LA21_2 == 54 || LA21_2 == 56 || LA21_2 == 79) )
             	        {
             	            alt21 = 1;
             	        }
-            	        else if ( ((LA21_2 >= IM_PATH && LA21_2 <= COMMAND) || (LA21_2 >= WS && LA21_2 <= 42) || LA21_2 == 46 || LA21_2 == 51 || (LA21_2 >= 57 && LA21_2 <= 77) || (LA21_2 >= 79 && LA21_2 <= 94)) )
+            	        else if ( ((LA21_2 >= IM_PATH && LA21_2 <= COMMAND) || (LA21_2 >= WS && LA21_2 <= 42) || LA21_2 == 46 || (LA21_2 >= 51 && LA21_2 <= 52) || (LA21_2 >= 58 && LA21_2 <= 78) || (LA21_2 >= 80 && LA21_2 <= 95)) )
             	        {
             	            alt21 = 1;
             	        }
 
 
             	    }
-            	    else if ( ((LA21_0 >= IM_PATH && LA21_0 <= 42) || LA21_0 == 46 || LA21_0 == 51 || (LA21_0 >= 57 && LA21_0 <= 77) || (LA21_0 >= 79 && LA21_0 <= 94)) )
+            	    else if ( ((LA21_0 >= IM_PATH && LA21_0 <= 42) || LA21_0 == 46 || (LA21_0 >= 51 && LA21_0 <= 52) || (LA21_0 >= 58 && LA21_0 <= 78) || (LA21_0 >= 80 && LA21_0 <= 95)) )
             	    {
             	        alt21 = 1;
             	    }
@@ -2692,13 +2744,13 @@ public partial class simpletikzParser : Parser
             	    switch (alt21) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:213:6: ~ ( '(' | ')' | '[' | ']' | '{' | '}' | ',' | '=' | ';' | ':' | '/.style' | '/.append' )
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:213:6: ~ ( '(' | ')' | '[' | ']' | '{' | '}' | ',' | '=' | ';' | ':' | '/.style' | '/.append' )
             			    {
-            			    	set69 = (IToken)input.LT(1);
-            			    	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= 42) || input.LA(1) == 46 || input.LA(1) == 51 || (input.LA(1) >= 57 && input.LA(1) <= 94) ) 
+            			    	set72 = (IToken)input.LT(1);
+            			    	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= 42) || input.LA(1) == 46 || (input.LA(1) >= 51 && input.LA(1) <= 52) || (input.LA(1) >= 58 && input.LA(1) <= 95) ) 
             			    	{
             			    	    input.Consume();
-            			    	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set69));
+            			    	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set72));
             			    	    state.errorRecovery = false;state.failed = false;
             			    	}
             			    	else 
@@ -2756,7 +2808,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "idd2"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:214:1: idd2 : ( ID )+ -> ^( IM_ID ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:214:1: idd2 : ( ID )+ -> ^( IM_ID ) ;
     public simpletikzParser.idd2_return idd2() // throws RecognitionException [1]
     {   
         simpletikzParser.idd2_return retval = new simpletikzParser.idd2_return();
@@ -2764,17 +2816,17 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken ID70 = null;
+        IToken ID73 = null;
 
-        object ID70_tree=null;
+        object ID73_tree=null;
         RewriteRuleTokenStream stream_ID = new RewriteRuleTokenStream(adaptor,"token ID");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:215:2: ( ( ID )+ -> ^( IM_ID ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:215:4: ( ID )+
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:215:2: ( ( ID )+ -> ^( IM_ID ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:215:4: ( ID )+
             {
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:215:4: ( ID )+
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:215:4: ( ID )+
             	int cnt22 = 0;
             	do 
             	{
@@ -2790,10 +2842,10 @@ public partial class simpletikzParser : Parser
             	    switch (alt22) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:215:4: ID
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:215:4: ID
             			    {
-            			    	ID70=(IToken)Match(input,ID,FOLLOW_ID_in_idd2846); if (state.failed) return retval; 
-            			    	if ( state.backtracking==0 ) stream_ID.Add(ID70);
+            			    	ID73=(IToken)Match(input,ID,FOLLOW_ID_in_idd2857); if (state.failed) return retval; 
+            			    	if ( state.backtracking==0 ) stream_ID.Add(ID73);
 
 
             			    }
@@ -2827,7 +2879,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 215:8: -> ^( IM_ID )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:215:11: ^( IM_ID )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:215:11: ^( IM_ID )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ID, "IM_ID"), root_1);
@@ -2868,7 +2920,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "numberunitorvariable"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:218:1: numberunitorvariable : ( numberunit | COMMAND );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:218:1: numberunitorvariable : ( numberunit | COMMAND );
     public simpletikzParser.numberunitorvariable_return numberunitorvariable() // throws RecognitionException [1]
     {   
         simpletikzParser.numberunitorvariable_return retval = new simpletikzParser.numberunitorvariable_return();
@@ -2876,15 +2928,15 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken COMMAND72 = null;
-        simpletikzParser.numberunit_return numberunit71 = default(simpletikzParser.numberunit_return);
+        IToken COMMAND75 = null;
+        simpletikzParser.numberunit_return numberunit74 = default(simpletikzParser.numberunit_return);
 
 
-        object COMMAND72_tree=null;
+        object COMMAND75_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:219:2: ( numberunit | COMMAND )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:219:2: ( numberunit | COMMAND )
             int alt23 = 2;
             int LA23_0 = input.LA(1);
 
@@ -2907,27 +2959,27 @@ public partial class simpletikzParser : Parser
             switch (alt23) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:219:4: numberunit
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:219:4: numberunit
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_numberunit_in_numberunitorvariable865);
-                    	numberunit71 = numberunit();
+                    	PushFollow(FOLLOW_numberunit_in_numberunitorvariable876);
+                    	numberunit74 = numberunit();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, numberunit71.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, numberunit74.Tree);
 
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:220:4: COMMAND
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:220:4: COMMAND
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	COMMAND72=(IToken)Match(input,COMMAND,FOLLOW_COMMAND_in_numberunitorvariable870); if (state.failed) return retval;
+                    	COMMAND75=(IToken)Match(input,COMMAND,FOLLOW_COMMAND_in_numberunitorvariable881); if (state.failed) return retval;
                     	if ( state.backtracking == 0 )
-                    	{COMMAND72_tree = (object)adaptor.Create(COMMAND72);
-                    		adaptor.AddChild(root_0, COMMAND72_tree);
+                    	{COMMAND75_tree = (object)adaptor.Create(COMMAND75);
+                    		adaptor.AddChild(root_0, COMMAND75_tree);
                     	}
 
                     }
@@ -2962,7 +3014,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "numberunit"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:223:1: numberunit : number ( unit )? -> ^( IM_NUMBERUNIT number ( unit )? ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:223:1: numberunit : number ( unit )? -> ^( IM_NUMBERUNIT number ( unit )? ) ;
     public simpletikzParser.numberunit_return numberunit() // throws RecognitionException [1]
     {   
         simpletikzParser.numberunit_return retval = new simpletikzParser.numberunit_return();
@@ -2970,41 +3022,41 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.number_return number73 = default(simpletikzParser.number_return);
+        simpletikzParser.number_return number76 = default(simpletikzParser.number_return);
 
-        simpletikzParser.unit_return unit74 = default(simpletikzParser.unit_return);
+        simpletikzParser.unit_return unit77 = default(simpletikzParser.unit_return);
 
 
-        RewriteRuleSubtreeStream stream_unit = new RewriteRuleSubtreeStream(adaptor,"rule unit");
         RewriteRuleSubtreeStream stream_number = new RewriteRuleSubtreeStream(adaptor,"rule number");
+        RewriteRuleSubtreeStream stream_unit = new RewriteRuleSubtreeStream(adaptor,"rule unit");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:224:2: ( number ( unit )? -> ^( IM_NUMBERUNIT number ( unit )? ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:224:4: number ( unit )?
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:224:2: ( number ( unit )? -> ^( IM_NUMBERUNIT number ( unit )? ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:224:4: number ( unit )?
             {
-            	PushFollow(FOLLOW_number_in_numberunit883);
-            	number73 = number();
+            	PushFollow(FOLLOW_number_in_numberunit894);
+            	number76 = number();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_number.Add(number73.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:224:11: ( unit )?
+            	if ( state.backtracking==0 ) stream_number.Add(number76.Tree);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:224:11: ( unit )?
             	int alt24 = 2;
             	int LA24_0 = input.LA(1);
 
-            	if ( ((LA24_0 >= 57 && LA24_0 <= 62)) )
+            	if ( ((LA24_0 >= 58 && LA24_0 <= 63)) )
             	{
             	    alt24 = 1;
             	}
             	switch (alt24) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:224:11: unit
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:224:11: unit
             	        {
-            	        	PushFollow(FOLLOW_unit_in_numberunit885);
-            	        	unit74 = unit();
+            	        	PushFollow(FOLLOW_unit_in_numberunit896);
+            	        	unit77 = unit();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_unit.Add(unit74.Tree);
+            	        	if ( state.backtracking==0 ) stream_unit.Add(unit77.Tree);
 
             	        }
             	        break;
@@ -3026,13 +3078,13 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 224:17: -> ^( IM_NUMBERUNIT number ( unit )? )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:224:20: ^( IM_NUMBERUNIT number ( unit )? )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:224:20: ^( IM_NUMBERUNIT number ( unit )? )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_NUMBERUNIT, "IM_NUMBERUNIT"), root_1);
 
             	    adaptor.AddChild(root_1, stream_number.NextTree());
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:224:43: ( unit )?
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:224:43: ( unit )?
             	    if ( stream_unit.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_unit.NextTree());
@@ -3076,7 +3128,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "number"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:228:1: number : ( FLOAT_WO_EXP | INT ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:228:1: number : ( FLOAT_WO_EXP | INT ) ;
     public simpletikzParser.number_return number() // throws RecognitionException [1]
     {   
         simpletikzParser.number_return retval = new simpletikzParser.number_return();
@@ -3084,22 +3136,22 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set75 = null;
+        IToken set78 = null;
 
-        object set75_tree=null;
+        object set78_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:229:2: ( ( FLOAT_WO_EXP | INT ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:229:4: ( FLOAT_WO_EXP | INT )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:229:2: ( ( FLOAT_WO_EXP | INT ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:229:4: ( FLOAT_WO_EXP | INT )
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set75 = (IToken)input.LT(1);
+            	set78 = (IToken)input.LT(1);
             	if ( (input.LA(1) >= FLOAT_WO_EXP && input.LA(1) <= INT) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set75));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set78));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -3140,7 +3192,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "unit"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:232:1: unit : ( 'cm' | 'in' | 'ex' | 'mm' | 'pt' | 'em' );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:232:1: unit : ( 'cm' | 'in' | 'ex' | 'mm' | 'pt' | 'em' );
     public simpletikzParser.unit_return unit() // throws RecognitionException [1]
     {   
         simpletikzParser.unit_return retval = new simpletikzParser.unit_return();
@@ -3148,22 +3200,22 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set76 = null;
+        IToken set79 = null;
 
-        object set76_tree=null;
+        object set79_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:233:2: ( 'cm' | 'in' | 'ex' | 'mm' | 'pt' | 'em' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:233:2: ( 'cm' | 'in' | 'ex' | 'mm' | 'pt' | 'em' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set76 = (IToken)input.LT(1);
-            	if ( (input.LA(1) >= 57 && input.LA(1) <= 62) ) 
+            	set79 = (IToken)input.LT(1);
+            	if ( (input.LA(1) >= 58 && input.LA(1) <= 63) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set76));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set79));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -3204,7 +3256,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikz_set"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:236:1: tikz_set : tikz_set_start ( option ( ',' option )* ( ',' )? )? roundbr_end -> ^( IM_TIKZSET tikz_set_start ( option )* roundbr_end ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:236:1: tikz_set : tikz_set_start ( option ( ',' option )* ( ',' )? )? roundbr_end -> ^( IM_TIKZSET tikz_set_start ( option )* roundbr_end ) ;
     public simpletikzParser.tikz_set_return tikz_set() // throws RecognitionException [1]
     {   
         simpletikzParser.tikz_set_return retval = new simpletikzParser.tikz_set_return();
@@ -3212,52 +3264,52 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal79 = null;
-        IToken char_literal81 = null;
-        simpletikzParser.tikz_set_start_return tikz_set_start77 = default(simpletikzParser.tikz_set_start_return);
+        IToken char_literal82 = null;
+        IToken char_literal84 = null;
+        simpletikzParser.tikz_set_start_return tikz_set_start80 = default(simpletikzParser.tikz_set_start_return);
 
-        simpletikzParser.option_return option78 = default(simpletikzParser.option_return);
+        simpletikzParser.option_return option81 = default(simpletikzParser.option_return);
 
-        simpletikzParser.option_return option80 = default(simpletikzParser.option_return);
+        simpletikzParser.option_return option83 = default(simpletikzParser.option_return);
 
-        simpletikzParser.roundbr_end_return roundbr_end82 = default(simpletikzParser.roundbr_end_return);
+        simpletikzParser.roundbr_end_return roundbr_end85 = default(simpletikzParser.roundbr_end_return);
 
 
-        object char_literal79_tree=null;
-        object char_literal81_tree=null;
+        object char_literal82_tree=null;
+        object char_literal84_tree=null;
         RewriteRuleTokenStream stream_47 = new RewriteRuleTokenStream(adaptor,"token 47");
         RewriteRuleSubtreeStream stream_tikz_set_start = new RewriteRuleSubtreeStream(adaptor,"rule tikz_set_start");
         RewriteRuleSubtreeStream stream_roundbr_end = new RewriteRuleSubtreeStream(adaptor,"rule roundbr_end");
         RewriteRuleSubtreeStream stream_option = new RewriteRuleSubtreeStream(adaptor,"rule option");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:237:2: ( tikz_set_start ( option ( ',' option )* ( ',' )? )? roundbr_end -> ^( IM_TIKZSET tikz_set_start ( option )* roundbr_end ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:237:5: tikz_set_start ( option ( ',' option )* ( ',' )? )? roundbr_end
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:2: ( tikz_set_start ( option ( ',' option )* ( ',' )? )? roundbr_end -> ^( IM_TIKZSET tikz_set_start ( option )* roundbr_end ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:5: tikz_set_start ( option ( ',' option )* ( ',' )? )? roundbr_end
             {
-            	PushFollow(FOLLOW_tikz_set_start_in_tikz_set966);
-            	tikz_set_start77 = tikz_set_start();
+            	PushFollow(FOLLOW_tikz_set_start_in_tikz_set977);
+            	tikz_set_start80 = tikz_set_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikz_set_start.Add(tikz_set_start77.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:237:20: ( option ( ',' option )* ( ',' )? )?
+            	if ( state.backtracking==0 ) stream_tikz_set_start.Add(tikz_set_start80.Tree);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:20: ( option ( ',' option )* ( ',' )? )?
             	int alt27 = 2;
             	int LA27_0 = input.LA(1);
 
-            	if ( ((LA27_0 >= IM_PATH && LA27_0 <= 42) || LA27_0 == 46 || LA27_0 == 51 || (LA27_0 >= 57 && LA27_0 <= 94)) )
+            	if ( ((LA27_0 >= IM_PATH && LA27_0 <= 42) || LA27_0 == 46 || (LA27_0 >= 51 && LA27_0 <= 52) || (LA27_0 >= 58 && LA27_0 <= 95)) )
             	{
             	    alt27 = 1;
             	}
             	switch (alt27) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:237:21: option ( ',' option )* ( ',' )?
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:21: option ( ',' option )* ( ',' )?
             	        {
-            	        	PushFollow(FOLLOW_option_in_tikz_set969);
-            	        	option78 = option();
+            	        	PushFollow(FOLLOW_option_in_tikz_set980);
+            	        	option81 = option();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_option.Add(option78.Tree);
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:237:28: ( ',' option )*
+            	        	if ( state.backtracking==0 ) stream_option.Add(option81.Tree);
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:28: ( ',' option )*
             	        	do 
             	        	{
             	        	    int alt25 = 2;
@@ -3267,7 +3319,7 @@ public partial class simpletikzParser : Parser
             	        	    {
             	        	        int LA25_1 = input.LA(2);
 
-            	        	        if ( ((LA25_1 >= IM_PATH && LA25_1 <= 42) || LA25_1 == 46 || LA25_1 == 51 || (LA25_1 >= 57 && LA25_1 <= 94)) )
+            	        	        if ( ((LA25_1 >= IM_PATH && LA25_1 <= 42) || LA25_1 == 46 || (LA25_1 >= 51 && LA25_1 <= 52) || (LA25_1 >= 58 && LA25_1 <= 95)) )
             	        	        {
             	        	            alt25 = 1;
             	        	        }
@@ -3279,16 +3331,16 @@ public partial class simpletikzParser : Parser
             	        	    switch (alt25) 
             	        		{
             	        			case 1 :
-            	        			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:237:29: ',' option
+            	        			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:29: ',' option
             	        			    {
-            	        			    	char_literal79=(IToken)Match(input,47,FOLLOW_47_in_tikz_set972); if (state.failed) return retval; 
-            	        			    	if ( state.backtracking==0 ) stream_47.Add(char_literal79);
+            	        			    	char_literal82=(IToken)Match(input,47,FOLLOW_47_in_tikz_set983); if (state.failed) return retval; 
+            	        			    	if ( state.backtracking==0 ) stream_47.Add(char_literal82);
 
-            	        			    	PushFollow(FOLLOW_option_in_tikz_set974);
-            	        			    	option80 = option();
+            	        			    	PushFollow(FOLLOW_option_in_tikz_set985);
+            	        			    	option83 = option();
             	        			    	state.followingStackPointer--;
             	        			    	if (state.failed) return retval;
-            	        			    	if ( state.backtracking==0 ) stream_option.Add(option80.Tree);
+            	        			    	if ( state.backtracking==0 ) stream_option.Add(option83.Tree);
 
             	        			    }
             	        			    break;
@@ -3301,7 +3353,7 @@ public partial class simpletikzParser : Parser
             	        	loop25:
             	        		;	// Stops C# compiler whining that label 'loop25' has no statements
 
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:237:42: ( ',' )?
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:42: ( ',' )?
             	        	int alt26 = 2;
             	        	int LA26_0 = input.LA(1);
 
@@ -3312,10 +3364,10 @@ public partial class simpletikzParser : Parser
             	        	switch (alt26) 
             	        	{
             	        	    case 1 :
-            	        	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:237:42: ','
+            	        	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:42: ','
             	        	        {
-            	        	        	char_literal81=(IToken)Match(input,47,FOLLOW_47_in_tikz_set978); if (state.failed) return retval; 
-            	        	        	if ( state.backtracking==0 ) stream_47.Add(char_literal81);
+            	        	        	char_literal84=(IToken)Match(input,47,FOLLOW_47_in_tikz_set989); if (state.failed) return retval; 
+            	        	        	if ( state.backtracking==0 ) stream_47.Add(char_literal84);
 
 
             	        	        }
@@ -3329,15 +3381,15 @@ public partial class simpletikzParser : Parser
 
             	}
 
-            	PushFollow(FOLLOW_roundbr_end_in_tikz_set983);
-            	roundbr_end82 = roundbr_end();
+            	PushFollow(FOLLOW_roundbr_end_in_tikz_set994);
+            	roundbr_end85 = roundbr_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_roundbr_end.Add(roundbr_end82.Tree);
+            	if ( state.backtracking==0 ) stream_roundbr_end.Add(roundbr_end85.Tree);
 
 
             	// AST REWRITE
-            	// elements:          option, tikz_set_start, roundbr_end
+            	// elements:          tikz_set_start, option, roundbr_end
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -3349,13 +3401,13 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 237:61: -> ^( IM_TIKZSET tikz_set_start ( option )* roundbr_end )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:237:64: ^( IM_TIKZSET tikz_set_start ( option )* roundbr_end )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:64: ^( IM_TIKZSET tikz_set_start ( option )* roundbr_end )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_TIKZSET, "IM_TIKZSET"), root_1);
 
             	    adaptor.AddChild(root_1, stream_tikz_set_start.NextTree());
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:237:92: ( option )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:237:92: ( option )*
             	    while ( stream_option.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_option.NextTree());
@@ -3400,7 +3452,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzpicture"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:242:1: tikzpicture : ( ( tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end ) -> ^( IM_PICTURE tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end ) | ( tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end ) -> ^( IM_PICTURE tikz_start ( tikz_options )? ( tikzbody2 )? roundbr_end ) );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:242:1: tikzpicture : ( ( tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end ) -> ^( IM_PICTURE tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end ) | ( tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end ) -> ^( IM_PICTURE tikz_start ( tikz_options )? ( tikzbody2 )? roundbr_end ) );
     public simpletikzParser.tikzpicture_return tikzpicture() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzpicture_return retval = new simpletikzParser.tikzpicture_return();
@@ -3408,36 +3460,36 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal89 = null;
-        simpletikzParser.tikzpicture_start_return tikzpicture_start83 = default(simpletikzParser.tikzpicture_start_return);
+        IToken char_literal92 = null;
+        simpletikzParser.tikzpicture_start_return tikzpicture_start86 = default(simpletikzParser.tikzpicture_start_return);
 
-        simpletikzParser.tikz_options_return tikz_options84 = default(simpletikzParser.tikz_options_return);
+        simpletikzParser.tikz_options_return tikz_options87 = default(simpletikzParser.tikz_options_return);
 
-        simpletikzParser.tikzbody_return tikzbody85 = default(simpletikzParser.tikzbody_return);
+        simpletikzParser.tikzbody_return tikzbody88 = default(simpletikzParser.tikzbody_return);
 
-        simpletikzParser.tikzpicture_end_return tikzpicture_end86 = default(simpletikzParser.tikzpicture_end_return);
+        simpletikzParser.tikzpicture_end_return tikzpicture_end89 = default(simpletikzParser.tikzpicture_end_return);
 
-        simpletikzParser.tikz_start_return tikz_start87 = default(simpletikzParser.tikz_start_return);
+        simpletikzParser.tikz_start_return tikz_start90 = default(simpletikzParser.tikz_start_return);
 
-        simpletikzParser.tikz_options_return tikz_options88 = default(simpletikzParser.tikz_options_return);
+        simpletikzParser.tikz_options_return tikz_options91 = default(simpletikzParser.tikz_options_return);
 
-        simpletikzParser.tikzbody2_return tikzbody290 = default(simpletikzParser.tikzbody2_return);
+        simpletikzParser.tikzbody2_return tikzbody293 = default(simpletikzParser.tikzbody2_return);
 
-        simpletikzParser.roundbr_end_return roundbr_end91 = default(simpletikzParser.roundbr_end_return);
+        simpletikzParser.roundbr_end_return roundbr_end94 = default(simpletikzParser.roundbr_end_return);
 
 
-        object char_literal89_tree=null;
+        object char_literal92_tree=null;
         RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
-        RewriteRuleSubtreeStream stream_tikzbody2 = new RewriteRuleSubtreeStream(adaptor,"rule tikzbody2");
-        RewriteRuleSubtreeStream stream_tikzpicture_end = new RewriteRuleSubtreeStream(adaptor,"rule tikzpicture_end");
-        RewriteRuleSubtreeStream stream_tikzpicture_start = new RewriteRuleSubtreeStream(adaptor,"rule tikzpicture_start");
-        RewriteRuleSubtreeStream stream_tikz_start = new RewriteRuleSubtreeStream(adaptor,"rule tikz_start");
-        RewriteRuleSubtreeStream stream_roundbr_end = new RewriteRuleSubtreeStream(adaptor,"rule roundbr_end");
-        RewriteRuleSubtreeStream stream_tikzbody = new RewriteRuleSubtreeStream(adaptor,"rule tikzbody");
         RewriteRuleSubtreeStream stream_tikz_options = new RewriteRuleSubtreeStream(adaptor,"rule tikz_options");
+        RewriteRuleSubtreeStream stream_tikz_start = new RewriteRuleSubtreeStream(adaptor,"rule tikz_start");
+        RewriteRuleSubtreeStream stream_tikzbody = new RewriteRuleSubtreeStream(adaptor,"rule tikzbody");
+        RewriteRuleSubtreeStream stream_tikzpicture_start = new RewriteRuleSubtreeStream(adaptor,"rule tikzpicture_start");
+        RewriteRuleSubtreeStream stream_tikzpicture_end = new RewriteRuleSubtreeStream(adaptor,"rule tikzpicture_end");
+        RewriteRuleSubtreeStream stream_tikzbody2 = new RewriteRuleSubtreeStream(adaptor,"rule tikzbody2");
+        RewriteRuleSubtreeStream stream_roundbr_end = new RewriteRuleSubtreeStream(adaptor,"rule roundbr_end");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:243:2: ( ( tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end ) -> ^( IM_PICTURE tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end ) | ( tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end ) -> ^( IM_PICTURE tikz_start ( tikz_options )? ( tikzbody2 )? roundbr_end ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:2: ( ( tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end ) -> ^( IM_PICTURE tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end ) | ( tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end ) -> ^( IM_PICTURE tikz_start ( tikz_options )? ( tikzbody2 )? roundbr_end ) )
             int alt32 = 2;
             int LA32_0 = input.LA(1);
 
@@ -3460,49 +3512,49 @@ public partial class simpletikzParser : Parser
             switch (alt32) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:243:7: ( tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end )
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:7: ( tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end )
                     {
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:243:7: ( tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end )
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:243:9: tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:7: ( tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end )
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:9: tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end
                     	{
-                    		PushFollow(FOLLOW_tikzpicture_start_in_tikzpicture1015);
-                    		tikzpicture_start83 = tikzpicture_start();
+                    		PushFollow(FOLLOW_tikzpicture_start_in_tikzpicture1026);
+                    		tikzpicture_start86 = tikzpicture_start();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_tikzpicture_start.Add(tikzpicture_start83.Tree);
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:243:27: ( tikz_options )?
+                    		if ( state.backtracking==0 ) stream_tikzpicture_start.Add(tikzpicture_start86.Tree);
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:27: ( tikz_options )?
                     		int alt28 = 2;
                     		int LA28_0 = input.LA(1);
 
-                    		if ( (LA28_0 == 54) )
+                    		if ( (LA28_0 == 55) )
                     		{
                     		    alt28 = 1;
                     		}
                     		switch (alt28) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:243:27: tikz_options
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:27: tikz_options
                     		        {
-                    		        	PushFollow(FOLLOW_tikz_options_in_tikzpicture1017);
-                    		        	tikz_options84 = tikz_options();
+                    		        	PushFollow(FOLLOW_tikz_options_in_tikzpicture1028);
+                    		        	tikz_options87 = tikz_options();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options84.Tree);
+                    		        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options87.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:243:41: ( tikzbody )?
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:41: ( tikzbody )?
                     		int alt29 = 2;
                     		int LA29_0 = input.LA(1);
 
-                    		if ( ((LA29_0 >= IM_PATH && LA29_0 <= 53) || (LA29_0 >= 55 && LA29_0 <= 62) || (LA29_0 >= 64 && LA29_0 <= 94)) )
+                    		if ( ((LA29_0 >= IM_PATH && LA29_0 <= 54) || (LA29_0 >= 56 && LA29_0 <= 63) || (LA29_0 >= 65 && LA29_0 <= 95)) )
                     		{
                     		    alt29 = 1;
                     		}
-                    		else if ( (LA29_0 == 63) )
+                    		else if ( (LA29_0 == 64) )
                     		{
                     		    int LA29_2 = input.LA(2);
 
@@ -3519,31 +3571,31 @@ public partial class simpletikzParser : Parser
                     		switch (alt29) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:243:41: tikzbody
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:41: tikzbody
                     		        {
-                    		        	PushFollow(FOLLOW_tikzbody_in_tikzpicture1020);
-                    		        	tikzbody85 = tikzbody();
+                    		        	PushFollow(FOLLOW_tikzbody_in_tikzpicture1031);
+                    		        	tikzbody88 = tikzbody();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_tikzbody.Add(tikzbody85.Tree);
+                    		        	if ( state.backtracking==0 ) stream_tikzbody.Add(tikzbody88.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		PushFollow(FOLLOW_tikzpicture_end_in_tikzpicture1023);
-                    		tikzpicture_end86 = tikzpicture_end();
+                    		PushFollow(FOLLOW_tikzpicture_end_in_tikzpicture1034);
+                    		tikzpicture_end89 = tikzpicture_end();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_tikzpicture_end.Add(tikzpicture_end86.Tree);
+                    		if ( state.backtracking==0 ) stream_tikzpicture_end.Add(tikzpicture_end89.Tree);
 
                     	}
 
 
 
                     	// AST REWRITE
-                    	// elements:          tikzpicture_end, tikzbody, tikzpicture_start, tikz_options
+                    	// elements:          tikzbody, tikzpicture_start, tikzpicture_end, tikz_options
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -3555,20 +3607,20 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 243:68: -> ^( IM_PICTURE tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:243:71: ^( IM_PICTURE tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:71: ^( IM_PICTURE tikzpicture_start ( tikz_options )? ( tikzbody )? tikzpicture_end )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_PICTURE, "IM_PICTURE"), root_1);
 
                     	    adaptor.AddChild(root_1, stream_tikzpicture_start.NextTree());
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:243:102: ( tikz_options )?
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:102: ( tikz_options )?
                     	    if ( stream_tikz_options.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_tikz_options.NextTree());
 
                     	    }
                     	    stream_tikz_options.Reset();
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:243:116: ( tikzbody )?
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:243:116: ( tikzbody )?
                     	    if ( stream_tikzbody.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_tikzbody.NextTree());
@@ -3586,79 +3638,79 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:244:5: ( tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end )
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:5: ( tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end )
                     {
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:244:5: ( tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end )
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:244:7: tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:5: ( tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end )
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:7: tikz_start ( tikz_options )? '{' ( tikzbody2 )? roundbr_end
                     	{
-                    		PushFollow(FOLLOW_tikz_start_in_tikzpicture1048);
-                    		tikz_start87 = tikz_start();
+                    		PushFollow(FOLLOW_tikz_start_in_tikzpicture1059);
+                    		tikz_start90 = tikz_start();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_tikz_start.Add(tikz_start87.Tree);
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:244:19: ( tikz_options )?
+                    		if ( state.backtracking==0 ) stream_tikz_start.Add(tikz_start90.Tree);
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:19: ( tikz_options )?
                     		int alt30 = 2;
                     		int LA30_0 = input.LA(1);
 
-                    		if ( (LA30_0 == 54) )
+                    		if ( (LA30_0 == 55) )
                     		{
                     		    alt30 = 1;
                     		}
                     		switch (alt30) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:244:19: tikz_options
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:19: tikz_options
                     		        {
-                    		        	PushFollow(FOLLOW_tikz_options_in_tikzpicture1051);
-                    		        	tikz_options88 = tikz_options();
+                    		        	PushFollow(FOLLOW_tikz_options_in_tikzpicture1062);
+                    		        	tikz_options91 = tikz_options();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options88.Tree);
+                    		        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options91.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal89=(IToken)Match(input,43,FOLLOW_43_in_tikzpicture1054); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_43.Add(char_literal89);
+                    		char_literal92=(IToken)Match(input,43,FOLLOW_43_in_tikzpicture1065); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_43.Add(char_literal92);
 
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:244:37: ( tikzbody2 )?
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:37: ( tikzbody2 )?
                     		int alt31 = 2;
                     		int LA31_0 = input.LA(1);
 
-                    		if ( ((LA31_0 >= IM_PATH && LA31_0 <= 42) || (LA31_0 >= 45 && LA31_0 <= 53) || (LA31_0 >= 55 && LA31_0 <= 94)) )
+                    		if ( ((LA31_0 >= IM_PATH && LA31_0 <= 42) || (LA31_0 >= 45 && LA31_0 <= 54) || (LA31_0 >= 56 && LA31_0 <= 95)) )
                     		{
                     		    alt31 = 1;
                     		}
                     		switch (alt31) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:244:37: tikzbody2
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:37: tikzbody2
                     		        {
-                    		        	PushFollow(FOLLOW_tikzbody2_in_tikzpicture1056);
-                    		        	tikzbody290 = tikzbody2();
+                    		        	PushFollow(FOLLOW_tikzbody2_in_tikzpicture1067);
+                    		        	tikzbody293 = tikzbody2();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_tikzbody2.Add(tikzbody290.Tree);
+                    		        	if ( state.backtracking==0 ) stream_tikzbody2.Add(tikzbody293.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		PushFollow(FOLLOW_roundbr_end_in_tikzpicture1059);
-                    		roundbr_end91 = roundbr_end();
+                    		PushFollow(FOLLOW_roundbr_end_in_tikzpicture1070);
+                    		roundbr_end94 = roundbr_end();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_roundbr_end.Add(roundbr_end91.Tree);
+                    		if ( state.backtracking==0 ) stream_roundbr_end.Add(roundbr_end94.Tree);
 
                     	}
 
 
 
                     	// AST REWRITE
-                    	// elements:          roundbr_end, tikzbody2, tikz_start, tikz_options
+                    	// elements:          tikzbody2, tikz_start, tikz_options, roundbr_end
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -3670,20 +3722,20 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 244:63: -> ^( IM_PICTURE tikz_start ( tikz_options )? ( tikzbody2 )? roundbr_end )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:244:66: ^( IM_PICTURE tikz_start ( tikz_options )? ( tikzbody2 )? roundbr_end )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:66: ^( IM_PICTURE tikz_start ( tikz_options )? ( tikzbody2 )? roundbr_end )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_PICTURE, "IM_PICTURE"), root_1);
 
                     	    adaptor.AddChild(root_1, stream_tikz_start.NextTree());
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:244:90: ( tikz_options )?
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:90: ( tikz_options )?
                     	    if ( stream_tikz_options.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_tikz_options.NextTree());
 
                     	    }
                     	    stream_tikz_options.Reset();
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:244:104: ( tikzbody2 )?
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:244:104: ( tikzbody2 )?
                     	    if ( stream_tikzbody2.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_tikzbody2.NextTree());
@@ -3730,7 +3782,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzbody"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:247:1: tikzbody : ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr ) ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body )* ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:247:1: tikzbody : ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr ) ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body )* ;
     public simpletikzParser.tikzbody_return tikzbody() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzbody_return retval = new simpletikzParser.tikzbody_return();
@@ -3738,177 +3790,177 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikzscope_return tikzscope92 = default(simpletikzParser.tikzscope_return);
+        simpletikzParser.tikzscope_return tikzscope95 = default(simpletikzParser.tikzscope_return);
 
-        simpletikzParser.tikzpath_return tikzpath93 = default(simpletikzParser.tikzpath_return);
+        simpletikzParser.tikzpath_return tikzpath96 = default(simpletikzParser.tikzpath_return);
 
-        simpletikzParser.tikznode_ext_return tikznode_ext94 = default(simpletikzParser.tikznode_ext_return);
+        simpletikzParser.tikznode_ext_return tikznode_ext97 = default(simpletikzParser.tikznode_ext_return);
 
-        simpletikzParser.tikzdef_ext_return tikzdef_ext95 = default(simpletikzParser.tikzdef_ext_return);
+        simpletikzParser.tikzdef_ext_return tikzdef_ext98 = default(simpletikzParser.tikzdef_ext_return);
 
-        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext96 = default(simpletikzParser.tikzmatrix_ext_return);
+        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext99 = default(simpletikzParser.tikzmatrix_ext_return);
 
-        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext97 = default(simpletikzParser.tikzcoordinate_ext_return);
+        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext100 = default(simpletikzParser.tikzcoordinate_ext_return);
 
-        simpletikzParser.tikz_set_return tikz_set98 = default(simpletikzParser.tikz_set_return);
+        simpletikzParser.tikz_set_return tikz_set101 = default(simpletikzParser.tikz_set_return);
 
-        simpletikzParser.tikz_style_return tikz_style99 = default(simpletikzParser.tikz_style_return);
+        simpletikzParser.tikz_style_return tikz_style102 = default(simpletikzParser.tikz_style_return);
 
-        simpletikzParser.otherbegin_return otherbegin100 = default(simpletikzParser.otherbegin_return);
+        simpletikzParser.otherbegin_return otherbegin103 = default(simpletikzParser.otherbegin_return);
 
-        simpletikzParser.otherend_return otherend101 = default(simpletikzParser.otherend_return);
+        simpletikzParser.otherend_return otherend104 = default(simpletikzParser.otherend_return);
 
-        simpletikzParser.dontcare_body_nobr_return dontcare_body_nobr102 = default(simpletikzParser.dontcare_body_nobr_return);
+        simpletikzParser.dontcare_body_nobr_return dontcare_body_nobr105 = default(simpletikzParser.dontcare_body_nobr_return);
 
-        simpletikzParser.tikzscope_return tikzscope103 = default(simpletikzParser.tikzscope_return);
+        simpletikzParser.tikzscope_return tikzscope106 = default(simpletikzParser.tikzscope_return);
 
-        simpletikzParser.tikzpath_return tikzpath104 = default(simpletikzParser.tikzpath_return);
+        simpletikzParser.tikzpath_return tikzpath107 = default(simpletikzParser.tikzpath_return);
 
-        simpletikzParser.tikznode_ext_return tikznode_ext105 = default(simpletikzParser.tikznode_ext_return);
+        simpletikzParser.tikznode_ext_return tikznode_ext108 = default(simpletikzParser.tikznode_ext_return);
 
-        simpletikzParser.tikzdef_ext_return tikzdef_ext106 = default(simpletikzParser.tikzdef_ext_return);
+        simpletikzParser.tikzdef_ext_return tikzdef_ext109 = default(simpletikzParser.tikzdef_ext_return);
 
-        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext107 = default(simpletikzParser.tikzmatrix_ext_return);
+        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext110 = default(simpletikzParser.tikzmatrix_ext_return);
 
-        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext108 = default(simpletikzParser.tikzcoordinate_ext_return);
+        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext111 = default(simpletikzParser.tikzcoordinate_ext_return);
 
-        simpletikzParser.tikz_set_return tikz_set109 = default(simpletikzParser.tikz_set_return);
+        simpletikzParser.tikz_set_return tikz_set112 = default(simpletikzParser.tikz_set_return);
 
-        simpletikzParser.tikz_style_return tikz_style110 = default(simpletikzParser.tikz_style_return);
+        simpletikzParser.tikz_style_return tikz_style113 = default(simpletikzParser.tikz_style_return);
 
-        simpletikzParser.otherbegin_return otherbegin111 = default(simpletikzParser.otherbegin_return);
+        simpletikzParser.otherbegin_return otherbegin114 = default(simpletikzParser.otherbegin_return);
 
-        simpletikzParser.otherend_return otherend112 = default(simpletikzParser.otherend_return);
+        simpletikzParser.otherend_return otherend115 = default(simpletikzParser.otherend_return);
 
-        simpletikzParser.dontcare_body_return dontcare_body113 = default(simpletikzParser.dontcare_body_return);
+        simpletikzParser.dontcare_body_return dontcare_body116 = default(simpletikzParser.dontcare_body_return);
 
 
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:2: ( ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr ) ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body )* )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr ) ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body )*
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:2: ( ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr ) ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body )* )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr ) ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body )*
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr )
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr )
             	int alt33 = 11;
             	alt33 = dfa33.Predict(input);
             	switch (alt33) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:6: tikzscope
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:6: tikzscope
             	        {
-            	        	PushFollow(FOLLOW_tikzscope_in_tikzbody1091);
-            	        	tikzscope92 = tikzscope();
+            	        	PushFollow(FOLLOW_tikzscope_in_tikzbody1102);
+            	        	tikzscope95 = tikzscope();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope92.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope95.Tree);
 
             	        }
             	        break;
             	    case 2 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:18: tikzpath
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:18: tikzpath
             	        {
-            	        	PushFollow(FOLLOW_tikzpath_in_tikzbody1095);
-            	        	tikzpath93 = tikzpath();
+            	        	PushFollow(FOLLOW_tikzpath_in_tikzbody1106);
+            	        	tikzpath96 = tikzpath();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath93.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath96.Tree);
 
             	        }
             	        break;
             	    case 3 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:29: tikznode_ext
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:29: tikznode_ext
             	        {
-            	        	PushFollow(FOLLOW_tikznode_ext_in_tikzbody1099);
-            	        	tikznode_ext94 = tikznode_ext();
+            	        	PushFollow(FOLLOW_tikznode_ext_in_tikzbody1110);
+            	        	tikznode_ext97 = tikznode_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext94.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext97.Tree);
 
             	        }
             	        break;
             	    case 4 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:44: tikzdef_ext
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:44: tikzdef_ext
             	        {
-            	        	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody1103);
-            	        	tikzdef_ext95 = tikzdef_ext();
+            	        	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody1114);
+            	        	tikzdef_ext98 = tikzdef_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext95.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext98.Tree);
 
             	        }
             	        break;
             	    case 5 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:58: tikzmatrix_ext
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:58: tikzmatrix_ext
             	        {
-            	        	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody1107);
-            	        	tikzmatrix_ext96 = tikzmatrix_ext();
+            	        	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody1118);
+            	        	tikzmatrix_ext99 = tikzmatrix_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext96.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext99.Tree);
 
             	        }
             	        break;
             	    case 6 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:75: tikzcoordinate_ext
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:75: tikzcoordinate_ext
             	        {
-            	        	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody1111);
-            	        	tikzcoordinate_ext97 = tikzcoordinate_ext();
+            	        	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody1122);
+            	        	tikzcoordinate_ext100 = tikzcoordinate_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext97.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext100.Tree);
 
             	        }
             	        break;
             	    case 7 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:96: tikz_set
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:96: tikz_set
             	        {
-            	        	PushFollow(FOLLOW_tikz_set_in_tikzbody1115);
-            	        	tikz_set98 = tikz_set();
+            	        	PushFollow(FOLLOW_tikz_set_in_tikzbody1126);
+            	        	tikz_set101 = tikz_set();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set98.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set101.Tree);
 
             	        }
             	        break;
             	    case 8 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:107: tikz_style
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:107: tikz_style
             	        {
-            	        	PushFollow(FOLLOW_tikz_style_in_tikzbody1119);
-            	        	tikz_style99 = tikz_style();
+            	        	PushFollow(FOLLOW_tikz_style_in_tikzbody1130);
+            	        	tikz_style102 = tikz_style();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style99.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style102.Tree);
 
             	        }
             	        break;
             	    case 9 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:120: otherbegin
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:120: otherbegin
             	        {
-            	        	PushFollow(FOLLOW_otherbegin_in_tikzbody1123);
-            	        	otherbegin100 = otherbegin();
+            	        	PushFollow(FOLLOW_otherbegin_in_tikzbody1134);
+            	        	otherbegin103 = otherbegin();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
 
             	        }
             	        break;
             	    case 10 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:134: otherend
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:134: otherend
             	        {
-            	        	PushFollow(FOLLOW_otherend_in_tikzbody1128);
-            	        	otherend101 = otherend();
+            	        	PushFollow(FOLLOW_otherend_in_tikzbody1139);
+            	        	otherend104 = otherend();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
 
             	        }
             	        break;
             	    case 11 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:248:146: dontcare_body_nobr
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:248:146: dontcare_body_nobr
             	        {
-            	        	PushFollow(FOLLOW_dontcare_body_nobr_in_tikzbody1133);
-            	        	dontcare_body_nobr102 = dontcare_body_nobr();
+            	        	PushFollow(FOLLOW_dontcare_body_nobr_in_tikzbody1144);
+            	        	dontcare_body_nobr105 = dontcare_body_nobr();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
 
@@ -3917,7 +3969,7 @@ public partial class simpletikzParser : Parser
 
             	}
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:249:3: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:3: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body )*
             	do 
             	{
             	    int alt34 = 12;
@@ -3925,118 +3977,118 @@ public partial class simpletikzParser : Parser
             	    switch (alt34) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:249:5: tikzscope
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:5: tikzscope
             			    {
-            			    	PushFollow(FOLLOW_tikzscope_in_tikzbody1144);
-            			    	tikzscope103 = tikzscope();
+            			    	PushFollow(FOLLOW_tikzscope_in_tikzbody1155);
+            			    	tikzscope106 = tikzscope();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope103.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope106.Tree);
 
             			    }
             			    break;
             			case 2 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:249:17: tikzpath
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:17: tikzpath
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_in_tikzbody1148);
-            			    	tikzpath104 = tikzpath();
+            			    	PushFollow(FOLLOW_tikzpath_in_tikzbody1159);
+            			    	tikzpath107 = tikzpath();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath104.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath107.Tree);
 
             			    }
             			    break;
             			case 3 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:249:28: tikznode_ext
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:28: tikznode_ext
             			    {
-            			    	PushFollow(FOLLOW_tikznode_ext_in_tikzbody1152);
-            			    	tikznode_ext105 = tikznode_ext();
+            			    	PushFollow(FOLLOW_tikznode_ext_in_tikzbody1163);
+            			    	tikznode_ext108 = tikznode_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext105.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext108.Tree);
 
             			    }
             			    break;
             			case 4 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:249:43: tikzdef_ext
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:43: tikzdef_ext
             			    {
-            			    	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody1156);
-            			    	tikzdef_ext106 = tikzdef_ext();
+            			    	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody1167);
+            			    	tikzdef_ext109 = tikzdef_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext106.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext109.Tree);
 
             			    }
             			    break;
             			case 5 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:249:57: tikzmatrix_ext
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:57: tikzmatrix_ext
             			    {
-            			    	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody1160);
-            			    	tikzmatrix_ext107 = tikzmatrix_ext();
+            			    	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody1171);
+            			    	tikzmatrix_ext110 = tikzmatrix_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext107.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext110.Tree);
 
             			    }
             			    break;
             			case 6 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:249:74: tikzcoordinate_ext
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:74: tikzcoordinate_ext
             			    {
-            			    	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody1164);
-            			    	tikzcoordinate_ext108 = tikzcoordinate_ext();
+            			    	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody1175);
+            			    	tikzcoordinate_ext111 = tikzcoordinate_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext108.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext111.Tree);
 
             			    }
             			    break;
             			case 7 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:249:95: tikz_set
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:95: tikz_set
             			    {
-            			    	PushFollow(FOLLOW_tikz_set_in_tikzbody1168);
-            			    	tikz_set109 = tikz_set();
+            			    	PushFollow(FOLLOW_tikz_set_in_tikzbody1179);
+            			    	tikz_set112 = tikz_set();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set109.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set112.Tree);
 
             			    }
             			    break;
             			case 8 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:249:106: tikz_style
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:106: tikz_style
             			    {
-            			    	PushFollow(FOLLOW_tikz_style_in_tikzbody1172);
-            			    	tikz_style110 = tikz_style();
+            			    	PushFollow(FOLLOW_tikz_style_in_tikzbody1183);
+            			    	tikz_style113 = tikz_style();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style110.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style113.Tree);
 
             			    }
             			    break;
             			case 9 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:249:119: otherbegin
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:119: otherbegin
             			    {
-            			    	PushFollow(FOLLOW_otherbegin_in_tikzbody1176);
-            			    	otherbegin111 = otherbegin();
+            			    	PushFollow(FOLLOW_otherbegin_in_tikzbody1187);
+            			    	otherbegin114 = otherbegin();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
 
             			    }
             			    break;
             			case 10 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:249:133: otherend
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:133: otherend
             			    {
-            			    	PushFollow(FOLLOW_otherend_in_tikzbody1181);
-            			    	otherend112 = otherend();
+            			    	PushFollow(FOLLOW_otherend_in_tikzbody1192);
+            			    	otherend115 = otherend();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
 
             			    }
             			    break;
             			case 11 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:249:145: dontcare_body
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:249:145: dontcare_body
             			    {
-            			    	PushFollow(FOLLOW_dontcare_body_in_tikzbody1186);
-            			    	dontcare_body113 = dontcare_body();
+            			    	PushFollow(FOLLOW_dontcare_body_in_tikzbody1197);
+            			    	dontcare_body116 = dontcare_body();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
 
@@ -4082,7 +4134,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzbody2"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:251:1: tikzbody2 : ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr2 ) ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body2 )* ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:251:1: tikzbody2 : ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr2 ) ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body2 )* ;
     public simpletikzParser.tikzbody2_return tikzbody2() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzbody2_return retval = new simpletikzParser.tikzbody2_return();
@@ -4090,177 +4142,177 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikzscope_return tikzscope114 = default(simpletikzParser.tikzscope_return);
+        simpletikzParser.tikzscope_return tikzscope117 = default(simpletikzParser.tikzscope_return);
 
-        simpletikzParser.tikzpath_return tikzpath115 = default(simpletikzParser.tikzpath_return);
+        simpletikzParser.tikzpath_return tikzpath118 = default(simpletikzParser.tikzpath_return);
 
-        simpletikzParser.tikznode_ext_return tikznode_ext116 = default(simpletikzParser.tikznode_ext_return);
+        simpletikzParser.tikznode_ext_return tikznode_ext119 = default(simpletikzParser.tikznode_ext_return);
 
-        simpletikzParser.tikzdef_ext_return tikzdef_ext117 = default(simpletikzParser.tikzdef_ext_return);
+        simpletikzParser.tikzdef_ext_return tikzdef_ext120 = default(simpletikzParser.tikzdef_ext_return);
 
-        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext118 = default(simpletikzParser.tikzmatrix_ext_return);
+        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext121 = default(simpletikzParser.tikzmatrix_ext_return);
 
-        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext119 = default(simpletikzParser.tikzcoordinate_ext_return);
+        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext122 = default(simpletikzParser.tikzcoordinate_ext_return);
 
-        simpletikzParser.tikz_set_return tikz_set120 = default(simpletikzParser.tikz_set_return);
+        simpletikzParser.tikz_set_return tikz_set123 = default(simpletikzParser.tikz_set_return);
 
-        simpletikzParser.tikz_style_return tikz_style121 = default(simpletikzParser.tikz_style_return);
+        simpletikzParser.tikz_style_return tikz_style124 = default(simpletikzParser.tikz_style_return);
 
-        simpletikzParser.otherbegin_return otherbegin122 = default(simpletikzParser.otherbegin_return);
+        simpletikzParser.otherbegin_return otherbegin125 = default(simpletikzParser.otherbegin_return);
 
-        simpletikzParser.otherend_return otherend123 = default(simpletikzParser.otherend_return);
+        simpletikzParser.otherend_return otherend126 = default(simpletikzParser.otherend_return);
 
-        simpletikzParser.dontcare_body_nobr2_return dontcare_body_nobr2124 = default(simpletikzParser.dontcare_body_nobr2_return);
+        simpletikzParser.dontcare_body_nobr2_return dontcare_body_nobr2127 = default(simpletikzParser.dontcare_body_nobr2_return);
 
-        simpletikzParser.tikzscope_return tikzscope125 = default(simpletikzParser.tikzscope_return);
+        simpletikzParser.tikzscope_return tikzscope128 = default(simpletikzParser.tikzscope_return);
 
-        simpletikzParser.tikzpath_return tikzpath126 = default(simpletikzParser.tikzpath_return);
+        simpletikzParser.tikzpath_return tikzpath129 = default(simpletikzParser.tikzpath_return);
 
-        simpletikzParser.tikznode_ext_return tikznode_ext127 = default(simpletikzParser.tikznode_ext_return);
+        simpletikzParser.tikznode_ext_return tikznode_ext130 = default(simpletikzParser.tikznode_ext_return);
 
-        simpletikzParser.tikzdef_ext_return tikzdef_ext128 = default(simpletikzParser.tikzdef_ext_return);
+        simpletikzParser.tikzdef_ext_return tikzdef_ext131 = default(simpletikzParser.tikzdef_ext_return);
 
-        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext129 = default(simpletikzParser.tikzmatrix_ext_return);
+        simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext132 = default(simpletikzParser.tikzmatrix_ext_return);
 
-        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext130 = default(simpletikzParser.tikzcoordinate_ext_return);
+        simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext133 = default(simpletikzParser.tikzcoordinate_ext_return);
 
-        simpletikzParser.tikz_set_return tikz_set131 = default(simpletikzParser.tikz_set_return);
+        simpletikzParser.tikz_set_return tikz_set134 = default(simpletikzParser.tikz_set_return);
 
-        simpletikzParser.tikz_style_return tikz_style132 = default(simpletikzParser.tikz_style_return);
+        simpletikzParser.tikz_style_return tikz_style135 = default(simpletikzParser.tikz_style_return);
 
-        simpletikzParser.otherbegin_return otherbegin133 = default(simpletikzParser.otherbegin_return);
+        simpletikzParser.otherbegin_return otherbegin136 = default(simpletikzParser.otherbegin_return);
 
-        simpletikzParser.otherend_return otherend134 = default(simpletikzParser.otherend_return);
+        simpletikzParser.otherend_return otherend137 = default(simpletikzParser.otherend_return);
 
-        simpletikzParser.dontcare_body2_return dontcare_body2135 = default(simpletikzParser.dontcare_body2_return);
+        simpletikzParser.dontcare_body2_return dontcare_body2138 = default(simpletikzParser.dontcare_body2_return);
 
 
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:2: ( ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr2 ) ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body2 )* )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr2 ) ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body2 )*
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:2: ( ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr2 ) ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body2 )* )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr2 ) ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body2 )*
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr2 )
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:4: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body_nobr2 )
             	int alt35 = 11;
             	alt35 = dfa35.Predict(input);
             	switch (alt35) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:6: tikzscope
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:6: tikzscope
             	        {
-            	        	PushFollow(FOLLOW_tikzscope_in_tikzbody21202);
-            	        	tikzscope114 = tikzscope();
+            	        	PushFollow(FOLLOW_tikzscope_in_tikzbody21213);
+            	        	tikzscope117 = tikzscope();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope114.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope117.Tree);
 
             	        }
             	        break;
             	    case 2 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:18: tikzpath
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:18: tikzpath
             	        {
-            	        	PushFollow(FOLLOW_tikzpath_in_tikzbody21206);
-            	        	tikzpath115 = tikzpath();
+            	        	PushFollow(FOLLOW_tikzpath_in_tikzbody21217);
+            	        	tikzpath118 = tikzpath();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath115.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath118.Tree);
 
             	        }
             	        break;
             	    case 3 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:29: tikznode_ext
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:29: tikznode_ext
             	        {
-            	        	PushFollow(FOLLOW_tikznode_ext_in_tikzbody21210);
-            	        	tikznode_ext116 = tikznode_ext();
+            	        	PushFollow(FOLLOW_tikznode_ext_in_tikzbody21221);
+            	        	tikznode_ext119 = tikznode_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext116.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext119.Tree);
 
             	        }
             	        break;
             	    case 4 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:44: tikzdef_ext
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:44: tikzdef_ext
             	        {
-            	        	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody21214);
-            	        	tikzdef_ext117 = tikzdef_ext();
+            	        	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody21225);
+            	        	tikzdef_ext120 = tikzdef_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext117.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext120.Tree);
 
             	        }
             	        break;
             	    case 5 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:58: tikzmatrix_ext
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:58: tikzmatrix_ext
             	        {
-            	        	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody21218);
-            	        	tikzmatrix_ext118 = tikzmatrix_ext();
+            	        	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody21229);
+            	        	tikzmatrix_ext121 = tikzmatrix_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext118.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext121.Tree);
 
             	        }
             	        break;
             	    case 6 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:75: tikzcoordinate_ext
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:75: tikzcoordinate_ext
             	        {
-            	        	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody21222);
-            	        	tikzcoordinate_ext119 = tikzcoordinate_ext();
+            	        	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody21233);
+            	        	tikzcoordinate_ext122 = tikzcoordinate_ext();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext119.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext122.Tree);
 
             	        }
             	        break;
             	    case 7 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:96: tikz_set
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:96: tikz_set
             	        {
-            	        	PushFollow(FOLLOW_tikz_set_in_tikzbody21226);
-            	        	tikz_set120 = tikz_set();
+            	        	PushFollow(FOLLOW_tikz_set_in_tikzbody21237);
+            	        	tikz_set123 = tikz_set();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set120.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set123.Tree);
 
             	        }
             	        break;
             	    case 8 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:107: tikz_style
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:107: tikz_style
             	        {
-            	        	PushFollow(FOLLOW_tikz_style_in_tikzbody21230);
-            	        	tikz_style121 = tikz_style();
+            	        	PushFollow(FOLLOW_tikz_style_in_tikzbody21241);
+            	        	tikz_style124 = tikz_style();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style121.Tree);
+            	        	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style124.Tree);
 
             	        }
             	        break;
             	    case 9 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:120: otherbegin
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:120: otherbegin
             	        {
-            	        	PushFollow(FOLLOW_otherbegin_in_tikzbody21234);
-            	        	otherbegin122 = otherbegin();
+            	        	PushFollow(FOLLOW_otherbegin_in_tikzbody21245);
+            	        	otherbegin125 = otherbegin();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
 
             	        }
             	        break;
             	    case 10 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:134: otherend
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:134: otherend
             	        {
-            	        	PushFollow(FOLLOW_otherend_in_tikzbody21239);
-            	        	otherend123 = otherend();
+            	        	PushFollow(FOLLOW_otherend_in_tikzbody21250);
+            	        	otherend126 = otherend();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
 
             	        }
             	        break;
             	    case 11 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:252:146: dontcare_body_nobr2
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:252:146: dontcare_body_nobr2
             	        {
-            	        	PushFollow(FOLLOW_dontcare_body_nobr2_in_tikzbody21244);
-            	        	dontcare_body_nobr2124 = dontcare_body_nobr2();
+            	        	PushFollow(FOLLOW_dontcare_body_nobr2_in_tikzbody21255);
+            	        	dontcare_body_nobr2127 = dontcare_body_nobr2();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
 
@@ -4269,7 +4321,7 @@ public partial class simpletikzParser : Parser
 
             	}
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:253:3: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body2 )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:3: ( tikzscope | tikzpath | tikznode_ext | tikzdef_ext | tikzmatrix_ext | tikzcoordinate_ext | tikz_set | tikz_style | otherbegin | otherend | dontcare_body2 )*
             	do 
             	{
             	    int alt36 = 12;
@@ -4277,118 +4329,118 @@ public partial class simpletikzParser : Parser
             	    switch (alt36) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:253:5: tikzscope
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:5: tikzscope
             			    {
-            			    	PushFollow(FOLLOW_tikzscope_in_tikzbody21255);
-            			    	tikzscope125 = tikzscope();
+            			    	PushFollow(FOLLOW_tikzscope_in_tikzbody21266);
+            			    	tikzscope128 = tikzscope();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope125.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzscope128.Tree);
 
             			    }
             			    break;
             			case 2 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:253:17: tikzpath
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:17: tikzpath
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_in_tikzbody21259);
-            			    	tikzpath126 = tikzpath();
+            			    	PushFollow(FOLLOW_tikzpath_in_tikzbody21270);
+            			    	tikzpath129 = tikzpath();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath126.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath129.Tree);
 
             			    }
             			    break;
             			case 3 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:253:28: tikznode_ext
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:28: tikznode_ext
             			    {
-            			    	PushFollow(FOLLOW_tikznode_ext_in_tikzbody21263);
-            			    	tikznode_ext127 = tikznode_ext();
+            			    	PushFollow(FOLLOW_tikznode_ext_in_tikzbody21274);
+            			    	tikznode_ext130 = tikznode_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext127.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_ext130.Tree);
 
             			    }
             			    break;
             			case 4 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:253:43: tikzdef_ext
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:43: tikzdef_ext
             			    {
-            			    	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody21267);
-            			    	tikzdef_ext128 = tikzdef_ext();
+            			    	PushFollow(FOLLOW_tikzdef_ext_in_tikzbody21278);
+            			    	tikzdef_ext131 = tikzdef_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext128.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzdef_ext131.Tree);
 
             			    }
             			    break;
             			case 5 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:253:57: tikzmatrix_ext
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:57: tikzmatrix_ext
             			    {
-            			    	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody21271);
-            			    	tikzmatrix_ext129 = tikzmatrix_ext();
+            			    	PushFollow(FOLLOW_tikzmatrix_ext_in_tikzbody21282);
+            			    	tikzmatrix_ext132 = tikzmatrix_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext129.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzmatrix_ext132.Tree);
 
             			    }
             			    break;
             			case 6 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:253:74: tikzcoordinate_ext
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:74: tikzcoordinate_ext
             			    {
-            			    	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody21275);
-            			    	tikzcoordinate_ext130 = tikzcoordinate_ext();
+            			    	PushFollow(FOLLOW_tikzcoordinate_ext_in_tikzbody21286);
+            			    	tikzcoordinate_ext133 = tikzcoordinate_ext();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext130.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_ext133.Tree);
 
             			    }
             			    break;
             			case 7 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:253:95: tikz_set
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:95: tikz_set
             			    {
-            			    	PushFollow(FOLLOW_tikz_set_in_tikzbody21279);
-            			    	tikz_set131 = tikz_set();
+            			    	PushFollow(FOLLOW_tikz_set_in_tikzbody21290);
+            			    	tikz_set134 = tikz_set();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set131.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_set134.Tree);
 
             			    }
             			    break;
             			case 8 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:253:106: tikz_style
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:106: tikz_style
             			    {
-            			    	PushFollow(FOLLOW_tikz_style_in_tikzbody21283);
-            			    	tikz_style132 = tikz_style();
+            			    	PushFollow(FOLLOW_tikz_style_in_tikzbody21294);
+            			    	tikz_style135 = tikz_style();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style132.Tree);
+            			    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_style135.Tree);
 
             			    }
             			    break;
             			case 9 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:253:119: otherbegin
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:119: otherbegin
             			    {
-            			    	PushFollow(FOLLOW_otherbegin_in_tikzbody21287);
-            			    	otherbegin133 = otherbegin();
+            			    	PushFollow(FOLLOW_otherbegin_in_tikzbody21298);
+            			    	otherbegin136 = otherbegin();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
 
             			    }
             			    break;
             			case 10 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:253:133: otherend
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:133: otherend
             			    {
-            			    	PushFollow(FOLLOW_otherend_in_tikzbody21292);
-            			    	otherend134 = otherend();
+            			    	PushFollow(FOLLOW_otherend_in_tikzbody21303);
+            			    	otherend137 = otherend();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
 
             			    }
             			    break;
             			case 11 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:253:145: dontcare_body2
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:253:145: dontcare_body2
             			    {
-            			    	PushFollow(FOLLOW_dontcare_body2_in_tikzbody21297);
-            			    	dontcare_body2135 = dontcare_body2();
+            			    	PushFollow(FOLLOW_dontcare_body2_in_tikzbody21308);
+            			    	dontcare_body2138 = dontcare_body2();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
 
@@ -4434,7 +4486,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "dontcare_body_nobr2"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:256:1: dontcare_body_nobr2 : (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' | '{' | '}' ) ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:256:1: dontcare_body_nobr2 : (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' | '{' | '}' ) ) ;
     public simpletikzParser.dontcare_body_nobr2_return dontcare_body_nobr2() // throws RecognitionException [1]
     {   
         simpletikzParser.dontcare_body_nobr2_return retval = new simpletikzParser.dontcare_body_nobr2_return();
@@ -4442,25 +4494,25 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set136 = null;
+        IToken set139 = null;
 
-        object set136_tree=null;
+        object set139_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:257:2: ( (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' | '{' | '}' ) ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:257:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' | '{' | '}' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:257:2: ( (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' | '{' | '}' ) ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:257:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' | '{' | '}' ) )
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:257:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' | '{' | '}' ) )
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:257:5: ~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' | '{' | '}' )
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:257:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' | '{' | '}' ) )
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:257:5: ~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' | '{' | '}' )
             	{
-            		set136 = (IToken)input.LT(1);
-            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || input.LA(1) == 42 || (input.LA(1) >= 45 && input.LA(1) <= 53) || (input.LA(1) >= 55 && input.LA(1) <= 62) || (input.LA(1) >= 77 && input.LA(1) <= 94) ) 
+            		set139 = (IToken)input.LT(1);
+            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || input.LA(1) == 42 || (input.LA(1) >= 45 && input.LA(1) <= 54) || (input.LA(1) >= 56 && input.LA(1) <= 63) || (input.LA(1) >= 78 && input.LA(1) <= 95) ) 
             		{
             		    input.Consume();
-            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set136));
+            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set139));
             		    state.errorRecovery = false;state.failed = false;
             		}
             		else 
@@ -4504,7 +4556,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "dontcare_body2"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:259:1: dontcare_body2 : (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '{' | '}' ) ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:259:1: dontcare_body2 : (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '{' | '}' ) ) ;
     public simpletikzParser.dontcare_body2_return dontcare_body2() // throws RecognitionException [1]
     {   
         simpletikzParser.dontcare_body2_return retval = new simpletikzParser.dontcare_body2_return();
@@ -4512,25 +4564,25 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set137 = null;
+        IToken set140 = null;
 
-        object set137_tree=null;
+        object set140_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:260:2: ( (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '{' | '}' ) ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:260:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '{' | '}' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:260:2: ( (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '{' | '}' ) ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:260:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '{' | '}' ) )
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:260:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '{' | '}' ) )
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:260:5: ~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '{' | '}' )
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:260:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '{' | '}' ) )
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:260:5: ~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '{' | '}' )
             	{
-            		set137 = (IToken)input.LT(1);
-            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || input.LA(1) == 42 || (input.LA(1) >= 45 && input.LA(1) <= 62) || (input.LA(1) >= 77 && input.LA(1) <= 94) ) 
+            		set140 = (IToken)input.LT(1);
+            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || input.LA(1) == 42 || (input.LA(1) >= 45 && input.LA(1) <= 63) || (input.LA(1) >= 78 && input.LA(1) <= 95) ) 
             		{
             		    input.Consume();
-            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set137));
+            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set140));
             		    state.errorRecovery = false;state.failed = false;
             		}
             		else 
@@ -4574,7 +4626,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "dontcare_body_nobr"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:262:1: dontcare_body_nobr : (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' ) ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:262:1: dontcare_body_nobr : (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' ) ) ;
     public simpletikzParser.dontcare_body_nobr_return dontcare_body_nobr() // throws RecognitionException [1]
     {   
         simpletikzParser.dontcare_body_nobr_return retval = new simpletikzParser.dontcare_body_nobr_return();
@@ -4582,25 +4634,25 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set138 = null;
+        IToken set141 = null;
 
-        object set138_tree=null;
+        object set141_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:263:2: ( (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' ) ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:263:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:263:2: ( (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' ) ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:263:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' ) )
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:263:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' ) )
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:263:5: ~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' )
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:263:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' ) )
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:263:5: ~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' | '[' )
             	{
-            		set138 = (IToken)input.LT(1);
-            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || (input.LA(1) >= 42 && input.LA(1) <= 53) || (input.LA(1) >= 55 && input.LA(1) <= 62) || (input.LA(1) >= 77 && input.LA(1) <= 94) ) 
+            		set141 = (IToken)input.LT(1);
+            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || (input.LA(1) >= 42 && input.LA(1) <= 54) || (input.LA(1) >= 56 && input.LA(1) <= 63) || (input.LA(1) >= 78 && input.LA(1) <= 95) ) 
             		{
             		    input.Consume();
-            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set138));
+            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set141));
             		    state.errorRecovery = false;state.failed = false;
             		}
             		else 
@@ -4644,7 +4696,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "dontcare_body"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:265:1: dontcare_body : (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' ) ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:265:1: dontcare_body : (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' ) ) ;
     public simpletikzParser.dontcare_body_return dontcare_body() // throws RecognitionException [1]
     {   
         simpletikzParser.dontcare_body_return retval = new simpletikzParser.dontcare_body_return();
@@ -4652,25 +4704,25 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set139 = null;
+        IToken set142 = null;
 
-        object set139_tree=null;
+        object set142_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:266:2: ( (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' ) ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:266:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:266:2: ( (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' ) ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:266:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' ) )
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:266:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' ) )
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:266:5: ~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' )
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:266:4: (~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' ) )
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:266:5: ~ ( '\\\\begin' | '\\\\end' | '\\\\node' | '\\\\matrix' | '\\\\coordinate' | '\\\\draw' | '\\\\path' | '\\\\def' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' | '\\\\fill' | '\\\\clip' | '\\\\tikzstyle' | '\\\\tikzset' )
             	{
-            		set139 = (IToken)input.LT(1);
-            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || (input.LA(1) >= 42 && input.LA(1) <= 62) || (input.LA(1) >= 77 && input.LA(1) <= 94) ) 
+            		set142 = (IToken)input.LT(1);
+            		if ( (input.LA(1) >= IM_PATH && input.LA(1) <= SOMETHING1) || (input.LA(1) >= 42 && input.LA(1) <= 63) || (input.LA(1) >= 78 && input.LA(1) <= 95) ) 
             		{
             		    input.Consume();
-            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set139));
+            		    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set142));
             		    state.errorRecovery = false;state.failed = false;
             		}
             		else 
@@ -4714,7 +4766,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "otherend"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:268:1: otherend : '\\\\end' '{' idd2 '}' ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:268:1: otherend : '\\\\end' '{' idd2 '}' ;
     public simpletikzParser.otherend_return otherend() // throws RecognitionException [1]
     {   
         simpletikzParser.otherend_return retval = new simpletikzParser.otherend_return();
@@ -4722,42 +4774,42 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal140 = null;
-        IToken char_literal141 = null;
-        IToken char_literal143 = null;
-        simpletikzParser.idd2_return idd2142 = default(simpletikzParser.idd2_return);
+        IToken string_literal143 = null;
+        IToken char_literal144 = null;
+        IToken char_literal146 = null;
+        simpletikzParser.idd2_return idd2145 = default(simpletikzParser.idd2_return);
 
 
-        object string_literal140_tree=null;
-        object char_literal141_tree=null;
-        object char_literal143_tree=null;
+        object string_literal143_tree=null;
+        object char_literal144_tree=null;
+        object char_literal146_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:269:2: ( '\\\\end' '{' idd2 '}' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:269:4: '\\\\end' '{' idd2 '}'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:269:2: ( '\\\\end' '{' idd2 '}' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:269:4: '\\\\end' '{' idd2 '}'
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	string_literal140=(IToken)Match(input,63,FOLLOW_63_in_otherend1668); if (state.failed) return retval;
+            	string_literal143=(IToken)Match(input,64,FOLLOW_64_in_otherend1679); if (state.failed) return retval;
             	if ( state.backtracking == 0 )
-            	{string_literal140_tree = (object)adaptor.Create(string_literal140);
-            		adaptor.AddChild(root_0, string_literal140_tree);
+            	{string_literal143_tree = (object)adaptor.Create(string_literal143);
+            		adaptor.AddChild(root_0, string_literal143_tree);
             	}
-            	char_literal141=(IToken)Match(input,43,FOLLOW_43_in_otherend1670); if (state.failed) return retval;
+            	char_literal144=(IToken)Match(input,43,FOLLOW_43_in_otherend1681); if (state.failed) return retval;
             	if ( state.backtracking == 0 )
-            	{char_literal141_tree = (object)adaptor.Create(char_literal141);
-            		adaptor.AddChild(root_0, char_literal141_tree);
+            	{char_literal144_tree = (object)adaptor.Create(char_literal144);
+            		adaptor.AddChild(root_0, char_literal144_tree);
             	}
-            	PushFollow(FOLLOW_idd2_in_otherend1672);
-            	idd2142 = idd2();
+            	PushFollow(FOLLOW_idd2_in_otherend1683);
+            	idd2145 = idd2();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, idd2142.Tree);
-            	char_literal143=(IToken)Match(input,44,FOLLOW_44_in_otherend1674); if (state.failed) return retval;
+            	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, idd2145.Tree);
+            	char_literal146=(IToken)Match(input,44,FOLLOW_44_in_otherend1685); if (state.failed) return retval;
             	if ( state.backtracking == 0 )
-            	{char_literal143_tree = (object)adaptor.Create(char_literal143);
-            		adaptor.AddChild(root_0, char_literal143_tree);
+            	{char_literal146_tree = (object)adaptor.Create(char_literal146);
+            		adaptor.AddChild(root_0, char_literal146_tree);
             	}
 
             }
@@ -4790,7 +4842,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzscope"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:283:1: tikzscope : tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end -> ^( IM_SCOPE tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:283:1: tikzscope : tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end -> ^( IM_SCOPE tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end ) ;
     public simpletikzParser.tikzscope_return tikzscope() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzscope_return retval = new simpletikzParser.tikzscope_return();
@@ -4798,62 +4850,62 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikzscope_start_return tikzscope_start144 = default(simpletikzParser.tikzscope_start_return);
+        simpletikzParser.tikzscope_start_return tikzscope_start147 = default(simpletikzParser.tikzscope_start_return);
 
-        simpletikzParser.tikz_options_return tikz_options145 = default(simpletikzParser.tikz_options_return);
+        simpletikzParser.tikz_options_return tikz_options148 = default(simpletikzParser.tikz_options_return);
 
-        simpletikzParser.tikzbody_return tikzbody146 = default(simpletikzParser.tikzbody_return);
+        simpletikzParser.tikzbody_return tikzbody149 = default(simpletikzParser.tikzbody_return);
 
-        simpletikzParser.tikzscope_end_return tikzscope_end147 = default(simpletikzParser.tikzscope_end_return);
+        simpletikzParser.tikzscope_end_return tikzscope_end150 = default(simpletikzParser.tikzscope_end_return);
 
 
+        RewriteRuleSubtreeStream stream_tikz_options = new RewriteRuleSubtreeStream(adaptor,"rule tikz_options");
+        RewriteRuleSubtreeStream stream_tikzbody = new RewriteRuleSubtreeStream(adaptor,"rule tikzbody");
         RewriteRuleSubtreeStream stream_tikzscope_start = new RewriteRuleSubtreeStream(adaptor,"rule tikzscope_start");
         RewriteRuleSubtreeStream stream_tikzscope_end = new RewriteRuleSubtreeStream(adaptor,"rule tikzscope_end");
-        RewriteRuleSubtreeStream stream_tikzbody = new RewriteRuleSubtreeStream(adaptor,"rule tikzbody");
-        RewriteRuleSubtreeStream stream_tikz_options = new RewriteRuleSubtreeStream(adaptor,"rule tikz_options");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:284:2: ( tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end -> ^( IM_SCOPE tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:284:4: tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:2: ( tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end -> ^( IM_SCOPE tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:4: tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end
             {
-            	PushFollow(FOLLOW_tikzscope_start_in_tikzscope1701);
-            	tikzscope_start144 = tikzscope_start();
+            	PushFollow(FOLLOW_tikzscope_start_in_tikzscope1712);
+            	tikzscope_start147 = tikzscope_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikzscope_start.Add(tikzscope_start144.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:284:20: ( tikz_options )?
+            	if ( state.backtracking==0 ) stream_tikzscope_start.Add(tikzscope_start147.Tree);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:20: ( tikz_options )?
             	int alt37 = 2;
             	int LA37_0 = input.LA(1);
 
-            	if ( (LA37_0 == 54) )
+            	if ( (LA37_0 == 55) )
             	{
             	    alt37 = 1;
             	}
             	switch (alt37) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:284:20: tikz_options
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:20: tikz_options
             	        {
-            	        	PushFollow(FOLLOW_tikz_options_in_tikzscope1703);
-            	        	tikz_options145 = tikz_options();
+            	        	PushFollow(FOLLOW_tikz_options_in_tikzscope1714);
+            	        	tikz_options148 = tikz_options();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options145.Tree);
+            	        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options148.Tree);
 
             	        }
             	        break;
 
             	}
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:284:34: ( tikzbody )?
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:34: ( tikzbody )?
             	int alt38 = 2;
             	int LA38_0 = input.LA(1);
 
-            	if ( ((LA38_0 >= IM_PATH && LA38_0 <= 53) || (LA38_0 >= 55 && LA38_0 <= 62) || (LA38_0 >= 64 && LA38_0 <= 94)) )
+            	if ( ((LA38_0 >= IM_PATH && LA38_0 <= 54) || (LA38_0 >= 56 && LA38_0 <= 63) || (LA38_0 >= 65 && LA38_0 <= 95)) )
             	{
             	    alt38 = 1;
             	}
-            	else if ( (LA38_0 == 63) )
+            	else if ( (LA38_0 == 64) )
             	{
             	    int LA38_2 = input.LA(2);
 
@@ -4870,28 +4922,28 @@ public partial class simpletikzParser : Parser
             	switch (alt38) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:284:34: tikzbody
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:34: tikzbody
             	        {
-            	        	PushFollow(FOLLOW_tikzbody_in_tikzscope1706);
-            	        	tikzbody146 = tikzbody();
+            	        	PushFollow(FOLLOW_tikzbody_in_tikzscope1717);
+            	        	tikzbody149 = tikzbody();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_tikzbody.Add(tikzbody146.Tree);
+            	        	if ( state.backtracking==0 ) stream_tikzbody.Add(tikzbody149.Tree);
 
             	        }
             	        break;
 
             	}
 
-            	PushFollow(FOLLOW_tikzscope_end_in_tikzscope1709);
-            	tikzscope_end147 = tikzscope_end();
+            	PushFollow(FOLLOW_tikzscope_end_in_tikzscope1720);
+            	tikzscope_end150 = tikzscope_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikzscope_end.Add(tikzscope_end147.Tree);
+            	if ( state.backtracking==0 ) stream_tikzscope_end.Add(tikzscope_end150.Tree);
 
 
             	// AST REWRITE
-            	// elements:          tikzscope_start, tikzbody, tikz_options, tikzscope_end
+            	// elements:          tikz_options, tikzbody, tikzscope_start, tikzscope_end
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -4903,20 +4955,20 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 284:59: -> ^( IM_SCOPE tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:284:62: ^( IM_SCOPE tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:62: ^( IM_SCOPE tikzscope_start ( tikz_options )? ( tikzbody )? tikzscope_end )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_SCOPE, "IM_SCOPE"), root_1);
 
             	    adaptor.AddChild(root_1, stream_tikzscope_start.NextTree());
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:284:89: ( tikz_options )?
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:89: ( tikz_options )?
             	    if ( stream_tikz_options.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikz_options.NextTree());
 
             	    }
             	    stream_tikz_options.Reset();
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:284:103: ( tikzbody )?
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:284:103: ( tikzbody )?
             	    if ( stream_tikzbody.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikzbody.NextTree());
@@ -4961,7 +5013,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzpath"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:310:1: tikzpath : path_start ( tikzpath_element )* semicolon_end -> ^( IM_PATH path_start ( tikzpath_element )* semicolon_end ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:310:1: tikzpath : path_start ( tikzpath_element )* semicolon_end -> ^( IM_PATH path_start ( tikzpath_element )* semicolon_end ) ;
     public simpletikzParser.tikzpath_return tikzpath() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzpath_return retval = new simpletikzParser.tikzpath_return();
@@ -4969,33 +5021,33 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.path_start_return path_start148 = default(simpletikzParser.path_start_return);
+        simpletikzParser.path_start_return path_start151 = default(simpletikzParser.path_start_return);
 
-        simpletikzParser.tikzpath_element_return tikzpath_element149 = default(simpletikzParser.tikzpath_element_return);
+        simpletikzParser.tikzpath_element_return tikzpath_element152 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.semicolon_end_return semicolon_end150 = default(simpletikzParser.semicolon_end_return);
+        simpletikzParser.semicolon_end_return semicolon_end153 = default(simpletikzParser.semicolon_end_return);
 
 
         RewriteRuleSubtreeStream stream_tikzpath_element = new RewriteRuleSubtreeStream(adaptor,"rule tikzpath_element");
-        RewriteRuleSubtreeStream stream_path_start = new RewriteRuleSubtreeStream(adaptor,"rule path_start");
         RewriteRuleSubtreeStream stream_semicolon_end = new RewriteRuleSubtreeStream(adaptor,"rule semicolon_end");
+        RewriteRuleSubtreeStream stream_path_start = new RewriteRuleSubtreeStream(adaptor,"rule path_start");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:311:2: ( path_start ( tikzpath_element )* semicolon_end -> ^( IM_PATH path_start ( tikzpath_element )* semicolon_end ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:311:4: path_start ( tikzpath_element )* semicolon_end
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:311:2: ( path_start ( tikzpath_element )* semicolon_end -> ^( IM_PATH path_start ( tikzpath_element )* semicolon_end ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:311:4: path_start ( tikzpath_element )* semicolon_end
             {
-            	PushFollow(FOLLOW_path_start_in_tikzpath1765);
-            	path_start148 = path_start();
+            	PushFollow(FOLLOW_path_start_in_tikzpath1776);
+            	path_start151 = path_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_path_start.Add(path_start148.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:311:15: ( tikzpath_element )*
+            	if ( state.backtracking==0 ) stream_path_start.Add(path_start151.Tree);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:311:15: ( tikzpath_element )*
             	do 
             	{
             	    int alt39 = 2;
             	    int LA39_0 = input.LA(1);
 
-            	    if ( ((LA39_0 >= ID && LA39_0 <= COMMAND) || LA39_0 == 43 || LA39_0 == 45 || LA39_0 == 52 || LA39_0 == 54 || LA39_0 == 58 || LA39_0 == 77 || (LA39_0 >= 79 && LA39_0 <= 80) || (LA39_0 >= 82 && LA39_0 <= 91)) )
+            	    if ( ((LA39_0 >= ID && LA39_0 <= COMMAND) || LA39_0 == 43 || LA39_0 == 45 || LA39_0 == 53 || LA39_0 == 55 || LA39_0 == 59 || LA39_0 == 78 || (LA39_0 >= 80 && LA39_0 <= 81) || (LA39_0 >= 83 && LA39_0 <= 92)) )
             	    {
             	        alt39 = 1;
             	    }
@@ -5004,13 +5056,13 @@ public partial class simpletikzParser : Parser
             	    switch (alt39) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:311:15: tikzpath_element
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:311:15: tikzpath_element
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzpath1767);
-            			    	tikzpath_element149 = tikzpath_element();
+            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzpath1778);
+            			    	tikzpath_element152 = tikzpath_element();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element149.Tree);
+            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element152.Tree);
 
             			    }
             			    break;
@@ -5023,15 +5075,15 @@ public partial class simpletikzParser : Parser
             	loop39:
             		;	// Stops C# compiler whining that label 'loop39' has no statements
 
-            	PushFollow(FOLLOW_semicolon_end_in_tikzpath1770);
-            	semicolon_end150 = semicolon_end();
+            	PushFollow(FOLLOW_semicolon_end_in_tikzpath1781);
+            	semicolon_end153 = semicolon_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end150.Tree);
+            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end153.Tree);
 
 
             	// AST REWRITE
-            	// elements:          path_start, semicolon_end, tikzpath_element
+            	// elements:          path_start, tikzpath_element, semicolon_end
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -5043,13 +5095,13 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 311:47: -> ^( IM_PATH path_start ( tikzpath_element )* semicolon_end )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:311:50: ^( IM_PATH path_start ( tikzpath_element )* semicolon_end )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:311:50: ^( IM_PATH path_start ( tikzpath_element )* semicolon_end )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_PATH, "IM_PATH"), root_1);
 
             	    adaptor.AddChild(root_1, stream_path_start.NextTree());
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:311:71: ( tikzpath_element )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:311:71: ( tikzpath_element )*
             	    while ( stream_tikzpath_element.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikzpath_element.NextTree());
@@ -5094,7 +5146,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "let_cmd_parts"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:316:1: let_cmd_parts : ( 'let' | 'in' | '=' | COMMAND );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:316:1: let_cmd_parts : ( 'let' | 'in' | '=' | COMMAND );
     public simpletikzParser.let_cmd_parts_return let_cmd_parts() // throws RecognitionException [1]
     {   
         simpletikzParser.let_cmd_parts_return retval = new simpletikzParser.let_cmd_parts_return();
@@ -5102,22 +5154,22 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set151 = null;
+        IToken set154 = null;
 
-        object set151_tree=null;
+        object set154_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:317:2: ( 'let' | 'in' | '=' | COMMAND )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:317:2: ( 'let' | 'in' | '=' | COMMAND )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set151 = (IToken)input.LT(1);
-            	if ( input.LA(1) == COMMAND || input.LA(1) == 45 || input.LA(1) == 58 || input.LA(1) == 77 ) 
+            	set154 = (IToken)input.LT(1);
+            	if ( input.LA(1) == COMMAND || input.LA(1) == 45 || input.LA(1) == 59 || input.LA(1) == 78 ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set151));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set154));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -5158,7 +5210,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzpath_element"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:321:1: tikzpath_element : tikzpath_element_single ( ',' )? ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:321:1: tikzpath_element : tikzpath_element_single ( ',' )? ;
     public simpletikzParser.tikzpath_element_return tikzpath_element() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzpath_element_return retval = new simpletikzParser.tikzpath_element_return();
@@ -5166,25 +5218,25 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal153 = null;
-        simpletikzParser.tikzpath_element_single_return tikzpath_element_single152 = default(simpletikzParser.tikzpath_element_single_return);
+        IToken char_literal156 = null;
+        simpletikzParser.tikzpath_element_single_return tikzpath_element_single155 = default(simpletikzParser.tikzpath_element_single_return);
 
 
-        object char_literal153_tree=null;
+        object char_literal156_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:322:2: ( tikzpath_element_single ( ',' )? )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:322:4: tikzpath_element_single ( ',' )?
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:322:2: ( tikzpath_element_single ( ',' )? )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:322:4: tikzpath_element_single ( ',' )?
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	PushFollow(FOLLOW_tikzpath_element_single_in_tikzpath_element1826);
-            	tikzpath_element_single152 = tikzpath_element_single();
+            	PushFollow(FOLLOW_tikzpath_element_single_in_tikzpath_element1837);
+            	tikzpath_element_single155 = tikzpath_element_single();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath_element_single152.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:322:31: ( ',' )?
+            	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzpath_element_single155.Tree);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:322:31: ( ',' )?
             	int alt40 = 2;
             	int LA40_0 = input.LA(1);
 
@@ -5195,9 +5247,9 @@ public partial class simpletikzParser : Parser
             	switch (alt40) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:322:31: ','
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:322:31: ','
             	        {
-            	        	char_literal153=(IToken)Match(input,47,FOLLOW_47_in_tikzpath_element1828); if (state.failed) return retval;
+            	        	char_literal156=(IToken)Match(input,47,FOLLOW_47_in_tikzpath_element1839); if (state.failed) return retval;
 
             	        }
             	        break;
@@ -5235,7 +5287,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzpath_element_single"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:325:1: tikzpath_element_single : ( tikz_options | let_cmd_parts -> ^( IM_DONTCARE ( let_cmd_parts )+ ) | arc | ( coord )=> coord | controls | tikznode_int | tikzcoordinate_int | circle | roundbr_start ( tikzpath_element )* roundbr_end -> ^( IM_PATH roundbr_start ( tikzpath_element )* roundbr_end ) | '(' ( tikzpath_element )* ')' -> ^( IM_PATH '(' ( tikzpath_element )* ')' ) | edgeop );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:325:1: tikzpath_element_single : ( tikz_options | let_cmd_parts -> ^( IM_DONTCARE ( let_cmd_parts )+ ) | arc | ( coord )=> coord | controls | tikznode_int | tikzcoordinate_int | circle | roundbr_start ( tikzpath_element )* roundbr_end -> ^( IM_PATH roundbr_start ( tikzpath_element )* roundbr_end ) | '(' ( tikzpath_element )* ')' -> ^( IM_PATH '(' ( tikzpath_element )* ')' ) | edgeop );
     public simpletikzParser.tikzpath_element_single_return tikzpath_element_single() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzpath_element_single_return retval = new simpletikzParser.tikzpath_element_single_return();
@@ -5243,71 +5295,71 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal165 = null;
-        IToken char_literal167 = null;
-        simpletikzParser.tikz_options_return tikz_options154 = default(simpletikzParser.tikz_options_return);
+        IToken char_literal168 = null;
+        IToken char_literal170 = null;
+        simpletikzParser.tikz_options_return tikz_options157 = default(simpletikzParser.tikz_options_return);
 
-        simpletikzParser.let_cmd_parts_return let_cmd_parts155 = default(simpletikzParser.let_cmd_parts_return);
+        simpletikzParser.let_cmd_parts_return let_cmd_parts158 = default(simpletikzParser.let_cmd_parts_return);
 
-        simpletikzParser.arc_return arc156 = default(simpletikzParser.arc_return);
+        simpletikzParser.arc_return arc159 = default(simpletikzParser.arc_return);
 
-        simpletikzParser.coord_return coord157 = default(simpletikzParser.coord_return);
+        simpletikzParser.coord_return coord160 = default(simpletikzParser.coord_return);
 
-        simpletikzParser.controls_return controls158 = default(simpletikzParser.controls_return);
+        simpletikzParser.controls_return controls161 = default(simpletikzParser.controls_return);
 
-        simpletikzParser.tikznode_int_return tikznode_int159 = default(simpletikzParser.tikznode_int_return);
+        simpletikzParser.tikznode_int_return tikznode_int162 = default(simpletikzParser.tikznode_int_return);
 
-        simpletikzParser.tikzcoordinate_int_return tikzcoordinate_int160 = default(simpletikzParser.tikzcoordinate_int_return);
+        simpletikzParser.tikzcoordinate_int_return tikzcoordinate_int163 = default(simpletikzParser.tikzcoordinate_int_return);
 
-        simpletikzParser.circle_return circle161 = default(simpletikzParser.circle_return);
+        simpletikzParser.circle_return circle164 = default(simpletikzParser.circle_return);
 
-        simpletikzParser.roundbr_start_return roundbr_start162 = default(simpletikzParser.roundbr_start_return);
-
-        simpletikzParser.tikzpath_element_return tikzpath_element163 = default(simpletikzParser.tikzpath_element_return);
-
-        simpletikzParser.roundbr_end_return roundbr_end164 = default(simpletikzParser.roundbr_end_return);
+        simpletikzParser.roundbr_start_return roundbr_start165 = default(simpletikzParser.roundbr_start_return);
 
         simpletikzParser.tikzpath_element_return tikzpath_element166 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.edgeop_return edgeop168 = default(simpletikzParser.edgeop_return);
+        simpletikzParser.roundbr_end_return roundbr_end167 = default(simpletikzParser.roundbr_end_return);
+
+        simpletikzParser.tikzpath_element_return tikzpath_element169 = default(simpletikzParser.tikzpath_element_return);
+
+        simpletikzParser.edgeop_return edgeop171 = default(simpletikzParser.edgeop_return);
 
 
-        object char_literal165_tree=null;
-        object char_literal167_tree=null;
-        RewriteRuleTokenStream stream_52 = new RewriteRuleTokenStream(adaptor,"token 52");
+        object char_literal168_tree=null;
+        object char_literal170_tree=null;
         RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
+        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
         RewriteRuleSubtreeStream stream_tikzpath_element = new RewriteRuleSubtreeStream(adaptor,"rule tikzpath_element");
+        RewriteRuleSubtreeStream stream_let_cmd_parts = new RewriteRuleSubtreeStream(adaptor,"rule let_cmd_parts");
         RewriteRuleSubtreeStream stream_roundbr_start = new RewriteRuleSubtreeStream(adaptor,"rule roundbr_start");
         RewriteRuleSubtreeStream stream_roundbr_end = new RewriteRuleSubtreeStream(adaptor,"rule roundbr_end");
-        RewriteRuleSubtreeStream stream_let_cmd_parts = new RewriteRuleSubtreeStream(adaptor,"rule let_cmd_parts");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:326:2: ( tikz_options | let_cmd_parts -> ^( IM_DONTCARE ( let_cmd_parts )+ ) | arc | ( coord )=> coord | controls | tikznode_int | tikzcoordinate_int | circle | roundbr_start ( tikzpath_element )* roundbr_end -> ^( IM_PATH roundbr_start ( tikzpath_element )* roundbr_end ) | '(' ( tikzpath_element )* ')' -> ^( IM_PATH '(' ( tikzpath_element )* ')' ) | edgeop )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:326:2: ( tikz_options | let_cmd_parts -> ^( IM_DONTCARE ( let_cmd_parts )+ ) | arc | ( coord )=> coord | controls | tikznode_int | tikzcoordinate_int | circle | roundbr_start ( tikzpath_element )* roundbr_end -> ^( IM_PATH roundbr_start ( tikzpath_element )* roundbr_end ) | '(' ( tikzpath_element )* ')' -> ^( IM_PATH '(' ( tikzpath_element )* ')' ) | edgeop )
             int alt43 = 11;
             alt43 = dfa43.Predict(input);
             switch (alt43) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:327:5: tikz_options
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:327:5: tikz_options
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_tikz_options_in_tikzpath_element_single1846);
-                    	tikz_options154 = tikz_options();
+                    	PushFollow(FOLLOW_tikz_options_in_tikzpath_element_single1857);
+                    	tikz_options157 = tikz_options();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_options154.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_options157.Tree);
 
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:328:5: let_cmd_parts
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:328:5: let_cmd_parts
                     {
-                    	PushFollow(FOLLOW_let_cmd_parts_in_tikzpath_element_single1853);
-                    	let_cmd_parts155 = let_cmd_parts();
+                    	PushFollow(FOLLOW_let_cmd_parts_in_tikzpath_element_single1864);
+                    	let_cmd_parts158 = let_cmd_parts();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_let_cmd_parts.Add(let_cmd_parts155.Tree);
+                    	if ( state.backtracking==0 ) stream_let_cmd_parts.Add(let_cmd_parts158.Tree);
 
 
                     	// AST REWRITE
@@ -5323,7 +5375,7 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 328:19: -> ^( IM_DONTCARE ( let_cmd_parts )+ )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:328:22: ^( IM_DONTCARE ( let_cmd_parts )+ )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:328:22: ^( IM_DONTCARE ( let_cmd_parts )+ )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_DONTCARE, "IM_DONTCARE"), root_1);
@@ -5347,97 +5399,97 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 3 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:330:5: arc
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:330:5: arc
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_arc_in_tikzpath_element_single1871);
-                    	arc156 = arc();
+                    	PushFollow(FOLLOW_arc_in_tikzpath_element_single1882);
+                    	arc159 = arc();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, arc156.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, arc159.Tree);
 
                     }
                     break;
                 case 4 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:331:5: ( coord )=> coord
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:331:5: ( coord )=> coord
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_coord_in_tikzpath_element_single1881);
-                    	coord157 = coord();
+                    	PushFollow(FOLLOW_coord_in_tikzpath_element_single1892);
+                    	coord160 = coord();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, coord157.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, coord160.Tree);
 
                     }
                     break;
                 case 5 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:332:5: controls
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:332:5: controls
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_controls_in_tikzpath_element_single1887);
-                    	controls158 = controls();
+                    	PushFollow(FOLLOW_controls_in_tikzpath_element_single1898);
+                    	controls161 = controls();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, controls158.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, controls161.Tree);
 
                     }
                     break;
                 case 6 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:333:5: tikznode_int
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:333:5: tikznode_int
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_tikznode_int_in_tikzpath_element_single1893);
-                    	tikznode_int159 = tikznode_int();
+                    	PushFollow(FOLLOW_tikznode_int_in_tikzpath_element_single1904);
+                    	tikznode_int162 = tikznode_int();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_int159.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_int162.Tree);
 
                     }
                     break;
                 case 7 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:334:5: tikzcoordinate_int
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:334:5: tikzcoordinate_int
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_tikzcoordinate_int_in_tikzpath_element_single1899);
-                    	tikzcoordinate_int160 = tikzcoordinate_int();
+                    	PushFollow(FOLLOW_tikzcoordinate_int_in_tikzpath_element_single1910);
+                    	tikzcoordinate_int163 = tikzcoordinate_int();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_int160.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_int163.Tree);
 
                     }
                     break;
                 case 8 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:335:5: circle
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:335:5: circle
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_circle_in_tikzpath_element_single1905);
-                    	circle161 = circle();
+                    	PushFollow(FOLLOW_circle_in_tikzpath_element_single1916);
+                    	circle164 = circle();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
 
                     }
                     break;
                 case 9 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:336:5: roundbr_start ( tikzpath_element )* roundbr_end
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:336:5: roundbr_start ( tikzpath_element )* roundbr_end
                     {
-                    	PushFollow(FOLLOW_roundbr_start_in_tikzpath_element_single1912);
-                    	roundbr_start162 = roundbr_start();
+                    	PushFollow(FOLLOW_roundbr_start_in_tikzpath_element_single1923);
+                    	roundbr_start165 = roundbr_start();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_roundbr_start.Add(roundbr_start162.Tree);
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:336:19: ( tikzpath_element )*
+                    	if ( state.backtracking==0 ) stream_roundbr_start.Add(roundbr_start165.Tree);
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:336:19: ( tikzpath_element )*
                     	do 
                     	{
                     	    int alt41 = 2;
                     	    int LA41_0 = input.LA(1);
 
-                    	    if ( ((LA41_0 >= ID && LA41_0 <= COMMAND) || LA41_0 == 43 || LA41_0 == 45 || LA41_0 == 52 || LA41_0 == 54 || LA41_0 == 58 || LA41_0 == 77 || (LA41_0 >= 79 && LA41_0 <= 80) || (LA41_0 >= 82 && LA41_0 <= 91)) )
+                    	    if ( ((LA41_0 >= ID && LA41_0 <= COMMAND) || LA41_0 == 43 || LA41_0 == 45 || LA41_0 == 53 || LA41_0 == 55 || LA41_0 == 59 || LA41_0 == 78 || (LA41_0 >= 80 && LA41_0 <= 81) || (LA41_0 >= 83 && LA41_0 <= 92)) )
                     	    {
                     	        alt41 = 1;
                     	    }
@@ -5446,13 +5498,13 @@ public partial class simpletikzParser : Parser
                     	    switch (alt41) 
                     		{
                     			case 1 :
-                    			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:336:19: tikzpath_element
+                    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:336:19: tikzpath_element
                     			    {
-                    			    	PushFollow(FOLLOW_tikzpath_element_in_tikzpath_element_single1914);
-                    			    	tikzpath_element163 = tikzpath_element();
+                    			    	PushFollow(FOLLOW_tikzpath_element_in_tikzpath_element_single1925);
+                    			    	tikzpath_element166 = tikzpath_element();
                     			    	state.followingStackPointer--;
                     			    	if (state.failed) return retval;
-                    			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element163.Tree);
+                    			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element166.Tree);
 
                     			    }
                     			    break;
@@ -5465,15 +5517,15 @@ public partial class simpletikzParser : Parser
                     	loop41:
                     		;	// Stops C# compiler whining that label 'loop41' has no statements
 
-                    	PushFollow(FOLLOW_roundbr_end_in_tikzpath_element_single1917);
-                    	roundbr_end164 = roundbr_end();
+                    	PushFollow(FOLLOW_roundbr_end_in_tikzpath_element_single1928);
+                    	roundbr_end167 = roundbr_end();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_roundbr_end.Add(roundbr_end164.Tree);
+                    	if ( state.backtracking==0 ) stream_roundbr_end.Add(roundbr_end167.Tree);
 
 
                     	// AST REWRITE
-                    	// elements:          roundbr_end, tikzpath_element, roundbr_start
+                    	// elements:          roundbr_end, roundbr_start, tikzpath_element
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -5485,13 +5537,13 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 336:49: -> ^( IM_PATH roundbr_start ( tikzpath_element )* roundbr_end )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:336:52: ^( IM_PATH roundbr_start ( tikzpath_element )* roundbr_end )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:336:52: ^( IM_PATH roundbr_start ( tikzpath_element )* roundbr_end )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_PATH, "IM_PATH"), root_1);
 
                     	    adaptor.AddChild(root_1, stream_roundbr_start.NextTree());
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:336:76: ( tikzpath_element )*
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:336:76: ( tikzpath_element )*
                     	    while ( stream_tikzpath_element.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_tikzpath_element.NextTree());
@@ -5509,18 +5561,18 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 10 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:337:6: '(' ( tikzpath_element )* ')'
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:337:6: '(' ( tikzpath_element )* ')'
                     {
-                    	char_literal165=(IToken)Match(input,52,FOLLOW_52_in_tikzpath_element_single1937); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_52.Add(char_literal165);
+                    	char_literal168=(IToken)Match(input,53,FOLLOW_53_in_tikzpath_element_single1948); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_53.Add(char_literal168);
 
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:337:10: ( tikzpath_element )*
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:337:10: ( tikzpath_element )*
                     	do 
                     	{
                     	    int alt42 = 2;
                     	    int LA42_0 = input.LA(1);
 
-                    	    if ( ((LA42_0 >= ID && LA42_0 <= COMMAND) || LA42_0 == 43 || LA42_0 == 45 || LA42_0 == 52 || LA42_0 == 54 || LA42_0 == 58 || LA42_0 == 77 || (LA42_0 >= 79 && LA42_0 <= 80) || (LA42_0 >= 82 && LA42_0 <= 91)) )
+                    	    if ( ((LA42_0 >= ID && LA42_0 <= COMMAND) || LA42_0 == 43 || LA42_0 == 45 || LA42_0 == 53 || LA42_0 == 55 || LA42_0 == 59 || LA42_0 == 78 || (LA42_0 >= 80 && LA42_0 <= 81) || (LA42_0 >= 83 && LA42_0 <= 92)) )
                     	    {
                     	        alt42 = 1;
                     	    }
@@ -5529,13 +5581,13 @@ public partial class simpletikzParser : Parser
                     	    switch (alt42) 
                     		{
                     			case 1 :
-                    			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:337:10: tikzpath_element
+                    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:337:10: tikzpath_element
                     			    {
-                    			    	PushFollow(FOLLOW_tikzpath_element_in_tikzpath_element_single1939);
-                    			    	tikzpath_element166 = tikzpath_element();
+                    			    	PushFollow(FOLLOW_tikzpath_element_in_tikzpath_element_single1950);
+                    			    	tikzpath_element169 = tikzpath_element();
                     			    	state.followingStackPointer--;
                     			    	if (state.failed) return retval;
-                    			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element166.Tree);
+                    			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element169.Tree);
 
                     			    }
                     			    break;
@@ -5548,13 +5600,13 @@ public partial class simpletikzParser : Parser
                     	loop42:
                     		;	// Stops C# compiler whining that label 'loop42' has no statements
 
-                    	char_literal167=(IToken)Match(input,53,FOLLOW_53_in_tikzpath_element_single1942); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_53.Add(char_literal167);
+                    	char_literal170=(IToken)Match(input,54,FOLLOW_54_in_tikzpath_element_single1953); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_54.Add(char_literal170);
 
 
 
                     	// AST REWRITE
-                    	// elements:          53, tikzpath_element, 52
+                    	// elements:          54, tikzpath_element, 53
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -5566,20 +5618,20 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 337:32: -> ^( IM_PATH '(' ( tikzpath_element )* ')' )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:337:35: ^( IM_PATH '(' ( tikzpath_element )* ')' )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:337:35: ^( IM_PATH '(' ( tikzpath_element )* ')' )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_PATH, "IM_PATH"), root_1);
 
-                    	    adaptor.AddChild(root_1, stream_52.NextNode());
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:337:49: ( tikzpath_element )*
+                    	    adaptor.AddChild(root_1, stream_53.NextNode());
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:337:49: ( tikzpath_element )*
                     	    while ( stream_tikzpath_element.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_tikzpath_element.NextTree());
 
                     	    }
                     	    stream_tikzpath_element.Reset();
-                    	    adaptor.AddChild(root_1, stream_53.NextNode());
+                    	    adaptor.AddChild(root_1, stream_54.NextNode());
 
                     	    adaptor.AddChild(root_0, root_1);
                     	    }
@@ -5590,12 +5642,12 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 11 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:338:5: edgeop
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:338:5: edgeop
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_edgeop_in_tikzpath_element_single1961);
-                    	edgeop168 = edgeop();
+                    	PushFollow(FOLLOW_edgeop_in_tikzpath_element_single1972);
+                    	edgeop171 = edgeop();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
 
@@ -5631,7 +5683,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "controls"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:341:1: controls : controls_start coord ( 'and' coord )? controls_end -> ^( IM_CONTROLS controls_start ( coord )+ controls_end ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:341:1: controls : controls_start coord ( 'and' coord )? controls_end -> ^( IM_CONTROLS controls_start ( coord )+ controls_end ) ;
     public simpletikzParser.controls_return controls() // throws RecognitionException [1]
     {   
         simpletikzParser.controls_return retval = new simpletikzParser.controls_return();
@@ -5639,72 +5691,72 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal171 = null;
-        simpletikzParser.controls_start_return controls_start169 = default(simpletikzParser.controls_start_return);
+        IToken string_literal174 = null;
+        simpletikzParser.controls_start_return controls_start172 = default(simpletikzParser.controls_start_return);
 
-        simpletikzParser.coord_return coord170 = default(simpletikzParser.coord_return);
+        simpletikzParser.coord_return coord173 = default(simpletikzParser.coord_return);
 
-        simpletikzParser.coord_return coord172 = default(simpletikzParser.coord_return);
+        simpletikzParser.coord_return coord175 = default(simpletikzParser.coord_return);
 
-        simpletikzParser.controls_end_return controls_end173 = default(simpletikzParser.controls_end_return);
+        simpletikzParser.controls_end_return controls_end176 = default(simpletikzParser.controls_end_return);
 
 
-        object string_literal171_tree=null;
-        RewriteRuleTokenStream stream_78 = new RewriteRuleTokenStream(adaptor,"token 78");
+        object string_literal174_tree=null;
+        RewriteRuleTokenStream stream_79 = new RewriteRuleTokenStream(adaptor,"token 79");
+        RewriteRuleSubtreeStream stream_controls_end = new RewriteRuleSubtreeStream(adaptor,"rule controls_end");
         RewriteRuleSubtreeStream stream_coord = new RewriteRuleSubtreeStream(adaptor,"rule coord");
         RewriteRuleSubtreeStream stream_controls_start = new RewriteRuleSubtreeStream(adaptor,"rule controls_start");
-        RewriteRuleSubtreeStream stream_controls_end = new RewriteRuleSubtreeStream(adaptor,"rule controls_end");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:342:2: ( controls_start coord ( 'and' coord )? controls_end -> ^( IM_CONTROLS controls_start ( coord )+ controls_end ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:342:4: controls_start coord ( 'and' coord )? controls_end
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:342:2: ( controls_start coord ( 'and' coord )? controls_end -> ^( IM_CONTROLS controls_start ( coord )+ controls_end ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:342:4: controls_start coord ( 'and' coord )? controls_end
             {
-            	PushFollow(FOLLOW_controls_start_in_controls1976);
-            	controls_start169 = controls_start();
+            	PushFollow(FOLLOW_controls_start_in_controls1987);
+            	controls_start172 = controls_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_controls_start.Add(controls_start169.Tree);
-            	PushFollow(FOLLOW_coord_in_controls1978);
-            	coord170 = coord();
+            	if ( state.backtracking==0 ) stream_controls_start.Add(controls_start172.Tree);
+            	PushFollow(FOLLOW_coord_in_controls1989);
+            	coord173 = coord();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_coord.Add(coord170.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:342:25: ( 'and' coord )?
+            	if ( state.backtracking==0 ) stream_coord.Add(coord173.Tree);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:342:25: ( 'and' coord )?
             	int alt44 = 2;
             	int LA44_0 = input.LA(1);
 
-            	if ( (LA44_0 == 78) )
+            	if ( (LA44_0 == 79) )
             	{
             	    alt44 = 1;
             	}
             	switch (alt44) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:342:26: 'and' coord
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:342:26: 'and' coord
             	        {
-            	        	string_literal171=(IToken)Match(input,78,FOLLOW_78_in_controls1981); if (state.failed) return retval; 
-            	        	if ( state.backtracking==0 ) stream_78.Add(string_literal171);
+            	        	string_literal174=(IToken)Match(input,79,FOLLOW_79_in_controls1992); if (state.failed) return retval; 
+            	        	if ( state.backtracking==0 ) stream_79.Add(string_literal174);
 
-            	        	PushFollow(FOLLOW_coord_in_controls1983);
-            	        	coord172 = coord();
+            	        	PushFollow(FOLLOW_coord_in_controls1994);
+            	        	coord175 = coord();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_coord.Add(coord172.Tree);
+            	        	if ( state.backtracking==0 ) stream_coord.Add(coord175.Tree);
 
             	        }
             	        break;
 
             	}
 
-            	PushFollow(FOLLOW_controls_end_in_controls1987);
-            	controls_end173 = controls_end();
+            	PushFollow(FOLLOW_controls_end_in_controls1998);
+            	controls_end176 = controls_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_controls_end.Add(controls_end173.Tree);
+            	if ( state.backtracking==0 ) stream_controls_end.Add(controls_end176.Tree);
 
 
             	// AST REWRITE
-            	// elements:          coord, controls_start, controls_end
+            	// elements:          controls_start, coord, controls_end
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -5716,7 +5768,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 342:53: -> ^( IM_CONTROLS controls_start ( coord )+ controls_end )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:342:56: ^( IM_CONTROLS controls_start ( coord )+ controls_end )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:342:56: ^( IM_CONTROLS controls_start ( coord )+ controls_end )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_CONTROLS, "IM_CONTROLS"), root_1);
@@ -5769,7 +5821,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikznode_ext"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:345:1: tikznode_ext : node_start tikznode_core ( tikzpath_element )* semicolon_end -> ^( IM_PATH node_start tikznode_core ( tikzpath_element )* semicolon_end ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:345:1: tikznode_ext : node_start tikznode_core ( tikzpath_element )* semicolon_end -> ^( IM_PATH node_start tikznode_core ( tikzpath_element )* semicolon_end ) ;
     public simpletikzParser.tikznode_ext_return tikznode_ext() // throws RecognitionException [1]
     {   
         simpletikzParser.tikznode_ext_return retval = new simpletikzParser.tikznode_ext_return();
@@ -5777,41 +5829,41 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.node_start_return node_start174 = default(simpletikzParser.node_start_return);
+        simpletikzParser.node_start_return node_start177 = default(simpletikzParser.node_start_return);
 
-        simpletikzParser.tikznode_core_return tikznode_core175 = default(simpletikzParser.tikznode_core_return);
+        simpletikzParser.tikznode_core_return tikznode_core178 = default(simpletikzParser.tikznode_core_return);
 
-        simpletikzParser.tikzpath_element_return tikzpath_element176 = default(simpletikzParser.tikzpath_element_return);
+        simpletikzParser.tikzpath_element_return tikzpath_element179 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.semicolon_end_return semicolon_end177 = default(simpletikzParser.semicolon_end_return);
+        simpletikzParser.semicolon_end_return semicolon_end180 = default(simpletikzParser.semicolon_end_return);
 
 
         RewriteRuleSubtreeStream stream_tikzpath_element = new RewriteRuleSubtreeStream(adaptor,"rule tikzpath_element");
-        RewriteRuleSubtreeStream stream_node_start = new RewriteRuleSubtreeStream(adaptor,"rule node_start");
         RewriteRuleSubtreeStream stream_tikznode_core = new RewriteRuleSubtreeStream(adaptor,"rule tikznode_core");
+        RewriteRuleSubtreeStream stream_node_start = new RewriteRuleSubtreeStream(adaptor,"rule node_start");
         RewriteRuleSubtreeStream stream_semicolon_end = new RewriteRuleSubtreeStream(adaptor,"rule semicolon_end");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:346:2: ( node_start tikznode_core ( tikzpath_element )* semicolon_end -> ^( IM_PATH node_start tikznode_core ( tikzpath_element )* semicolon_end ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:346:4: node_start tikznode_core ( tikzpath_element )* semicolon_end
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:346:2: ( node_start tikznode_core ( tikzpath_element )* semicolon_end -> ^( IM_PATH node_start tikznode_core ( tikzpath_element )* semicolon_end ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:346:4: node_start tikznode_core ( tikzpath_element )* semicolon_end
             {
-            	PushFollow(FOLLOW_node_start_in_tikznode_ext2013);
-            	node_start174 = node_start();
+            	PushFollow(FOLLOW_node_start_in_tikznode_ext2024);
+            	node_start177 = node_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_node_start.Add(node_start174.Tree);
-            	PushFollow(FOLLOW_tikznode_core_in_tikznode_ext2015);
-            	tikznode_core175 = tikznode_core();
+            	if ( state.backtracking==0 ) stream_node_start.Add(node_start177.Tree);
+            	PushFollow(FOLLOW_tikznode_core_in_tikznode_ext2026);
+            	tikznode_core178 = tikznode_core();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_core.Add(tikznode_core175.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:346:29: ( tikzpath_element )*
+            	if ( state.backtracking==0 ) stream_tikznode_core.Add(tikznode_core178.Tree);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:346:29: ( tikzpath_element )*
             	do 
             	{
             	    int alt45 = 2;
             	    int LA45_0 = input.LA(1);
 
-            	    if ( ((LA45_0 >= ID && LA45_0 <= COMMAND) || LA45_0 == 43 || LA45_0 == 45 || LA45_0 == 52 || LA45_0 == 54 || LA45_0 == 58 || LA45_0 == 77 || (LA45_0 >= 79 && LA45_0 <= 80) || (LA45_0 >= 82 && LA45_0 <= 91)) )
+            	    if ( ((LA45_0 >= ID && LA45_0 <= COMMAND) || LA45_0 == 43 || LA45_0 == 45 || LA45_0 == 53 || LA45_0 == 55 || LA45_0 == 59 || LA45_0 == 78 || (LA45_0 >= 80 && LA45_0 <= 81) || (LA45_0 >= 83 && LA45_0 <= 92)) )
             	    {
             	        alt45 = 1;
             	    }
@@ -5820,13 +5872,13 @@ public partial class simpletikzParser : Parser
             	    switch (alt45) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:346:29: tikzpath_element
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:346:29: tikzpath_element
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_element_in_tikznode_ext2017);
-            			    	tikzpath_element176 = tikzpath_element();
+            			    	PushFollow(FOLLOW_tikzpath_element_in_tikznode_ext2028);
+            			    	tikzpath_element179 = tikzpath_element();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element176.Tree);
+            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element179.Tree);
 
             			    }
             			    break;
@@ -5839,15 +5891,15 @@ public partial class simpletikzParser : Parser
             	loop45:
             		;	// Stops C# compiler whining that label 'loop45' has no statements
 
-            	PushFollow(FOLLOW_semicolon_end_in_tikznode_ext2020);
-            	semicolon_end177 = semicolon_end();
+            	PushFollow(FOLLOW_semicolon_end_in_tikznode_ext2031);
+            	semicolon_end180 = semicolon_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end177.Tree);
+            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end180.Tree);
 
 
             	// AST REWRITE
-            	// elements:          tikznode_core, node_start, semicolon_end, tikzpath_element
+            	// elements:          node_start, tikzpath_element, semicolon_end, tikznode_core
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -5859,14 +5911,14 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 346:61: -> ^( IM_PATH node_start tikznode_core ( tikzpath_element )* semicolon_end )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:346:64: ^( IM_PATH node_start tikznode_core ( tikzpath_element )* semicolon_end )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:346:64: ^( IM_PATH node_start tikznode_core ( tikzpath_element )* semicolon_end )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_PATH, "IM_PATH"), root_1);
 
             	    adaptor.AddChild(root_1, stream_node_start.NextTree());
             	    adaptor.AddChild(root_1, stream_tikznode_core.NextTree());
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:346:99: ( tikzpath_element )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:346:99: ( tikzpath_element )*
             	    while ( stream_tikzpath_element.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikzpath_element.NextTree());
@@ -5911,7 +5963,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzdef_ext"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:348:1: tikzdef_ext : def_start ( tikzpath_element )* semicolon_end -> ^( IM_PATH def_start ( tikzpath_element )* semicolon_end ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:348:1: tikzdef_ext : def_start ( tikzpath_element )* semicolon_end -> ^( IM_PATH def_start ( tikzpath_element )* semicolon_end ) ;
     public simpletikzParser.tikzdef_ext_return tikzdef_ext() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzdef_ext_return retval = new simpletikzParser.tikzdef_ext_return();
@@ -5919,11 +5971,11 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.def_start_return def_start178 = default(simpletikzParser.def_start_return);
+        simpletikzParser.def_start_return def_start181 = default(simpletikzParser.def_start_return);
 
-        simpletikzParser.tikzpath_element_return tikzpath_element179 = default(simpletikzParser.tikzpath_element_return);
+        simpletikzParser.tikzpath_element_return tikzpath_element182 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.semicolon_end_return semicolon_end180 = default(simpletikzParser.semicolon_end_return);
+        simpletikzParser.semicolon_end_return semicolon_end183 = default(simpletikzParser.semicolon_end_return);
 
 
         RewriteRuleSubtreeStream stream_tikzpath_element = new RewriteRuleSubtreeStream(adaptor,"rule tikzpath_element");
@@ -5931,21 +5983,21 @@ public partial class simpletikzParser : Parser
         RewriteRuleSubtreeStream stream_semicolon_end = new RewriteRuleSubtreeStream(adaptor,"rule semicolon_end");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:349:2: ( def_start ( tikzpath_element )* semicolon_end -> ^( IM_PATH def_start ( tikzpath_element )* semicolon_end ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:349:4: def_start ( tikzpath_element )* semicolon_end
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:349:2: ( def_start ( tikzpath_element )* semicolon_end -> ^( IM_PATH def_start ( tikzpath_element )* semicolon_end ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:349:4: def_start ( tikzpath_element )* semicolon_end
             {
-            	PushFollow(FOLLOW_def_start_in_tikzdef_ext2045);
-            	def_start178 = def_start();
+            	PushFollow(FOLLOW_def_start_in_tikzdef_ext2056);
+            	def_start181 = def_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_def_start.Add(def_start178.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:349:14: ( tikzpath_element )*
+            	if ( state.backtracking==0 ) stream_def_start.Add(def_start181.Tree);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:349:14: ( tikzpath_element )*
             	do 
             	{
             	    int alt46 = 2;
             	    int LA46_0 = input.LA(1);
 
-            	    if ( ((LA46_0 >= ID && LA46_0 <= COMMAND) || LA46_0 == 43 || LA46_0 == 45 || LA46_0 == 52 || LA46_0 == 54 || LA46_0 == 58 || LA46_0 == 77 || (LA46_0 >= 79 && LA46_0 <= 80) || (LA46_0 >= 82 && LA46_0 <= 91)) )
+            	    if ( ((LA46_0 >= ID && LA46_0 <= COMMAND) || LA46_0 == 43 || LA46_0 == 45 || LA46_0 == 53 || LA46_0 == 55 || LA46_0 == 59 || LA46_0 == 78 || (LA46_0 >= 80 && LA46_0 <= 81) || (LA46_0 >= 83 && LA46_0 <= 92)) )
             	    {
             	        alt46 = 1;
             	    }
@@ -5954,13 +6006,13 @@ public partial class simpletikzParser : Parser
             	    switch (alt46) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:349:14: tikzpath_element
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:349:14: tikzpath_element
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzdef_ext2047);
-            			    	tikzpath_element179 = tikzpath_element();
+            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzdef_ext2058);
+            			    	tikzpath_element182 = tikzpath_element();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element179.Tree);
+            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element182.Tree);
 
             			    }
             			    break;
@@ -5973,15 +6025,15 @@ public partial class simpletikzParser : Parser
             	loop46:
             		;	// Stops C# compiler whining that label 'loop46' has no statements
 
-            	PushFollow(FOLLOW_semicolon_end_in_tikzdef_ext2050);
-            	semicolon_end180 = semicolon_end();
+            	PushFollow(FOLLOW_semicolon_end_in_tikzdef_ext2061);
+            	semicolon_end183 = semicolon_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end180.Tree);
+            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end183.Tree);
 
 
             	// AST REWRITE
-            	// elements:          tikzpath_element, semicolon_end, def_start
+            	// elements:          def_start, semicolon_end, tikzpath_element
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -5993,13 +6045,13 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 349:46: -> ^( IM_PATH def_start ( tikzpath_element )* semicolon_end )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:349:49: ^( IM_PATH def_start ( tikzpath_element )* semicolon_end )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:349:49: ^( IM_PATH def_start ( tikzpath_element )* semicolon_end )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_PATH, "IM_PATH"), root_1);
 
             	    adaptor.AddChild(root_1, stream_def_start.NextTree());
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:349:69: ( tikzpath_element )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:349:69: ( tikzpath_element )*
             	    while ( stream_tikzpath_element.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikzpath_element.NextTree());
@@ -6044,7 +6096,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzmatrix_ext"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:352:1: tikzmatrix_ext : matrix_start tikznode_core ( tikzpath_element )* semicolon_end -> ^( IM_PATH matrix_start tikznode_core ( tikzpath_element )* semicolon_end ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:352:1: tikzmatrix_ext : matrix_start tikznode_core ( tikzpath_element )* semicolon_end -> ^( IM_PATH matrix_start tikznode_core ( tikzpath_element )* semicolon_end ) ;
     public simpletikzParser.tikzmatrix_ext_return tikzmatrix_ext() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzmatrix_ext_return retval = new simpletikzParser.tikzmatrix_ext_return();
@@ -6052,41 +6104,41 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.matrix_start_return matrix_start181 = default(simpletikzParser.matrix_start_return);
+        simpletikzParser.matrix_start_return matrix_start184 = default(simpletikzParser.matrix_start_return);
 
-        simpletikzParser.tikznode_core_return tikznode_core182 = default(simpletikzParser.tikznode_core_return);
+        simpletikzParser.tikznode_core_return tikznode_core185 = default(simpletikzParser.tikznode_core_return);
 
-        simpletikzParser.tikzpath_element_return tikzpath_element183 = default(simpletikzParser.tikzpath_element_return);
+        simpletikzParser.tikzpath_element_return tikzpath_element186 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.semicolon_end_return semicolon_end184 = default(simpletikzParser.semicolon_end_return);
+        simpletikzParser.semicolon_end_return semicolon_end187 = default(simpletikzParser.semicolon_end_return);
 
 
         RewriteRuleSubtreeStream stream_tikzpath_element = new RewriteRuleSubtreeStream(adaptor,"rule tikzpath_element");
-        RewriteRuleSubtreeStream stream_matrix_start = new RewriteRuleSubtreeStream(adaptor,"rule matrix_start");
         RewriteRuleSubtreeStream stream_tikznode_core = new RewriteRuleSubtreeStream(adaptor,"rule tikznode_core");
         RewriteRuleSubtreeStream stream_semicolon_end = new RewriteRuleSubtreeStream(adaptor,"rule semicolon_end");
+        RewriteRuleSubtreeStream stream_matrix_start = new RewriteRuleSubtreeStream(adaptor,"rule matrix_start");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:353:2: ( matrix_start tikznode_core ( tikzpath_element )* semicolon_end -> ^( IM_PATH matrix_start tikznode_core ( tikzpath_element )* semicolon_end ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:353:4: matrix_start tikznode_core ( tikzpath_element )* semicolon_end
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:353:2: ( matrix_start tikznode_core ( tikzpath_element )* semicolon_end -> ^( IM_PATH matrix_start tikznode_core ( tikzpath_element )* semicolon_end ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:353:4: matrix_start tikznode_core ( tikzpath_element )* semicolon_end
             {
-            	PushFollow(FOLLOW_matrix_start_in_tikzmatrix_ext2075);
-            	matrix_start181 = matrix_start();
+            	PushFollow(FOLLOW_matrix_start_in_tikzmatrix_ext2086);
+            	matrix_start184 = matrix_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_matrix_start.Add(matrix_start181.Tree);
-            	PushFollow(FOLLOW_tikznode_core_in_tikzmatrix_ext2077);
-            	tikznode_core182 = tikznode_core();
+            	if ( state.backtracking==0 ) stream_matrix_start.Add(matrix_start184.Tree);
+            	PushFollow(FOLLOW_tikznode_core_in_tikzmatrix_ext2088);
+            	tikznode_core185 = tikznode_core();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_core.Add(tikznode_core182.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:353:31: ( tikzpath_element )*
+            	if ( state.backtracking==0 ) stream_tikznode_core.Add(tikznode_core185.Tree);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:353:31: ( tikzpath_element )*
             	do 
             	{
             	    int alt47 = 2;
             	    int LA47_0 = input.LA(1);
 
-            	    if ( ((LA47_0 >= ID && LA47_0 <= COMMAND) || LA47_0 == 43 || LA47_0 == 45 || LA47_0 == 52 || LA47_0 == 54 || LA47_0 == 58 || LA47_0 == 77 || (LA47_0 >= 79 && LA47_0 <= 80) || (LA47_0 >= 82 && LA47_0 <= 91)) )
+            	    if ( ((LA47_0 >= ID && LA47_0 <= COMMAND) || LA47_0 == 43 || LA47_0 == 45 || LA47_0 == 53 || LA47_0 == 55 || LA47_0 == 59 || LA47_0 == 78 || (LA47_0 >= 80 && LA47_0 <= 81) || (LA47_0 >= 83 && LA47_0 <= 92)) )
             	    {
             	        alt47 = 1;
             	    }
@@ -6095,13 +6147,13 @@ public partial class simpletikzParser : Parser
             	    switch (alt47) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:353:31: tikzpath_element
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:353:31: tikzpath_element
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzmatrix_ext2079);
-            			    	tikzpath_element183 = tikzpath_element();
+            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzmatrix_ext2090);
+            			    	tikzpath_element186 = tikzpath_element();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element183.Tree);
+            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element186.Tree);
 
             			    }
             			    break;
@@ -6114,15 +6166,15 @@ public partial class simpletikzParser : Parser
             	loop47:
             		;	// Stops C# compiler whining that label 'loop47' has no statements
 
-            	PushFollow(FOLLOW_semicolon_end_in_tikzmatrix_ext2082);
-            	semicolon_end184 = semicolon_end();
+            	PushFollow(FOLLOW_semicolon_end_in_tikzmatrix_ext2093);
+            	semicolon_end187 = semicolon_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end184.Tree);
+            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end187.Tree);
 
 
             	// AST REWRITE
-            	// elements:          tikznode_core, matrix_start, semicolon_end, tikzpath_element
+            	// elements:          matrix_start, semicolon_end, tikzpath_element, tikznode_core
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -6134,14 +6186,14 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 353:63: -> ^( IM_PATH matrix_start tikznode_core ( tikzpath_element )* semicolon_end )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:353:66: ^( IM_PATH matrix_start tikznode_core ( tikzpath_element )* semicolon_end )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:353:66: ^( IM_PATH matrix_start tikznode_core ( tikzpath_element )* semicolon_end )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_PATH, "IM_PATH"), root_1);
 
             	    adaptor.AddChild(root_1, stream_matrix_start.NextTree());
             	    adaptor.AddChild(root_1, stream_tikznode_core.NextTree());
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:353:103: ( tikzpath_element )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:353:103: ( tikzpath_element )*
             	    while ( stream_tikzpath_element.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikzpath_element.NextTree());
@@ -6186,7 +6238,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzcoordinate_ext"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:357:1: tikzcoordinate_ext : coordinate_start ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )? ( tikzpath_element )* semicolon_end -> ^( IM_PATH coordinate_start ( tikzcoordinate_core3 )? ( tikzcoordinate_core2 )? ( tikzcoordinate_core1 )? ( tikzpath_element )* semicolon_end ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:357:1: tikzcoordinate_ext : coordinate_start ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )? ( tikzpath_element )* semicolon_end -> ^( IM_PATH coordinate_start ( tikzcoordinate_core3 )? ( tikzcoordinate_core2 )? ( tikzcoordinate_core1 )? ( tikzpath_element )* semicolon_end ) ;
     public simpletikzParser.tikzcoordinate_ext_return tikzcoordinate_ext() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzcoordinate_ext_return retval = new simpletikzParser.tikzcoordinate_ext_return();
@@ -6194,51 +6246,51 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.coordinate_start_return coordinate_start185 = default(simpletikzParser.coordinate_start_return);
+        simpletikzParser.coordinate_start_return coordinate_start188 = default(simpletikzParser.coordinate_start_return);
 
-        simpletikzParser.tikzcoordinate_core3_return tikzcoordinate_core3186 = default(simpletikzParser.tikzcoordinate_core3_return);
+        simpletikzParser.tikzcoordinate_core3_return tikzcoordinate_core3189 = default(simpletikzParser.tikzcoordinate_core3_return);
 
-        simpletikzParser.tikzcoordinate_core2_return tikzcoordinate_core2187 = default(simpletikzParser.tikzcoordinate_core2_return);
+        simpletikzParser.tikzcoordinate_core2_return tikzcoordinate_core2190 = default(simpletikzParser.tikzcoordinate_core2_return);
 
-        simpletikzParser.tikzcoordinate_core1_return tikzcoordinate_core1188 = default(simpletikzParser.tikzcoordinate_core1_return);
+        simpletikzParser.tikzcoordinate_core1_return tikzcoordinate_core1191 = default(simpletikzParser.tikzcoordinate_core1_return);
 
-        simpletikzParser.tikzpath_element_return tikzpath_element189 = default(simpletikzParser.tikzpath_element_return);
+        simpletikzParser.tikzpath_element_return tikzpath_element192 = default(simpletikzParser.tikzpath_element_return);
 
-        simpletikzParser.semicolon_end_return semicolon_end190 = default(simpletikzParser.semicolon_end_return);
+        simpletikzParser.semicolon_end_return semicolon_end193 = default(simpletikzParser.semicolon_end_return);
 
 
-        RewriteRuleSubtreeStream stream_tikzpath_element = new RewriteRuleSubtreeStream(adaptor,"rule tikzpath_element");
         RewriteRuleSubtreeStream stream_tikzcoordinate_core3 = new RewriteRuleSubtreeStream(adaptor,"rule tikzcoordinate_core3");
         RewriteRuleSubtreeStream stream_tikzcoordinate_core2 = new RewriteRuleSubtreeStream(adaptor,"rule tikzcoordinate_core2");
+        RewriteRuleSubtreeStream stream_tikzpath_element = new RewriteRuleSubtreeStream(adaptor,"rule tikzpath_element");
         RewriteRuleSubtreeStream stream_coordinate_start = new RewriteRuleSubtreeStream(adaptor,"rule coordinate_start");
         RewriteRuleSubtreeStream stream_tikzcoordinate_core1 = new RewriteRuleSubtreeStream(adaptor,"rule tikzcoordinate_core1");
         RewriteRuleSubtreeStream stream_semicolon_end = new RewriteRuleSubtreeStream(adaptor,"rule semicolon_end");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:358:2: ( coordinate_start ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )? ( tikzpath_element )* semicolon_end -> ^( IM_PATH coordinate_start ( tikzcoordinate_core3 )? ( tikzcoordinate_core2 )? ( tikzcoordinate_core1 )? ( tikzpath_element )* semicolon_end ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:358:4: coordinate_start ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )? ( tikzpath_element )* semicolon_end
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:358:2: ( coordinate_start ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )? ( tikzpath_element )* semicolon_end -> ^( IM_PATH coordinate_start ( tikzcoordinate_core3 )? ( tikzcoordinate_core2 )? ( tikzcoordinate_core1 )? ( tikzpath_element )* semicolon_end ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:358:4: coordinate_start ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )? ( tikzpath_element )* semicolon_end
             {
-            	PushFollow(FOLLOW_coordinate_start_in_tikzcoordinate_ext2110);
-            	coordinate_start185 = coordinate_start();
+            	PushFollow(FOLLOW_coordinate_start_in_tikzcoordinate_ext2121);
+            	coordinate_start188 = coordinate_start();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_coordinate_start.Add(coordinate_start185.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:359:5: ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )?
+            	if ( state.backtracking==0 ) stream_coordinate_start.Add(coordinate_start188.Tree);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:5: ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )?
             	int alt48 = 4;
             	alt48 = dfa48.Predict(input);
             	switch (alt48) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:359:7: ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 )
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:7: ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 )
             	        {
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:359:7: ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 )
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:359:8: ( tikzcoordinate_core3 )=> tikzcoordinate_core3
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:7: ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 )
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:8: ( tikzcoordinate_core3 )=> tikzcoordinate_core3
             	        	{
-            	        		PushFollow(FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_ext2125);
-            	        		tikzcoordinate_core3186 = tikzcoordinate_core3();
+            	        		PushFollow(FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_ext2136);
+            	        		tikzcoordinate_core3189 = tikzcoordinate_core3();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking==0 ) stream_tikzcoordinate_core3.Add(tikzcoordinate_core3186.Tree);
+            	        		if ( state.backtracking==0 ) stream_tikzcoordinate_core3.Add(tikzcoordinate_core3189.Tree);
 
             	        	}
 
@@ -6246,16 +6298,16 @@ public partial class simpletikzParser : Parser
             	        }
             	        break;
             	    case 2 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:360:11: ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 )
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:360:11: ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 )
             	        {
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:360:11: ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 )
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:360:12: ( tikzcoordinate_core2 )=> tikzcoordinate_core2
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:360:11: ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 )
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:360:12: ( tikzcoordinate_core2 )=> tikzcoordinate_core2
             	        	{
-            	        		PushFollow(FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_ext2144);
-            	        		tikzcoordinate_core2187 = tikzcoordinate_core2();
+            	        		PushFollow(FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_ext2155);
+            	        		tikzcoordinate_core2190 = tikzcoordinate_core2();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking==0 ) stream_tikzcoordinate_core2.Add(tikzcoordinate_core2187.Tree);
+            	        		if ( state.backtracking==0 ) stream_tikzcoordinate_core2.Add(tikzcoordinate_core2190.Tree);
 
             	        	}
 
@@ -6263,16 +6315,16 @@ public partial class simpletikzParser : Parser
             	        }
             	        break;
             	    case 3 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:361:11: ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 )
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:361:11: ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 )
             	        {
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:361:11: ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 )
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:361:12: ( tikzcoordinate_core1 )=> tikzcoordinate_core1
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:361:11: ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 )
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:361:12: ( tikzcoordinate_core1 )=> tikzcoordinate_core1
             	        	{
-            	        		PushFollow(FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_ext2164);
-            	        		tikzcoordinate_core1188 = tikzcoordinate_core1();
+            	        		PushFollow(FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_ext2175);
+            	        		tikzcoordinate_core1191 = tikzcoordinate_core1();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking==0 ) stream_tikzcoordinate_core1.Add(tikzcoordinate_core1188.Tree);
+            	        		if ( state.backtracking==0 ) stream_tikzcoordinate_core1.Add(tikzcoordinate_core1191.Tree);
 
             	        	}
 
@@ -6282,13 +6334,13 @@ public partial class simpletikzParser : Parser
 
             	}
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:362:6: ( tikzpath_element )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:362:6: ( tikzpath_element )*
             	do 
             	{
             	    int alt49 = 2;
             	    int LA49_0 = input.LA(1);
 
-            	    if ( ((LA49_0 >= ID && LA49_0 <= COMMAND) || LA49_0 == 43 || LA49_0 == 45 || LA49_0 == 52 || LA49_0 == 54 || LA49_0 == 58 || LA49_0 == 77 || (LA49_0 >= 79 && LA49_0 <= 80) || (LA49_0 >= 82 && LA49_0 <= 91)) )
+            	    if ( ((LA49_0 >= ID && LA49_0 <= COMMAND) || LA49_0 == 43 || LA49_0 == 45 || LA49_0 == 53 || LA49_0 == 55 || LA49_0 == 59 || LA49_0 == 78 || (LA49_0 >= 80 && LA49_0 <= 81) || (LA49_0 >= 83 && LA49_0 <= 92)) )
             	    {
             	        alt49 = 1;
             	    }
@@ -6297,13 +6349,13 @@ public partial class simpletikzParser : Parser
             	    switch (alt49) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:362:6: tikzpath_element
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:362:6: tikzpath_element
             			    {
-            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzcoordinate_ext2175);
-            			    	tikzpath_element189 = tikzpath_element();
+            			    	PushFollow(FOLLOW_tikzpath_element_in_tikzcoordinate_ext2186);
+            			    	tikzpath_element192 = tikzpath_element();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element189.Tree);
+            			    	if ( state.backtracking==0 ) stream_tikzpath_element.Add(tikzpath_element192.Tree);
 
             			    }
             			    break;
@@ -6316,15 +6368,15 @@ public partial class simpletikzParser : Parser
             	loop49:
             		;	// Stops C# compiler whining that label 'loop49' has no statements
 
-            	PushFollow(FOLLOW_semicolon_end_in_tikzcoordinate_ext2178);
-            	semicolon_end190 = semicolon_end();
+            	PushFollow(FOLLOW_semicolon_end_in_tikzcoordinate_ext2189);
+            	semicolon_end193 = semicolon_end();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end190.Tree);
+            	if ( state.backtracking==0 ) stream_semicolon_end.Add(semicolon_end193.Tree);
 
 
             	// AST REWRITE
-            	// elements:          tikzcoordinate_core1, tikzcoordinate_core3, semicolon_end, tikzpath_element, tikzcoordinate_core2, coordinate_start
+            	// elements:          semicolon_end, coordinate_start, tikzcoordinate_core2, tikzcoordinate_core3, tikzcoordinate_core1, tikzpath_element
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -6336,34 +6388,34 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 363:6: -> ^( IM_PATH coordinate_start ( tikzcoordinate_core3 )? ( tikzcoordinate_core2 )? ( tikzcoordinate_core1 )? ( tikzpath_element )* semicolon_end )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:363:9: ^( IM_PATH coordinate_start ( tikzcoordinate_core3 )? ( tikzcoordinate_core2 )? ( tikzcoordinate_core1 )? ( tikzpath_element )* semicolon_end )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:363:9: ^( IM_PATH coordinate_start ( tikzcoordinate_core3 )? ( tikzcoordinate_core2 )? ( tikzcoordinate_core1 )? ( tikzpath_element )* semicolon_end )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_PATH, "IM_PATH"), root_1);
 
             	    adaptor.AddChild(root_1, stream_coordinate_start.NextTree());
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:364:6: ( tikzcoordinate_core3 )?
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:364:6: ( tikzcoordinate_core3 )?
             	    if ( stream_tikzcoordinate_core3.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikzcoordinate_core3.NextTree());
 
             	    }
             	    stream_tikzcoordinate_core3.Reset();
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:365:6: ( tikzcoordinate_core2 )?
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:365:6: ( tikzcoordinate_core2 )?
             	    if ( stream_tikzcoordinate_core2.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikzcoordinate_core2.NextTree());
 
             	    }
             	    stream_tikzcoordinate_core2.Reset();
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:366:6: ( tikzcoordinate_core1 )?
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:366:6: ( tikzcoordinate_core1 )?
             	    if ( stream_tikzcoordinate_core1.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikzcoordinate_core1.NextTree());
 
             	    }
             	    stream_tikzcoordinate_core1.Reset();
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:367:6: ( tikzpath_element )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:367:6: ( tikzpath_element )*
             	    while ( stream_tikzpath_element.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikzpath_element.NextTree());
@@ -6408,7 +6460,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzcoordinate_int"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:369:1: tikzcoordinate_int : 'coordinate' ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )? ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:369:1: tikzcoordinate_int : 'coordinate' ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )? ;
     public simpletikzParser.tikzcoordinate_int_return tikzcoordinate_int() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzcoordinate_int_return retval = new simpletikzParser.tikzcoordinate_int_return();
@@ -6416,40 +6468,40 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal191 = null;
-        simpletikzParser.tikzcoordinate_core3_return tikzcoordinate_core3192 = default(simpletikzParser.tikzcoordinate_core3_return);
+        IToken string_literal194 = null;
+        simpletikzParser.tikzcoordinate_core3_return tikzcoordinate_core3195 = default(simpletikzParser.tikzcoordinate_core3_return);
 
-        simpletikzParser.tikzcoordinate_core2_return tikzcoordinate_core2193 = default(simpletikzParser.tikzcoordinate_core2_return);
+        simpletikzParser.tikzcoordinate_core2_return tikzcoordinate_core2196 = default(simpletikzParser.tikzcoordinate_core2_return);
 
-        simpletikzParser.tikzcoordinate_core1_return tikzcoordinate_core1194 = default(simpletikzParser.tikzcoordinate_core1_return);
+        simpletikzParser.tikzcoordinate_core1_return tikzcoordinate_core1197 = default(simpletikzParser.tikzcoordinate_core1_return);
 
 
-        object string_literal191_tree=null;
+        object string_literal194_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:370:2: ( 'coordinate' ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )? )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:370:4: 'coordinate' ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )?
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:2: ( 'coordinate' ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )? )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:4: 'coordinate' ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )?
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	string_literal191=(IToken)Match(input,79,FOLLOW_79_in_tikzcoordinate_int2238); if (state.failed) return retval;
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:370:18: ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )?
+            	string_literal194=(IToken)Match(input,80,FOLLOW_80_in_tikzcoordinate_int2249); if (state.failed) return retval;
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:18: ( ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 ) | ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 ) | ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 ) )?
             	int alt50 = 4;
             	alt50 = dfa50.Predict(input);
             	switch (alt50) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:370:20: ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 )
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:20: ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 )
             	        {
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:370:20: ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 )
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:370:21: ( tikzcoordinate_core3 )=> tikzcoordinate_core3
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:20: ( ( tikzcoordinate_core3 )=> tikzcoordinate_core3 )
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:21: ( tikzcoordinate_core3 )=> tikzcoordinate_core3
             	        	{
-            	        		PushFollow(FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_int2249);
-            	        		tikzcoordinate_core3192 = tikzcoordinate_core3();
+            	        		PushFollow(FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_int2260);
+            	        		tikzcoordinate_core3195 = tikzcoordinate_core3();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_core3192.Tree);
+            	        		if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_core3195.Tree);
 
             	        	}
 
@@ -6457,16 +6509,16 @@ public partial class simpletikzParser : Parser
             	        }
             	        break;
             	    case 2 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:371:11: ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 )
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:371:11: ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 )
             	        {
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:371:11: ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 )
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:371:12: ( tikzcoordinate_core2 )=> tikzcoordinate_core2
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:371:11: ( ( tikzcoordinate_core2 )=> tikzcoordinate_core2 )
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:371:12: ( tikzcoordinate_core2 )=> tikzcoordinate_core2
             	        	{
-            	        		PushFollow(FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_int2268);
-            	        		tikzcoordinate_core2193 = tikzcoordinate_core2();
+            	        		PushFollow(FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_int2279);
+            	        		tikzcoordinate_core2196 = tikzcoordinate_core2();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_core2193.Tree);
+            	        		if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_core2196.Tree);
 
             	        	}
 
@@ -6474,16 +6526,16 @@ public partial class simpletikzParser : Parser
             	        }
             	        break;
             	    case 3 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:372:11: ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 )
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:372:11: ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 )
             	        {
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:372:11: ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 )
-            	        	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:372:12: ( tikzcoordinate_core1 )=> tikzcoordinate_core1
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:372:11: ( ( tikzcoordinate_core1 )=> tikzcoordinate_core1 )
+            	        	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:372:12: ( tikzcoordinate_core1 )=> tikzcoordinate_core1
             	        	{
-            	        		PushFollow(FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_int2288);
-            	        		tikzcoordinate_core1194 = tikzcoordinate_core1();
+            	        		PushFollow(FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_int2299);
+            	        		tikzcoordinate_core1197 = tikzcoordinate_core1();
             	        		state.followingStackPointer--;
             	        		if (state.failed) return retval;
-            	        		if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_core1194.Tree);
+            	        		if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikzcoordinate_core1197.Tree);
 
             	        	}
 
@@ -6524,7 +6576,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikznode_int"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:374:1: tikznode_int : 'node' tikznode_core ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:374:1: tikznode_int : 'node' tikznode_core ;
     public simpletikzParser.tikznode_int_return tikznode_int() // throws RecognitionException [1]
     {   
         simpletikzParser.tikznode_int_return retval = new simpletikzParser.tikznode_int_return();
@@ -6532,25 +6584,25 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal195 = null;
-        simpletikzParser.tikznode_core_return tikznode_core196 = default(simpletikzParser.tikznode_core_return);
+        IToken string_literal198 = null;
+        simpletikzParser.tikznode_core_return tikznode_core199 = default(simpletikzParser.tikznode_core_return);
 
 
-        object string_literal195_tree=null;
+        object string_literal198_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:375:2: ( 'node' tikznode_core )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:375:4: 'node' tikznode_core
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:375:2: ( 'node' tikznode_core )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:375:4: 'node' tikznode_core
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	string_literal195=(IToken)Match(input,80,FOLLOW_80_in_tikznode_int2304); if (state.failed) return retval;
-            	PushFollow(FOLLOW_tikznode_core_in_tikznode_int2307);
-            	tikznode_core196 = tikznode_core();
+            	string_literal198=(IToken)Match(input,81,FOLLOW_81_in_tikznode_int2315); if (state.failed) return retval;
+            	PushFollow(FOLLOW_tikznode_core_in_tikznode_int2318);
+            	tikznode_core199 = tikznode_core();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_core196.Tree);
+            	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikznode_core199.Tree);
 
             }
 
@@ -6582,7 +6634,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikznode_core"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:377:1: tikznode_core : ( tikznode_decorator )* tikzstring -> ^( IM_NODE ( tikznode_decorator )* tikzstring ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:377:1: tikznode_core : ( tikznode_decorator )* tikzstring -> ^( IM_NODE ( tikznode_decorator )* tikzstring ) ;
     public simpletikzParser.tikznode_core_return tikznode_core() // throws RecognitionException [1]
     {   
         simpletikzParser.tikznode_core_return retval = new simpletikzParser.tikznode_core_return();
@@ -6590,25 +6642,25 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator197 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator200 = default(simpletikzParser.tikznode_decorator_return);
 
-        simpletikzParser.tikzstring_return tikzstring198 = default(simpletikzParser.tikzstring_return);
+        simpletikzParser.tikzstring_return tikzstring201 = default(simpletikzParser.tikzstring_return);
 
 
         RewriteRuleSubtreeStream stream_tikzstring = new RewriteRuleSubtreeStream(adaptor,"rule tikzstring");
         RewriteRuleSubtreeStream stream_tikznode_decorator = new RewriteRuleSubtreeStream(adaptor,"rule tikznode_decorator");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:378:2: ( ( tikznode_decorator )* tikzstring -> ^( IM_NODE ( tikznode_decorator )* tikzstring ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:378:4: ( tikznode_decorator )* tikzstring
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:378:2: ( ( tikznode_decorator )* tikzstring -> ^( IM_NODE ( tikznode_decorator )* tikzstring ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:378:4: ( tikznode_decorator )* tikzstring
             {
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:378:4: ( tikznode_decorator )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:378:4: ( tikznode_decorator )*
             	do 
             	{
             	    int alt51 = 2;
             	    int LA51_0 = input.LA(1);
 
-            	    if ( (LA51_0 == 52 || LA51_0 == 54 || LA51_0 == 81) )
+            	    if ( (LA51_0 == 53 || LA51_0 == 55 || LA51_0 == 82) )
             	    {
             	        alt51 = 1;
             	    }
@@ -6617,13 +6669,13 @@ public partial class simpletikzParser : Parser
             	    switch (alt51) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:378:4: tikznode_decorator
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:378:4: tikznode_decorator
             			    {
-            			    	PushFollow(FOLLOW_tikznode_decorator_in_tikznode_core2317);
-            			    	tikznode_decorator197 = tikznode_decorator();
+            			    	PushFollow(FOLLOW_tikznode_decorator_in_tikznode_core2328);
+            			    	tikznode_decorator200 = tikznode_decorator();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator197.Tree);
+            			    	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator200.Tree);
 
             			    }
             			    break;
@@ -6636,11 +6688,11 @@ public partial class simpletikzParser : Parser
             	loop51:
             		;	// Stops C# compiler whining that label 'loop51' has no statements
 
-            	PushFollow(FOLLOW_tikzstring_in_tikznode_core2320);
-            	tikzstring198 = tikzstring();
+            	PushFollow(FOLLOW_tikzstring_in_tikznode_core2331);
+            	tikzstring201 = tikzstring();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikzstring.Add(tikzstring198.Tree);
+            	if ( state.backtracking==0 ) stream_tikzstring.Add(tikzstring201.Tree);
 
 
             	// AST REWRITE
@@ -6656,12 +6708,12 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 378:36: -> ^( IM_NODE ( tikznode_decorator )* tikzstring )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:378:39: ^( IM_NODE ( tikznode_decorator )* tikzstring )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:378:39: ^( IM_NODE ( tikznode_decorator )* tikzstring )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_NODE, "IM_NODE"), root_1);
 
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:378:49: ( tikznode_decorator )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:378:49: ( tikznode_decorator )*
             	    while ( stream_tikznode_decorator.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikznode_decorator.NextTree());
@@ -6706,7 +6758,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzcoordinate_core3"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:381:1: tikzcoordinate_core3 : tikznode_decorator tikznode_decorator tikznode_decorator -> ^( IM_NODE tikznode_decorator tikznode_decorator tikznode_decorator ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:381:1: tikzcoordinate_core3 : tikznode_decorator tikznode_decorator tikznode_decorator -> ^( IM_NODE tikznode_decorator tikznode_decorator tikznode_decorator ) ;
     public simpletikzParser.tikzcoordinate_core3_return tikzcoordinate_core3() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzcoordinate_core3_return retval = new simpletikzParser.tikzcoordinate_core3_return();
@@ -6714,34 +6766,34 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator199 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator202 = default(simpletikzParser.tikznode_decorator_return);
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator200 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator203 = default(simpletikzParser.tikznode_decorator_return);
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator201 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator204 = default(simpletikzParser.tikznode_decorator_return);
 
 
         RewriteRuleSubtreeStream stream_tikznode_decorator = new RewriteRuleSubtreeStream(adaptor,"rule tikznode_decorator");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:382:2: ( tikznode_decorator tikznode_decorator tikznode_decorator -> ^( IM_NODE tikznode_decorator tikznode_decorator tikznode_decorator ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:382:6: tikznode_decorator tikznode_decorator tikznode_decorator
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:382:2: ( tikznode_decorator tikznode_decorator tikznode_decorator -> ^( IM_NODE tikznode_decorator tikznode_decorator tikznode_decorator ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:382:6: tikznode_decorator tikznode_decorator tikznode_decorator
             {
-            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core32345);
-            	tikznode_decorator199 = tikznode_decorator();
+            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core32356);
+            	tikznode_decorator202 = tikznode_decorator();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator199.Tree);
-            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core32347);
-            	tikznode_decorator200 = tikznode_decorator();
+            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator202.Tree);
+            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core32358);
+            	tikznode_decorator203 = tikznode_decorator();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator200.Tree);
-            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core32349);
-            	tikznode_decorator201 = tikznode_decorator();
+            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator203.Tree);
+            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core32360);
+            	tikznode_decorator204 = tikznode_decorator();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator201.Tree);
+            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator204.Tree);
 
 
             	// AST REWRITE
@@ -6757,7 +6809,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 382:64: -> ^( IM_NODE tikznode_decorator tikznode_decorator tikznode_decorator )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:382:67: ^( IM_NODE tikznode_decorator tikznode_decorator tikznode_decorator )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:382:67: ^( IM_NODE tikznode_decorator tikznode_decorator tikznode_decorator )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_NODE, "IM_NODE"), root_1);
@@ -6802,7 +6854,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzcoordinate_core2"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:386:1: tikzcoordinate_core2 : tikznode_decorator tikznode_decorator -> ^( IM_NODE tikznode_decorator tikznode_decorator ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:386:1: tikzcoordinate_core2 : tikznode_decorator tikznode_decorator -> ^( IM_NODE tikznode_decorator tikznode_decorator ) ;
     public simpletikzParser.tikzcoordinate_core2_return tikzcoordinate_core2() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzcoordinate_core2_return retval = new simpletikzParser.tikzcoordinate_core2_return();
@@ -6810,27 +6862,27 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator202 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator205 = default(simpletikzParser.tikznode_decorator_return);
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator203 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator206 = default(simpletikzParser.tikznode_decorator_return);
 
 
         RewriteRuleSubtreeStream stream_tikznode_decorator = new RewriteRuleSubtreeStream(adaptor,"rule tikznode_decorator");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:387:2: ( tikznode_decorator tikznode_decorator -> ^( IM_NODE tikznode_decorator tikznode_decorator ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:388:4: tikznode_decorator tikznode_decorator
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:387:2: ( tikznode_decorator tikznode_decorator -> ^( IM_NODE tikznode_decorator tikznode_decorator ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:388:4: tikznode_decorator tikznode_decorator
             {
-            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core22383);
-            	tikznode_decorator202 = tikznode_decorator();
+            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core22394);
+            	tikznode_decorator205 = tikznode_decorator();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator202.Tree);
-            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core22385);
-            	tikznode_decorator203 = tikznode_decorator();
+            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator205.Tree);
+            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core22396);
+            	tikznode_decorator206 = tikznode_decorator();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator203.Tree);
+            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator206.Tree);
 
 
             	// AST REWRITE
@@ -6846,7 +6898,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 388:47: -> ^( IM_NODE tikznode_decorator tikznode_decorator )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:388:50: ^( IM_NODE tikznode_decorator tikznode_decorator )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:388:50: ^( IM_NODE tikznode_decorator tikznode_decorator )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_NODE, "IM_NODE"), root_1);
@@ -6890,7 +6942,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzcoordinate_core1"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:391:1: tikzcoordinate_core1 : tikznode_decorator -> ^( IM_NODE tikznode_decorator ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:391:1: tikzcoordinate_core1 : tikznode_decorator -> ^( IM_NODE tikznode_decorator ) ;
     public simpletikzParser.tikzcoordinate_core1_return tikzcoordinate_core1() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzcoordinate_core1_return retval = new simpletikzParser.tikzcoordinate_core1_return();
@@ -6898,20 +6950,20 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.tikznode_decorator_return tikznode_decorator204 = default(simpletikzParser.tikznode_decorator_return);
+        simpletikzParser.tikznode_decorator_return tikznode_decorator207 = default(simpletikzParser.tikznode_decorator_return);
 
 
         RewriteRuleSubtreeStream stream_tikznode_decorator = new RewriteRuleSubtreeStream(adaptor,"rule tikznode_decorator");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:392:2: ( tikznode_decorator -> ^( IM_NODE tikznode_decorator ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:393:4: tikznode_decorator
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:392:2: ( tikznode_decorator -> ^( IM_NODE tikznode_decorator ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:393:4: tikznode_decorator
             {
-            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core12418);
-            	tikznode_decorator204 = tikznode_decorator();
+            	PushFollow(FOLLOW_tikznode_decorator_in_tikzcoordinate_core12429);
+            	tikznode_decorator207 = tikznode_decorator();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator204.Tree);
+            	if ( state.backtracking==0 ) stream_tikznode_decorator.Add(tikznode_decorator207.Tree);
 
 
             	// AST REWRITE
@@ -6927,7 +6979,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 393:31: -> ^( IM_NODE tikznode_decorator )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:393:34: ^( IM_NODE tikznode_decorator )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:393:34: ^( IM_NODE tikznode_decorator )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_NODE, "IM_NODE"), root_1);
@@ -6970,7 +7022,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikznode_decorator"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:400:1: tikznode_decorator : ( nodename | 'at' COMMAND | 'at' coord | tikz_options_dontcare );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:400:1: tikznode_decorator : ( nodename | 'at' COMMAND | 'at' coord | tikz_options_dontcare );
     public simpletikzParser.tikznode_decorator_return tikznode_decorator() // throws RecognitionException [1]
     {   
         simpletikzParser.tikznode_decorator_return retval = new simpletikzParser.tikznode_decorator_return();
@@ -6978,32 +7030,32 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal206 = null;
-        IToken COMMAND207 = null;
-        IToken string_literal208 = null;
-        simpletikzParser.nodename_return nodename205 = default(simpletikzParser.nodename_return);
+        IToken string_literal209 = null;
+        IToken COMMAND210 = null;
+        IToken string_literal211 = null;
+        simpletikzParser.nodename_return nodename208 = default(simpletikzParser.nodename_return);
 
-        simpletikzParser.coord_return coord209 = default(simpletikzParser.coord_return);
+        simpletikzParser.coord_return coord212 = default(simpletikzParser.coord_return);
 
-        simpletikzParser.tikz_options_dontcare_return tikz_options_dontcare210 = default(simpletikzParser.tikz_options_dontcare_return);
+        simpletikzParser.tikz_options_dontcare_return tikz_options_dontcare213 = default(simpletikzParser.tikz_options_dontcare_return);
 
 
-        object string_literal206_tree=null;
-        object COMMAND207_tree=null;
-        object string_literal208_tree=null;
+        object string_literal209_tree=null;
+        object COMMAND210_tree=null;
+        object string_literal211_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:401:2: ( nodename | 'at' COMMAND | 'at' coord | tikz_options_dontcare )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:401:2: ( nodename | 'at' COMMAND | 'at' coord | tikz_options_dontcare )
             int alt52 = 4;
             switch ( input.LA(1) ) 
             {
-            case 52:
+            case 53:
             	{
                 alt52 = 1;
                 }
                 break;
-            case 81:
+            case 82:
             	{
                 int LA52_2 = input.LA(2);
 
@@ -7011,7 +7063,7 @@ public partial class simpletikzParser : Parser
                 {
                     alt52 = 2;
                 }
-                else if ( (LA52_2 == 52 || (LA52_2 >= 89 && LA52_2 <= 90)) )
+                else if ( (LA52_2 == 53 || (LA52_2 >= 90 && LA52_2 <= 91)) )
                 {
                     alt52 = 3;
                 }
@@ -7025,7 +7077,7 @@ public partial class simpletikzParser : Parser
                 }
                 }
                 break;
-            case 54:
+            case 55:
             	{
                 alt52 = 4;
                 }
@@ -7041,56 +7093,56 @@ public partial class simpletikzParser : Parser
             switch (alt52) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:401:6: nodename
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:401:6: nodename
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_nodename_in_tikznode_decorator2455);
-                    	nodename205 = nodename();
+                    	PushFollow(FOLLOW_nodename_in_tikznode_decorator2466);
+                    	nodename208 = nodename();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, nodename205.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, nodename208.Tree);
 
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:402:5: 'at' COMMAND
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:402:5: 'at' COMMAND
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	string_literal206=(IToken)Match(input,81,FOLLOW_81_in_tikznode_decorator2462); if (state.failed) return retval;
-                    	COMMAND207=(IToken)Match(input,COMMAND,FOLLOW_COMMAND_in_tikznode_decorator2465); if (state.failed) return retval;
+                    	string_literal209=(IToken)Match(input,82,FOLLOW_82_in_tikznode_decorator2473); if (state.failed) return retval;
+                    	COMMAND210=(IToken)Match(input,COMMAND,FOLLOW_COMMAND_in_tikznode_decorator2476); if (state.failed) return retval;
                     	if ( state.backtracking == 0 )
-                    	{COMMAND207_tree = (object)adaptor.Create(COMMAND207);
-                    		adaptor.AddChild(root_0, COMMAND207_tree);
+                    	{COMMAND210_tree = (object)adaptor.Create(COMMAND210);
+                    		adaptor.AddChild(root_0, COMMAND210_tree);
                     	}
 
                     }
                     break;
                 case 3 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:403:5: 'at' coord
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:403:5: 'at' coord
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	string_literal208=(IToken)Match(input,81,FOLLOW_81_in_tikznode_decorator2471); if (state.failed) return retval;
-                    	PushFollow(FOLLOW_coord_in_tikznode_decorator2474);
-                    	coord209 = coord();
+                    	string_literal211=(IToken)Match(input,82,FOLLOW_82_in_tikznode_decorator2482); if (state.failed) return retval;
+                    	PushFollow(FOLLOW_coord_in_tikznode_decorator2485);
+                    	coord212 = coord();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, coord209.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, coord212.Tree);
 
                     }
                     break;
                 case 4 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:404:5: tikz_options_dontcare
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:404:5: tikz_options_dontcare
                     {
                     	root_0 = (object)adaptor.GetNilNode();
 
-                    	PushFollow(FOLLOW_tikz_options_dontcare_in_tikznode_decorator2480);
-                    	tikz_options_dontcare210 = tikz_options_dontcare();
+                    	PushFollow(FOLLOW_tikz_options_dontcare_in_tikznode_decorator2491);
+                    	tikz_options_dontcare213 = tikz_options_dontcare();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_options_dontcare210.Tree);
+                    	if ( state.backtracking == 0 ) adaptor.AddChild(root_0, tikz_options_dontcare213.Tree);
 
                     }
                     break;
@@ -7124,7 +7176,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikz_options_dontcare"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:406:1: tikz_options_dontcare : '[' ( no_rlbracket )* ( tikz_options_dontcare ( no_rlbracket )* )* ']' -> ^( IM_OPTIONS ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:406:1: tikz_options_dontcare : '[' ( no_rlbracket )* ( tikz_options_dontcare ( no_rlbracket )* )* ']' -> ^( IM_OPTIONS ) ;
     public simpletikzParser.tikz_options_dontcare_return tikz_options_dontcare() // throws RecognitionException [1]
     {   
         simpletikzParser.tikz_options_dontcare_return retval = new simpletikzParser.tikz_options_dontcare_return();
@@ -7132,36 +7184,36 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal211 = null;
-        IToken char_literal215 = null;
-        simpletikzParser.no_rlbracket_return no_rlbracket212 = default(simpletikzParser.no_rlbracket_return);
+        IToken char_literal214 = null;
+        IToken char_literal218 = null;
+        simpletikzParser.no_rlbracket_return no_rlbracket215 = default(simpletikzParser.no_rlbracket_return);
 
-        simpletikzParser.tikz_options_dontcare_return tikz_options_dontcare213 = default(simpletikzParser.tikz_options_dontcare_return);
+        simpletikzParser.tikz_options_dontcare_return tikz_options_dontcare216 = default(simpletikzParser.tikz_options_dontcare_return);
 
-        simpletikzParser.no_rlbracket_return no_rlbracket214 = default(simpletikzParser.no_rlbracket_return);
+        simpletikzParser.no_rlbracket_return no_rlbracket217 = default(simpletikzParser.no_rlbracket_return);
 
 
-        object char_literal211_tree=null;
-        object char_literal215_tree=null;
+        object char_literal214_tree=null;
+        object char_literal218_tree=null;
         RewriteRuleTokenStream stream_55 = new RewriteRuleTokenStream(adaptor,"token 55");
-        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
+        RewriteRuleTokenStream stream_56 = new RewriteRuleTokenStream(adaptor,"token 56");
         RewriteRuleSubtreeStream stream_tikz_options_dontcare = new RewriteRuleSubtreeStream(adaptor,"rule tikz_options_dontcare");
         RewriteRuleSubtreeStream stream_no_rlbracket = new RewriteRuleSubtreeStream(adaptor,"rule no_rlbracket");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:407:2: ( '[' ( no_rlbracket )* ( tikz_options_dontcare ( no_rlbracket )* )* ']' -> ^( IM_OPTIONS ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:407:4: '[' ( no_rlbracket )* ( tikz_options_dontcare ( no_rlbracket )* )* ']'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:2: ( '[' ( no_rlbracket )* ( tikz_options_dontcare ( no_rlbracket )* )* ']' -> ^( IM_OPTIONS ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:4: '[' ( no_rlbracket )* ( tikz_options_dontcare ( no_rlbracket )* )* ']'
             {
-            	char_literal211=(IToken)Match(input,54,FOLLOW_54_in_tikz_options_dontcare2490); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_54.Add(char_literal211);
+            	char_literal214=(IToken)Match(input,55,FOLLOW_55_in_tikz_options_dontcare2501); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_55.Add(char_literal214);
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:407:8: ( no_rlbracket )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:8: ( no_rlbracket )*
             	do 
             	{
             	    int alt53 = 2;
             	    int LA53_0 = input.LA(1);
 
-            	    if ( ((LA53_0 >= IM_PATH && LA53_0 <= 53) || (LA53_0 >= 56 && LA53_0 <= 94)) )
+            	    if ( ((LA53_0 >= IM_PATH && LA53_0 <= 54) || (LA53_0 >= 57 && LA53_0 <= 95)) )
             	    {
             	        alt53 = 1;
             	    }
@@ -7170,13 +7222,13 @@ public partial class simpletikzParser : Parser
             	    switch (alt53) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:407:8: no_rlbracket
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:8: no_rlbracket
             			    {
-            			    	PushFollow(FOLLOW_no_rlbracket_in_tikz_options_dontcare2492);
-            			    	no_rlbracket212 = no_rlbracket();
+            			    	PushFollow(FOLLOW_no_rlbracket_in_tikz_options_dontcare2503);
+            			    	no_rlbracket215 = no_rlbracket();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_no_rlbracket.Add(no_rlbracket212.Tree);
+            			    	if ( state.backtracking==0 ) stream_no_rlbracket.Add(no_rlbracket215.Tree);
 
             			    }
             			    break;
@@ -7189,13 +7241,13 @@ public partial class simpletikzParser : Parser
             	loop53:
             		;	// Stops C# compiler whining that label 'loop53' has no statements
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:407:22: ( tikz_options_dontcare ( no_rlbracket )* )*
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:22: ( tikz_options_dontcare ( no_rlbracket )* )*
             	do 
             	{
             	    int alt55 = 2;
             	    int LA55_0 = input.LA(1);
 
-            	    if ( (LA55_0 == 54) )
+            	    if ( (LA55_0 == 55) )
             	    {
             	        alt55 = 1;
             	    }
@@ -7204,20 +7256,20 @@ public partial class simpletikzParser : Parser
             	    switch (alt55) 
             		{
             			case 1 :
-            			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:407:23: tikz_options_dontcare ( no_rlbracket )*
+            			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:23: tikz_options_dontcare ( no_rlbracket )*
             			    {
-            			    	PushFollow(FOLLOW_tikz_options_dontcare_in_tikz_options_dontcare2496);
-            			    	tikz_options_dontcare213 = tikz_options_dontcare();
+            			    	PushFollow(FOLLOW_tikz_options_dontcare_in_tikz_options_dontcare2507);
+            			    	tikz_options_dontcare216 = tikz_options_dontcare();
             			    	state.followingStackPointer--;
             			    	if (state.failed) return retval;
-            			    	if ( state.backtracking==0 ) stream_tikz_options_dontcare.Add(tikz_options_dontcare213.Tree);
-            			    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:407:45: ( no_rlbracket )*
+            			    	if ( state.backtracking==0 ) stream_tikz_options_dontcare.Add(tikz_options_dontcare216.Tree);
+            			    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:45: ( no_rlbracket )*
             			    	do 
             			    	{
             			    	    int alt54 = 2;
             			    	    int LA54_0 = input.LA(1);
 
-            			    	    if ( ((LA54_0 >= IM_PATH && LA54_0 <= 53) || (LA54_0 >= 56 && LA54_0 <= 94)) )
+            			    	    if ( ((LA54_0 >= IM_PATH && LA54_0 <= 54) || (LA54_0 >= 57 && LA54_0 <= 95)) )
             			    	    {
             			    	        alt54 = 1;
             			    	    }
@@ -7226,13 +7278,13 @@ public partial class simpletikzParser : Parser
             			    	    switch (alt54) 
             			    		{
             			    			case 1 :
-            			    			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:407:45: no_rlbracket
+            			    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:45: no_rlbracket
             			    			    {
-            			    			    	PushFollow(FOLLOW_no_rlbracket_in_tikz_options_dontcare2498);
-            			    			    	no_rlbracket214 = no_rlbracket();
+            			    			    	PushFollow(FOLLOW_no_rlbracket_in_tikz_options_dontcare2509);
+            			    			    	no_rlbracket217 = no_rlbracket();
             			    			    	state.followingStackPointer--;
             			    			    	if (state.failed) return retval;
-            			    			    	if ( state.backtracking==0 ) stream_no_rlbracket.Add(no_rlbracket214.Tree);
+            			    			    	if ( state.backtracking==0 ) stream_no_rlbracket.Add(no_rlbracket217.Tree);
 
             			    			    }
             			    			    break;
@@ -7257,8 +7309,8 @@ public partial class simpletikzParser : Parser
             	loop55:
             		;	// Stops C# compiler whining that label 'loop55' has no statements
 
-            	char_literal215=(IToken)Match(input,55,FOLLOW_55_in_tikz_options_dontcare2503); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_55.Add(char_literal215);
+            	char_literal218=(IToken)Match(input,56,FOLLOW_56_in_tikz_options_dontcare2514); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_56.Add(char_literal218);
 
 
 
@@ -7275,7 +7327,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 407:65: -> ^( IM_OPTIONS )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:407:68: ^( IM_OPTIONS )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:407:68: ^( IM_OPTIONS )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_OPTIONS, "IM_OPTIONS"), root_1);
@@ -7316,7 +7368,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "no_rlbracket"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:409:1: no_rlbracket : ~ ( '[' | ']' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:409:1: no_rlbracket : ~ ( '[' | ']' ) ;
     public simpletikzParser.no_rlbracket_return no_rlbracket() // throws RecognitionException [1]
     {   
         simpletikzParser.no_rlbracket_return retval = new simpletikzParser.no_rlbracket_return();
@@ -7324,22 +7376,22 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set216 = null;
+        IToken set219 = null;
 
-        object set216_tree=null;
+        object set219_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:410:2: (~ ( '[' | ']' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:410:4: ~ ( '[' | ']' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:410:2: (~ ( '[' | ']' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:410:4: ~ ( '[' | ']' )
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set216 = (IToken)input.LT(1);
-            	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= 53) || (input.LA(1) >= 56 && input.LA(1) <= 94) ) 
+            	set219 = (IToken)input.LT(1);
+            	if ( (input.LA(1) >= IM_PATH && input.LA(1) <= 54) || (input.LA(1) >= 57 && input.LA(1) <= 95) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set216));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set219));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -7380,7 +7432,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "nodename"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:412:1: nodename : '(' idd ')' -> ^( IM_NODENAME idd ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:412:1: nodename : '(' idd ')' -> ^( IM_NODENAME idd ) ;
     public simpletikzParser.nodename_return nodename() // throws RecognitionException [1]
     {   
         simpletikzParser.nodename_return retval = new simpletikzParser.nodename_return();
@@ -7388,31 +7440,31 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal217 = null;
-        IToken char_literal219 = null;
-        simpletikzParser.idd_return idd218 = default(simpletikzParser.idd_return);
+        IToken char_literal220 = null;
+        IToken char_literal222 = null;
+        simpletikzParser.idd_return idd221 = default(simpletikzParser.idd_return);
 
 
-        object char_literal217_tree=null;
-        object char_literal219_tree=null;
-        RewriteRuleTokenStream stream_52 = new RewriteRuleTokenStream(adaptor,"token 52");
+        object char_literal220_tree=null;
+        object char_literal222_tree=null;
         RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
+        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
         RewriteRuleSubtreeStream stream_idd = new RewriteRuleSubtreeStream(adaptor,"rule idd");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:413:2: ( '(' idd ')' -> ^( IM_NODENAME idd ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:413:4: '(' idd ')'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:413:2: ( '(' idd ')' -> ^( IM_NODENAME idd ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:413:4: '(' idd ')'
             {
-            	char_literal217=(IToken)Match(input,52,FOLLOW_52_in_nodename2538); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_52.Add(char_literal217);
+            	char_literal220=(IToken)Match(input,53,FOLLOW_53_in_nodename2549); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_53.Add(char_literal220);
 
-            	PushFollow(FOLLOW_idd_in_nodename2540);
-            	idd218 = idd();
+            	PushFollow(FOLLOW_idd_in_nodename2551);
+            	idd221 = idd();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_idd.Add(idd218.Tree);
-            	char_literal219=(IToken)Match(input,53,FOLLOW_53_in_nodename2542); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_53.Add(char_literal219);
+            	if ( state.backtracking==0 ) stream_idd.Add(idd221.Tree);
+            	char_literal222=(IToken)Match(input,54,FOLLOW_54_in_nodename2553); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_54.Add(char_literal222);
 
 
 
@@ -7429,7 +7481,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 413:17: -> ^( IM_NODENAME idd )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:413:20: ^( IM_NODENAME idd )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:413:20: ^( IM_NODENAME idd )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_NODENAME, "IM_NODENAME"), root_1);
@@ -7472,7 +7524,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "circle"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:419:1: circle : ( 'circle' | 'ellipse' ) ( ( size )=> size )? ->;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:419:1: circle : ( 'circle' | 'ellipse' ) ( ( size )=> size )? ->;
     public simpletikzParser.circle_return circle() // throws RecognitionException [1]
     {   
         simpletikzParser.circle_return retval = new simpletikzParser.circle_return();
@@ -7480,30 +7532,30 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal220 = null;
-        IToken string_literal221 = null;
-        simpletikzParser.size_return size222 = default(simpletikzParser.size_return);
+        IToken string_literal223 = null;
+        IToken string_literal224 = null;
+        simpletikzParser.size_return size225 = default(simpletikzParser.size_return);
 
 
-        object string_literal220_tree=null;
-        object string_literal221_tree=null;
-        RewriteRuleTokenStream stream_82 = new RewriteRuleTokenStream(adaptor,"token 82");
+        object string_literal223_tree=null;
+        object string_literal224_tree=null;
         RewriteRuleTokenStream stream_83 = new RewriteRuleTokenStream(adaptor,"token 83");
+        RewriteRuleTokenStream stream_84 = new RewriteRuleTokenStream(adaptor,"token 84");
         RewriteRuleSubtreeStream stream_size = new RewriteRuleSubtreeStream(adaptor,"rule size");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:420:2: ( ( 'circle' | 'ellipse' ) ( ( size )=> size )? ->)
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:420:4: ( 'circle' | 'ellipse' ) ( ( size )=> size )?
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:2: ( ( 'circle' | 'ellipse' ) ( ( size )=> size )? ->)
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:4: ( 'circle' | 'ellipse' ) ( ( size )=> size )?
             {
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:420:4: ( 'circle' | 'ellipse' )
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:4: ( 'circle' | 'ellipse' )
             	int alt56 = 2;
             	int LA56_0 = input.LA(1);
 
-            	if ( (LA56_0 == 82) )
+            	if ( (LA56_0 == 83) )
             	{
             	    alt56 = 1;
             	}
-            	else if ( (LA56_0 == 83) )
+            	else if ( (LA56_0 == 84) )
             	{
             	    alt56 = 2;
             	}
@@ -7518,19 +7570,19 @@ public partial class simpletikzParser : Parser
             	switch (alt56) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:420:5: 'circle'
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:5: 'circle'
             	        {
-            	        	string_literal220=(IToken)Match(input,82,FOLLOW_82_in_circle2567); if (state.failed) return retval; 
-            	        	if ( state.backtracking==0 ) stream_82.Add(string_literal220);
+            	        	string_literal223=(IToken)Match(input,83,FOLLOW_83_in_circle2578); if (state.failed) return retval; 
+            	        	if ( state.backtracking==0 ) stream_83.Add(string_literal223);
 
 
             	        }
             	        break;
             	    case 2 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:420:16: 'ellipse'
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:16: 'ellipse'
             	        {
-            	        	string_literal221=(IToken)Match(input,83,FOLLOW_83_in_circle2571); if (state.failed) return retval; 
-            	        	if ( state.backtracking==0 ) stream_83.Add(string_literal221);
+            	        	string_literal224=(IToken)Match(input,84,FOLLOW_84_in_circle2582); if (state.failed) return retval; 
+            	        	if ( state.backtracking==0 ) stream_84.Add(string_literal224);
 
 
             	        }
@@ -7538,19 +7590,19 @@ public partial class simpletikzParser : Parser
 
             	}
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:420:27: ( ( size )=> size )?
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:27: ( ( size )=> size )?
             	int alt57 = 2;
             	alt57 = dfa57.Predict(input);
             	switch (alt57) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:420:28: ( size )=> size
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:28: ( size )=> size
             	        {
-            	        	PushFollow(FOLLOW_size_in_circle2580);
-            	        	size222 = size();
+            	        	PushFollow(FOLLOW_size_in_circle2591);
+            	        	size225 = size();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_size.Add(size222.Tree);
+            	        	if ( state.backtracking==0 ) stream_size.Add(size225.Tree);
 
             	        }
             	        break;
@@ -7606,7 +7658,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "arc"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:422:1: arc : ( 'arc' ( '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')' ) -> ^( IM_ARC ( numberunitorvariable )+ ( numberunit )? ) | 'arc' ( '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')' ) -> ^( IM_ARC ( coord_part )+ ( numberunit )? ) | 'arc' tikz_options -> ^( IM_DONTCARE ) );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:422:1: arc : ( 'arc' ( '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')' ) -> ^( IM_ARC ( numberunitorvariable )+ ( numberunit )? ) | 'arc' ( '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')' ) -> ^( IM_ARC ( coord_part )+ ( numberunit )? ) | 'arc' tikz_options -> ^( IM_DONTCARE ) );
     public simpletikzParser.arc_return arc() // throws RecognitionException [1]
     {   
         simpletikzParser.arc_return retval = new simpletikzParser.arc_return();
@@ -7614,129 +7666,129 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal223 = null;
-        IToken char_literal224 = null;
-        IToken char_literal226 = null;
-        IToken char_literal228 = null;
-        IToken string_literal230 = null;
-        IToken char_literal232 = null;
+        IToken string_literal226 = null;
+        IToken char_literal227 = null;
+        IToken char_literal229 = null;
+        IToken char_literal231 = null;
         IToken string_literal233 = null;
-        IToken char_literal234 = null;
-        IToken char_literal236 = null;
-        IToken char_literal238 = null;
-        IToken string_literal240 = null;
-        IToken char_literal242 = null;
+        IToken char_literal235 = null;
+        IToken string_literal236 = null;
+        IToken char_literal237 = null;
+        IToken char_literal239 = null;
+        IToken char_literal241 = null;
         IToken string_literal243 = null;
-        simpletikzParser.numberunitorvariable_return numberunitorvariable225 = default(simpletikzParser.numberunitorvariable_return);
+        IToken char_literal245 = null;
+        IToken string_literal246 = null;
+        simpletikzParser.numberunitorvariable_return numberunitorvariable228 = default(simpletikzParser.numberunitorvariable_return);
 
-        simpletikzParser.numberunitorvariable_return numberunitorvariable227 = default(simpletikzParser.numberunitorvariable_return);
+        simpletikzParser.numberunitorvariable_return numberunitorvariable230 = default(simpletikzParser.numberunitorvariable_return);
 
-        simpletikzParser.numberunitorvariable_return numberunitorvariable229 = default(simpletikzParser.numberunitorvariable_return);
+        simpletikzParser.numberunitorvariable_return numberunitorvariable232 = default(simpletikzParser.numberunitorvariable_return);
 
-        simpletikzParser.numberunit_return numberunit231 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit234 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.coord_part_return coord_part235 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part238 = default(simpletikzParser.coord_part_return);
 
-        simpletikzParser.coord_part_return coord_part237 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part240 = default(simpletikzParser.coord_part_return);
 
-        simpletikzParser.coord_part_return coord_part239 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part242 = default(simpletikzParser.coord_part_return);
 
-        simpletikzParser.numberunit_return numberunit241 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit244 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.tikz_options_return tikz_options244 = default(simpletikzParser.tikz_options_return);
+        simpletikzParser.tikz_options_return tikz_options247 = default(simpletikzParser.tikz_options_return);
 
 
-        object string_literal223_tree=null;
-        object char_literal224_tree=null;
-        object char_literal226_tree=null;
-        object char_literal228_tree=null;
-        object string_literal230_tree=null;
-        object char_literal232_tree=null;
+        object string_literal226_tree=null;
+        object char_literal227_tree=null;
+        object char_literal229_tree=null;
+        object char_literal231_tree=null;
         object string_literal233_tree=null;
-        object char_literal234_tree=null;
-        object char_literal236_tree=null;
-        object char_literal238_tree=null;
-        object string_literal240_tree=null;
-        object char_literal242_tree=null;
+        object char_literal235_tree=null;
+        object string_literal236_tree=null;
+        object char_literal237_tree=null;
+        object char_literal239_tree=null;
+        object char_literal241_tree=null;
         object string_literal243_tree=null;
+        object char_literal245_tree=null;
+        object string_literal246_tree=null;
+        RewriteRuleTokenStream stream_79 = new RewriteRuleTokenStream(adaptor,"token 79");
         RewriteRuleTokenStream stream_48 = new RewriteRuleTokenStream(adaptor,"token 48");
-        RewriteRuleTokenStream stream_78 = new RewriteRuleTokenStream(adaptor,"token 78");
-        RewriteRuleTokenStream stream_52 = new RewriteRuleTokenStream(adaptor,"token 52");
+        RewriteRuleTokenStream stream_85 = new RewriteRuleTokenStream(adaptor,"token 85");
         RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
-        RewriteRuleTokenStream stream_84 = new RewriteRuleTokenStream(adaptor,"token 84");
-        RewriteRuleSubtreeStream stream_numberunit = new RewriteRuleSubtreeStream(adaptor,"rule numberunit");
+        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
         RewriteRuleSubtreeStream stream_numberunitorvariable = new RewriteRuleSubtreeStream(adaptor,"rule numberunitorvariable");
         RewriteRuleSubtreeStream stream_coord_part = new RewriteRuleSubtreeStream(adaptor,"rule coord_part");
         RewriteRuleSubtreeStream stream_tikz_options = new RewriteRuleSubtreeStream(adaptor,"rule tikz_options");
+        RewriteRuleSubtreeStream stream_numberunit = new RewriteRuleSubtreeStream(adaptor,"rule numberunit");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:423:2: ( 'arc' ( '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')' ) -> ^( IM_ARC ( numberunitorvariable )+ ( numberunit )? ) | 'arc' ( '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')' ) -> ^( IM_ARC ( coord_part )+ ( numberunit )? ) | 'arc' tikz_options -> ^( IM_DONTCARE ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:2: ( 'arc' ( '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')' ) -> ^( IM_ARC ( numberunitorvariable )+ ( numberunit )? ) | 'arc' ( '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')' ) -> ^( IM_ARC ( coord_part )+ ( numberunit )? ) | 'arc' tikz_options -> ^( IM_DONTCARE ) )
             int alt60 = 3;
             alt60 = dfa60.Predict(input);
             switch (alt60) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:423:4: 'arc' ( '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')' )
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:4: 'arc' ( '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')' )
                     {
-                    	string_literal223=(IToken)Match(input,84,FOLLOW_84_in_arc2595); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_84.Add(string_literal223);
+                    	string_literal226=(IToken)Match(input,85,FOLLOW_85_in_arc2606); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_85.Add(string_literal226);
 
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:423:10: ( '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')' )
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:423:11: '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')'
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:10: ( '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')' )
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:11: '(' numberunitorvariable ':' numberunitorvariable ':' numberunitorvariable ( 'and' numberunit )? ')'
                     	{
-                    		char_literal224=(IToken)Match(input,52,FOLLOW_52_in_arc2598); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_52.Add(char_literal224);
+                    		char_literal227=(IToken)Match(input,53,FOLLOW_53_in_arc2609); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_53.Add(char_literal227);
 
-                    		PushFollow(FOLLOW_numberunitorvariable_in_arc2600);
-                    		numberunitorvariable225 = numberunitorvariable();
+                    		PushFollow(FOLLOW_numberunitorvariable_in_arc2611);
+                    		numberunitorvariable228 = numberunitorvariable();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunitorvariable.Add(numberunitorvariable225.Tree);
-                    		char_literal226=(IToken)Match(input,48,FOLLOW_48_in_arc2602); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_48.Add(char_literal226);
+                    		if ( state.backtracking==0 ) stream_numberunitorvariable.Add(numberunitorvariable228.Tree);
+                    		char_literal229=(IToken)Match(input,48,FOLLOW_48_in_arc2613); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_48.Add(char_literal229);
 
-                    		PushFollow(FOLLOW_numberunitorvariable_in_arc2604);
-                    		numberunitorvariable227 = numberunitorvariable();
+                    		PushFollow(FOLLOW_numberunitorvariable_in_arc2615);
+                    		numberunitorvariable230 = numberunitorvariable();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunitorvariable.Add(numberunitorvariable227.Tree);
-                    		char_literal228=(IToken)Match(input,48,FOLLOW_48_in_arc2606); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_48.Add(char_literal228);
+                    		if ( state.backtracking==0 ) stream_numberunitorvariable.Add(numberunitorvariable230.Tree);
+                    		char_literal231=(IToken)Match(input,48,FOLLOW_48_in_arc2617); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_48.Add(char_literal231);
 
-                    		PushFollow(FOLLOW_numberunitorvariable_in_arc2608);
-                    		numberunitorvariable229 = numberunitorvariable();
+                    		PushFollow(FOLLOW_numberunitorvariable_in_arc2619);
+                    		numberunitorvariable232 = numberunitorvariable();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunitorvariable.Add(numberunitorvariable229.Tree);
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:423:86: ( 'and' numberunit )?
+                    		if ( state.backtracking==0 ) stream_numberunitorvariable.Add(numberunitorvariable232.Tree);
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:86: ( 'and' numberunit )?
                     		int alt58 = 2;
                     		int LA58_0 = input.LA(1);
 
-                    		if ( (LA58_0 == 78) )
+                    		if ( (LA58_0 == 79) )
                     		{
                     		    alt58 = 1;
                     		}
                     		switch (alt58) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:423:87: 'and' numberunit
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:87: 'and' numberunit
                     		        {
-                    		        	string_literal230=(IToken)Match(input,78,FOLLOW_78_in_arc2611); if (state.failed) return retval; 
-                    		        	if ( state.backtracking==0 ) stream_78.Add(string_literal230);
+                    		        	string_literal233=(IToken)Match(input,79,FOLLOW_79_in_arc2622); if (state.failed) return retval; 
+                    		        	if ( state.backtracking==0 ) stream_79.Add(string_literal233);
 
-                    		        	PushFollow(FOLLOW_numberunit_in_arc2613);
-                    		        	numberunit231 = numberunit();
+                    		        	PushFollow(FOLLOW_numberunit_in_arc2624);
+                    		        	numberunit234 = numberunit();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit231.Tree);
+                    		        	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit234.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal232=(IToken)Match(input,53,FOLLOW_53_in_arc2617); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal232);
+                    		char_literal235=(IToken)Match(input,54,FOLLOW_54_in_arc2628); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_54.Add(char_literal235);
 
 
                     	}
@@ -7744,7 +7796,7 @@ public partial class simpletikzParser : Parser
 
 
                     	// AST REWRITE
-                    	// elements:          numberunitorvariable, numberunit
+                    	// elements:          numberunit, numberunitorvariable
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -7756,7 +7808,7 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 423:111: -> ^( IM_ARC ( numberunitorvariable )+ ( numberunit )? )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:423:114: ^( IM_ARC ( numberunitorvariable )+ ( numberunit )? )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:114: ^( IM_ARC ( numberunitorvariable )+ ( numberunit )? )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ARC, "IM_ARC"), root_1);
@@ -7770,7 +7822,7 @@ public partial class simpletikzParser : Parser
 
                     	    }
                     	    stream_numberunitorvariable.Reset();
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:423:145: ( numberunit )?
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:423:145: ( numberunit )?
                     	    if ( stream_numberunit.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_numberunit.NextTree());
@@ -7787,67 +7839,67 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:424:4: 'arc' ( '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')' )
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:424:4: 'arc' ( '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')' )
                     {
-                    	string_literal233=(IToken)Match(input,84,FOLLOW_84_in_arc2635); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_84.Add(string_literal233);
+                    	string_literal236=(IToken)Match(input,85,FOLLOW_85_in_arc2646); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_85.Add(string_literal236);
 
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:424:10: ( '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')' )
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:424:11: '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')'
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:424:10: ( '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')' )
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:424:11: '(' coord_part ':' coord_part ':' coord_part ( 'and' numberunit )? ')'
                     	{
-                    		char_literal234=(IToken)Match(input,52,FOLLOW_52_in_arc2638); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_52.Add(char_literal234);
+                    		char_literal237=(IToken)Match(input,53,FOLLOW_53_in_arc2649); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_53.Add(char_literal237);
 
-                    		PushFollow(FOLLOW_coord_part_in_arc2640);
-                    		coord_part235 = coord_part();
+                    		PushFollow(FOLLOW_coord_part_in_arc2651);
+                    		coord_part238 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part235.Tree);
-                    		char_literal236=(IToken)Match(input,48,FOLLOW_48_in_arc2642); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_48.Add(char_literal236);
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part238.Tree);
+                    		char_literal239=(IToken)Match(input,48,FOLLOW_48_in_arc2653); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_48.Add(char_literal239);
 
-                    		PushFollow(FOLLOW_coord_part_in_arc2644);
-                    		coord_part237 = coord_part();
+                    		PushFollow(FOLLOW_coord_part_in_arc2655);
+                    		coord_part240 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part237.Tree);
-                    		char_literal238=(IToken)Match(input,48,FOLLOW_48_in_arc2646); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_48.Add(char_literal238);
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part240.Tree);
+                    		char_literal241=(IToken)Match(input,48,FOLLOW_48_in_arc2657); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_48.Add(char_literal241);
 
-                    		PushFollow(FOLLOW_coord_part_in_arc2648);
-                    		coord_part239 = coord_part();
+                    		PushFollow(FOLLOW_coord_part_in_arc2659);
+                    		coord_part242 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part239.Tree);
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:424:56: ( 'and' numberunit )?
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part242.Tree);
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:424:56: ( 'and' numberunit )?
                     		int alt59 = 2;
                     		int LA59_0 = input.LA(1);
 
-                    		if ( (LA59_0 == 78) )
+                    		if ( (LA59_0 == 79) )
                     		{
                     		    alt59 = 1;
                     		}
                     		switch (alt59) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:424:57: 'and' numberunit
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:424:57: 'and' numberunit
                     		        {
-                    		        	string_literal240=(IToken)Match(input,78,FOLLOW_78_in_arc2651); if (state.failed) return retval; 
-                    		        	if ( state.backtracking==0 ) stream_78.Add(string_literal240);
+                    		        	string_literal243=(IToken)Match(input,79,FOLLOW_79_in_arc2662); if (state.failed) return retval; 
+                    		        	if ( state.backtracking==0 ) stream_79.Add(string_literal243);
 
-                    		        	PushFollow(FOLLOW_numberunit_in_arc2653);
-                    		        	numberunit241 = numberunit();
+                    		        	PushFollow(FOLLOW_numberunit_in_arc2664);
+                    		        	numberunit244 = numberunit();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit241.Tree);
+                    		        	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit244.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal242=(IToken)Match(input,53,FOLLOW_53_in_arc2657); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal242);
+                    		char_literal245=(IToken)Match(input,54,FOLLOW_54_in_arc2668); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_54.Add(char_literal245);
 
 
                     	}
@@ -7855,7 +7907,7 @@ public partial class simpletikzParser : Parser
 
 
                     	// AST REWRITE
-                    	// elements:          numberunit, coord_part
+                    	// elements:          coord_part, numberunit
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -7867,7 +7919,7 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 424:81: -> ^( IM_ARC ( coord_part )+ ( numberunit )? )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:424:84: ^( IM_ARC ( coord_part )+ ( numberunit )? )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:424:84: ^( IM_ARC ( coord_part )+ ( numberunit )? )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ARC, "IM_ARC"), root_1);
@@ -7881,7 +7933,7 @@ public partial class simpletikzParser : Parser
 
                     	    }
                     	    stream_coord_part.Reset();
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:424:105: ( numberunit )?
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:424:105: ( numberunit )?
                     	    if ( stream_numberunit.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_numberunit.NextTree());
@@ -7898,16 +7950,16 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 3 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:425:4: 'arc' tikz_options
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:425:4: 'arc' tikz_options
                     {
-                    	string_literal243=(IToken)Match(input,84,FOLLOW_84_in_arc2675); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_84.Add(string_literal243);
+                    	string_literal246=(IToken)Match(input,85,FOLLOW_85_in_arc2686); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_85.Add(string_literal246);
 
-                    	PushFollow(FOLLOW_tikz_options_in_arc2677);
-                    	tikz_options244 = tikz_options();
+                    	PushFollow(FOLLOW_tikz_options_in_arc2688);
+                    	tikz_options247 = tikz_options();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options244.Tree);
+                    	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options247.Tree);
 
 
                     	// AST REWRITE
@@ -7923,7 +7975,7 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 425:23: -> ^( IM_DONTCARE )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:425:25: ^( IM_DONTCARE )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:425:25: ^( IM_DONTCARE )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_DONTCARE, "IM_DONTCARE"), root_1);
@@ -7966,7 +8018,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "size"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:432:1: size : '(' numberunit ( 'and' numberunit )? ')' -> ^( IM_SIZE ( numberunit )* ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:432:1: size : '(' numberunit ( 'and' numberunit )? ')' -> ^( IM_SIZE ( numberunit )* ) ;
     public simpletikzParser.size_return size() // throws RecognitionException [1]
     {   
         simpletikzParser.size_return retval = new simpletikzParser.size_return();
@@ -7974,63 +8026,63 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal245 = null;
-        IToken string_literal247 = null;
-        IToken char_literal249 = null;
-        simpletikzParser.numberunit_return numberunit246 = default(simpletikzParser.numberunit_return);
+        IToken char_literal248 = null;
+        IToken string_literal250 = null;
+        IToken char_literal252 = null;
+        simpletikzParser.numberunit_return numberunit249 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.numberunit_return numberunit248 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit251 = default(simpletikzParser.numberunit_return);
 
 
-        object char_literal245_tree=null;
-        object string_literal247_tree=null;
-        object char_literal249_tree=null;
-        RewriteRuleTokenStream stream_78 = new RewriteRuleTokenStream(adaptor,"token 78");
-        RewriteRuleTokenStream stream_52 = new RewriteRuleTokenStream(adaptor,"token 52");
+        object char_literal248_tree=null;
+        object string_literal250_tree=null;
+        object char_literal252_tree=null;
+        RewriteRuleTokenStream stream_79 = new RewriteRuleTokenStream(adaptor,"token 79");
         RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
+        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
         RewriteRuleSubtreeStream stream_numberunit = new RewriteRuleSubtreeStream(adaptor,"rule numberunit");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:433:2: ( '(' numberunit ( 'and' numberunit )? ')' -> ^( IM_SIZE ( numberunit )* ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:433:6: '(' numberunit ( 'and' numberunit )? ')'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:433:2: ( '(' numberunit ( 'and' numberunit )? ')' -> ^( IM_SIZE ( numberunit )* ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:433:6: '(' numberunit ( 'and' numberunit )? ')'
             {
-            	char_literal245=(IToken)Match(input,52,FOLLOW_52_in_size2702); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_52.Add(char_literal245);
+            	char_literal248=(IToken)Match(input,53,FOLLOW_53_in_size2713); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_53.Add(char_literal248);
 
-            	PushFollow(FOLLOW_numberunit_in_size2704);
-            	numberunit246 = numberunit();
+            	PushFollow(FOLLOW_numberunit_in_size2715);
+            	numberunit249 = numberunit();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit246.Tree);
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:433:21: ( 'and' numberunit )?
+            	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit249.Tree);
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:433:21: ( 'and' numberunit )?
             	int alt61 = 2;
             	int LA61_0 = input.LA(1);
 
-            	if ( (LA61_0 == 78) )
+            	if ( (LA61_0 == 79) )
             	{
             	    alt61 = 1;
             	}
             	switch (alt61) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:433:22: 'and' numberunit
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:433:22: 'and' numberunit
             	        {
-            	        	string_literal247=(IToken)Match(input,78,FOLLOW_78_in_size2707); if (state.failed) return retval; 
-            	        	if ( state.backtracking==0 ) stream_78.Add(string_literal247);
+            	        	string_literal250=(IToken)Match(input,79,FOLLOW_79_in_size2718); if (state.failed) return retval; 
+            	        	if ( state.backtracking==0 ) stream_79.Add(string_literal250);
 
-            	        	PushFollow(FOLLOW_numberunit_in_size2709);
-            	        	numberunit248 = numberunit();
+            	        	PushFollow(FOLLOW_numberunit_in_size2720);
+            	        	numberunit251 = numberunit();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit248.Tree);
+            	        	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit251.Tree);
 
             	        }
             	        break;
 
             	}
 
-            	char_literal249=(IToken)Match(input,53,FOLLOW_53_in_size2713); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_53.Add(char_literal249);
+            	char_literal252=(IToken)Match(input,54,FOLLOW_54_in_size2724); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_54.Add(char_literal252);
 
 
 
@@ -8047,12 +8099,12 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 433:46: -> ^( IM_SIZE ( numberunit )* )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:433:49: ^( IM_SIZE ( numberunit )* )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:433:49: ^( IM_SIZE ( numberunit )* )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_SIZE, "IM_SIZE"), root_1);
 
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:433:59: ( numberunit )*
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:433:59: ( numberunit )*
             	    while ( stream_numberunit.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_numberunit.NextTree());
@@ -8096,7 +8148,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "coord_nodename"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:440:1: coord_nodename : '(' ( tikz_options )? idd ')' -> ^( IM_NODENAME idd ( tikz_options )? ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:440:1: coord_nodename : '(' ( tikz_options )? idd ')' -> ^( IM_NODENAME idd ( tikz_options )? ) ;
     public simpletikzParser.coord_nodename_return coord_nodename() // throws RecognitionException [1]
     {   
         simpletikzParser.coord_nodename_return retval = new simpletikzParser.coord_nodename_return();
@@ -8104,58 +8156,58 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal250 = null;
         IToken char_literal253 = null;
-        simpletikzParser.tikz_options_return tikz_options251 = default(simpletikzParser.tikz_options_return);
+        IToken char_literal256 = null;
+        simpletikzParser.tikz_options_return tikz_options254 = default(simpletikzParser.tikz_options_return);
 
-        simpletikzParser.idd_return idd252 = default(simpletikzParser.idd_return);
+        simpletikzParser.idd_return idd255 = default(simpletikzParser.idd_return);
 
 
-        object char_literal250_tree=null;
         object char_literal253_tree=null;
-        RewriteRuleTokenStream stream_52 = new RewriteRuleTokenStream(adaptor,"token 52");
+        object char_literal256_tree=null;
         RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
-        RewriteRuleSubtreeStream stream_idd = new RewriteRuleSubtreeStream(adaptor,"rule idd");
+        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
         RewriteRuleSubtreeStream stream_tikz_options = new RewriteRuleSubtreeStream(adaptor,"rule tikz_options");
+        RewriteRuleSubtreeStream stream_idd = new RewriteRuleSubtreeStream(adaptor,"rule idd");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:441:2: ( '(' ( tikz_options )? idd ')' -> ^( IM_NODENAME idd ( tikz_options )? ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:441:4: '(' ( tikz_options )? idd ')'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:441:2: ( '(' ( tikz_options )? idd ')' -> ^( IM_NODENAME idd ( tikz_options )? ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:441:4: '(' ( tikz_options )? idd ')'
             {
-            	char_literal250=(IToken)Match(input,52,FOLLOW_52_in_coord_nodename2741); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_52.Add(char_literal250);
+            	char_literal253=(IToken)Match(input,53,FOLLOW_53_in_coord_nodename2752); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_53.Add(char_literal253);
 
-            	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:441:8: ( tikz_options )?
+            	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:441:8: ( tikz_options )?
             	int alt62 = 2;
             	int LA62_0 = input.LA(1);
 
-            	if ( (LA62_0 == 54) )
+            	if ( (LA62_0 == 55) )
             	{
             	    alt62 = 1;
             	}
             	switch (alt62) 
             	{
             	    case 1 :
-            	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:441:8: tikz_options
+            	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:441:8: tikz_options
             	        {
-            	        	PushFollow(FOLLOW_tikz_options_in_coord_nodename2743);
-            	        	tikz_options251 = tikz_options();
+            	        	PushFollow(FOLLOW_tikz_options_in_coord_nodename2754);
+            	        	tikz_options254 = tikz_options();
             	        	state.followingStackPointer--;
             	        	if (state.failed) return retval;
-            	        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options251.Tree);
+            	        	if ( state.backtracking==0 ) stream_tikz_options.Add(tikz_options254.Tree);
 
             	        }
             	        break;
 
             	}
 
-            	PushFollow(FOLLOW_idd_in_coord_nodename2746);
-            	idd252 = idd();
+            	PushFollow(FOLLOW_idd_in_coord_nodename2757);
+            	idd255 = idd();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_idd.Add(idd252.Tree);
-            	char_literal253=(IToken)Match(input,53,FOLLOW_53_in_coord_nodename2749); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_53.Add(char_literal253);
+            	if ( state.backtracking==0 ) stream_idd.Add(idd255.Tree);
+            	char_literal256=(IToken)Match(input,54,FOLLOW_54_in_coord_nodename2760); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_54.Add(char_literal256);
 
 
 
@@ -8172,13 +8224,13 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 441:32: -> ^( IM_NODENAME idd ( tikz_options )? )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:441:35: ^( IM_NODENAME idd ( tikz_options )? )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:441:35: ^( IM_NODENAME idd ( tikz_options )? )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_NODENAME, "IM_NODENAME"), root_1);
 
             	    adaptor.AddChild(root_1, stream_idd.NextTree());
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:441:53: ( tikz_options )?
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:441:53: ( tikz_options )?
             	    if ( stream_tikz_options.HasNext() )
             	    {
             	        adaptor.AddChild(root_1, stream_tikz_options.NextTree());
@@ -8222,7 +8274,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "coord"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:442:1: coord : ( ( ( coord_modifier )? coord_nodename ) -> ^( IM_COORD ( coord_modifier )? coord_nodename ) | ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' ) -> ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep ) | ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' ) -> ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep ) | ( ( coord_modifier )? '(' ')' ) -> ^( IM_COORD ) );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:442:1: coord : ( ( ( coord_modifier )? coord_nodename ) -> ^( IM_COORD ( coord_modifier )? coord_nodename ) | ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' ) -> ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep ) | ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' ) -> ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep ) | ( ( coord_modifier )? '(' ')' ) -> ^( IM_COORD ) );
     public simpletikzParser.coord_return coord() // throws RecognitionException [1]
     {   
         simpletikzParser.coord_return retval = new simpletikzParser.coord_return();
@@ -8230,90 +8282,90 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal257 = null;
-        IToken char_literal261 = null;
-        IToken char_literal263 = null;
-        IToken char_literal267 = null;
-        IToken char_literal269 = null;
+        IToken char_literal260 = null;
+        IToken char_literal264 = null;
+        IToken char_literal266 = null;
         IToken char_literal270 = null;
-        simpletikzParser.coord_modifier_return coord_modifier254 = default(simpletikzParser.coord_modifier_return);
+        IToken char_literal272 = null;
+        IToken char_literal273 = null;
+        simpletikzParser.coord_modifier_return coord_modifier257 = default(simpletikzParser.coord_modifier_return);
 
-        simpletikzParser.coord_nodename_return coord_nodename255 = default(simpletikzParser.coord_nodename_return);
+        simpletikzParser.coord_nodename_return coord_nodename258 = default(simpletikzParser.coord_nodename_return);
 
-        simpletikzParser.coord_modifier_return coord_modifier256 = default(simpletikzParser.coord_modifier_return);
+        simpletikzParser.coord_modifier_return coord_modifier259 = default(simpletikzParser.coord_modifier_return);
 
-        simpletikzParser.numberunit_return numberunit258 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit261 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.coord_sep_return coord_sep259 = default(simpletikzParser.coord_sep_return);
+        simpletikzParser.coord_sep_return coord_sep262 = default(simpletikzParser.coord_sep_return);
 
-        simpletikzParser.numberunit_return numberunit260 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit263 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.coord_modifier_return coord_modifier262 = default(simpletikzParser.coord_modifier_return);
+        simpletikzParser.coord_modifier_return coord_modifier265 = default(simpletikzParser.coord_modifier_return);
 
-        simpletikzParser.coord_part_return coord_part264 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part267 = default(simpletikzParser.coord_part_return);
 
-        simpletikzParser.coord_sep_return coord_sep265 = default(simpletikzParser.coord_sep_return);
+        simpletikzParser.coord_sep_return coord_sep268 = default(simpletikzParser.coord_sep_return);
 
-        simpletikzParser.coord_part_return coord_part266 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part269 = default(simpletikzParser.coord_part_return);
 
-        simpletikzParser.coord_modifier_return coord_modifier268 = default(simpletikzParser.coord_modifier_return);
+        simpletikzParser.coord_modifier_return coord_modifier271 = default(simpletikzParser.coord_modifier_return);
 
 
-        object char_literal257_tree=null;
-        object char_literal261_tree=null;
-        object char_literal263_tree=null;
-        object char_literal267_tree=null;
-        object char_literal269_tree=null;
+        object char_literal260_tree=null;
+        object char_literal264_tree=null;
+        object char_literal266_tree=null;
         object char_literal270_tree=null;
-        RewriteRuleTokenStream stream_52 = new RewriteRuleTokenStream(adaptor,"token 52");
+        object char_literal272_tree=null;
+        object char_literal273_tree=null;
         RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
-        RewriteRuleSubtreeStream stream_numberunit = new RewriteRuleSubtreeStream(adaptor,"rule numberunit");
-        RewriteRuleSubtreeStream stream_coord_nodename = new RewriteRuleSubtreeStream(adaptor,"rule coord_nodename");
+        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
         RewriteRuleSubtreeStream stream_coord_part = new RewriteRuleSubtreeStream(adaptor,"rule coord_part");
+        RewriteRuleSubtreeStream stream_coord_nodename = new RewriteRuleSubtreeStream(adaptor,"rule coord_nodename");
+        RewriteRuleSubtreeStream stream_numberunit = new RewriteRuleSubtreeStream(adaptor,"rule numberunit");
         RewriteRuleSubtreeStream stream_coord_sep = new RewriteRuleSubtreeStream(adaptor,"rule coord_sep");
         RewriteRuleSubtreeStream stream_coord_modifier = new RewriteRuleSubtreeStream(adaptor,"rule coord_modifier");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:443:2: ( ( ( coord_modifier )? coord_nodename ) -> ^( IM_COORD ( coord_modifier )? coord_nodename ) | ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' ) -> ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep ) | ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' ) -> ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep ) | ( ( coord_modifier )? '(' ')' ) -> ^( IM_COORD ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:2: ( ( ( coord_modifier )? coord_nodename ) -> ^( IM_COORD ( coord_modifier )? coord_nodename ) | ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' ) -> ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep ) | ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' ) -> ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep ) | ( ( coord_modifier )? '(' ')' ) -> ^( IM_COORD ) )
             int alt67 = 4;
             alt67 = dfa67.Predict(input);
             switch (alt67) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:443:6: ( ( coord_modifier )? coord_nodename )
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:6: ( ( coord_modifier )? coord_nodename )
                     {
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:443:6: ( ( coord_modifier )? coord_nodename )
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:443:8: ( coord_modifier )? coord_nodename
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:6: ( ( coord_modifier )? coord_nodename )
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:8: ( coord_modifier )? coord_nodename
                     	{
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:443:8: ( coord_modifier )?
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:8: ( coord_modifier )?
                     		int alt63 = 2;
                     		int LA63_0 = input.LA(1);
 
-                    		if ( ((LA63_0 >= 89 && LA63_0 <= 90)) )
+                    		if ( ((LA63_0 >= 90 && LA63_0 <= 91)) )
                     		{
                     		    alt63 = 1;
                     		}
                     		switch (alt63) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:443:8: coord_modifier
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:8: coord_modifier
                     		        {
-                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2775);
-                    		        	coord_modifier254 = coord_modifier();
+                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2786);
+                    		        	coord_modifier257 = coord_modifier();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier254.Tree);
+                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier257.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		PushFollow(FOLLOW_coord_nodename_in_coord2778);
-                    		coord_nodename255 = coord_nodename();
+                    		PushFollow(FOLLOW_coord_nodename_in_coord2789);
+                    		coord_nodename258 = coord_nodename();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_nodename.Add(coord_nodename255.Tree);
+                    		if ( state.backtracking==0 ) stream_coord_nodename.Add(coord_nodename258.Tree);
 
                     	}
 
@@ -8332,12 +8384,12 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 443:44: -> ^( IM_COORD ( coord_modifier )? coord_nodename )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:443:47: ^( IM_COORD ( coord_modifier )? coord_nodename )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:47: ^( IM_COORD ( coord_modifier )? coord_nodename )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_COORD, "IM_COORD"), root_1);
 
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:443:58: ( coord_modifier )?
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:443:58: ( coord_modifier )?
                     	    if ( stream_coord_modifier.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_coord_modifier.NextTree());
@@ -8355,55 +8407,55 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:444:5: ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' )
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:444:5: ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' )
                     {
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:444:5: ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' )
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:444:7: ( coord_modifier )? '(' numberunit coord_sep numberunit ')'
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:444:5: ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' )
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:444:7: ( coord_modifier )? '(' numberunit coord_sep numberunit ')'
                     	{
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:444:7: ( coord_modifier )?
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:444:7: ( coord_modifier )?
                     		int alt64 = 2;
                     		int LA64_0 = input.LA(1);
 
-                    		if ( ((LA64_0 >= 89 && LA64_0 <= 90)) )
+                    		if ( ((LA64_0 >= 90 && LA64_0 <= 91)) )
                     		{
                     		    alt64 = 1;
                     		}
                     		switch (alt64) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:444:7: coord_modifier
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:444:7: coord_modifier
                     		        {
-                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2804);
-                    		        	coord_modifier256 = coord_modifier();
+                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2815);
+                    		        	coord_modifier259 = coord_modifier();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier256.Tree);
+                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier259.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal257=(IToken)Match(input,52,FOLLOW_52_in_coord2807); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_52.Add(char_literal257);
+                    		char_literal260=(IToken)Match(input,53,FOLLOW_53_in_coord2818); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_53.Add(char_literal260);
 
-                    		PushFollow(FOLLOW_numberunit_in_coord2809);
-                    		numberunit258 = numberunit();
+                    		PushFollow(FOLLOW_numberunit_in_coord2820);
+                    		numberunit261 = numberunit();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit258.Tree);
-                    		PushFollow(FOLLOW_coord_sep_in_coord2811);
-                    		coord_sep259 = coord_sep();
+                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit261.Tree);
+                    		PushFollow(FOLLOW_coord_sep_in_coord2822);
+                    		coord_sep262 = coord_sep();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep259.Tree);
-                    		PushFollow(FOLLOW_numberunit_in_coord2813);
-                    		numberunit260 = numberunit();
+                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep262.Tree);
+                    		PushFollow(FOLLOW_numberunit_in_coord2824);
+                    		numberunit263 = numberunit();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit260.Tree);
-                    		char_literal261=(IToken)Match(input,53,FOLLOW_53_in_coord2815); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal261);
+                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit263.Tree);
+                    		char_literal264=(IToken)Match(input,54,FOLLOW_54_in_coord2826); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_54.Add(char_literal264);
 
 
                     	}
@@ -8423,12 +8475,12 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 444:65: -> ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:444:68: ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:444:68: ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_COORD, "IM_COORD"), root_1);
 
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:444:79: ( coord_modifier )?
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:444:79: ( coord_modifier )?
                     	    if ( stream_coord_modifier.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_coord_modifier.NextTree());
@@ -8455,55 +8507,55 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 3 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:445:5: ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' )
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:445:5: ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' )
                     {
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:445:5: ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' )
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:445:7: ( coord_modifier )? '(' coord_part coord_sep coord_part ')'
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:445:5: ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' )
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:445:7: ( coord_modifier )? '(' coord_part coord_sep coord_part ')'
                     	{
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:445:7: ( coord_modifier )?
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:445:7: ( coord_modifier )?
                     		int alt65 = 2;
                     		int LA65_0 = input.LA(1);
 
-                    		if ( ((LA65_0 >= 89 && LA65_0 <= 90)) )
+                    		if ( ((LA65_0 >= 90 && LA65_0 <= 91)) )
                     		{
                     		    alt65 = 1;
                     		}
                     		switch (alt65) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:445:7: coord_modifier
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:445:7: coord_modifier
                     		        {
-                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2839);
-                    		        	coord_modifier262 = coord_modifier();
+                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2850);
+                    		        	coord_modifier265 = coord_modifier();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier262.Tree);
+                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier265.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal263=(IToken)Match(input,52,FOLLOW_52_in_coord2842); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_52.Add(char_literal263);
+                    		char_literal266=(IToken)Match(input,53,FOLLOW_53_in_coord2853); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_53.Add(char_literal266);
 
-                    		PushFollow(FOLLOW_coord_part_in_coord2844);
-                    		coord_part264 = coord_part();
+                    		PushFollow(FOLLOW_coord_part_in_coord2855);
+                    		coord_part267 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part264.Tree);
-                    		PushFollow(FOLLOW_coord_sep_in_coord2846);
-                    		coord_sep265 = coord_sep();
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part267.Tree);
+                    		PushFollow(FOLLOW_coord_sep_in_coord2857);
+                    		coord_sep268 = coord_sep();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep265.Tree);
-                    		PushFollow(FOLLOW_coord_part_in_coord2848);
-                    		coord_part266 = coord_part();
+                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep268.Tree);
+                    		PushFollow(FOLLOW_coord_part_in_coord2859);
+                    		coord_part269 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part266.Tree);
-                    		char_literal267=(IToken)Match(input,53,FOLLOW_53_in_coord2850); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal267);
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part269.Tree);
+                    		char_literal270=(IToken)Match(input,54,FOLLOW_54_in_coord2861); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_54.Add(char_literal270);
 
 
                     	}
@@ -8511,7 +8563,7 @@ public partial class simpletikzParser : Parser
 
 
                     	// AST REWRITE
-                    	// elements:          coord_modifier, coord_sep, coord_part
+                    	// elements:          coord_sep, coord_modifier, coord_part
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -8523,12 +8575,12 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 445:65: -> ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:445:68: ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:445:68: ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_COORD, "IM_COORD"), root_1);
 
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:445:79: ( coord_modifier )?
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:445:79: ( coord_modifier )?
                     	    if ( stream_coord_modifier.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_coord_modifier.NextTree());
@@ -8555,40 +8607,40 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 4 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:446:5: ( ( coord_modifier )? '(' ')' )
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:446:5: ( ( coord_modifier )? '(' ')' )
                     {
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:446:5: ( ( coord_modifier )? '(' ')' )
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:446:7: ( coord_modifier )? '(' ')'
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:446:5: ( ( coord_modifier )? '(' ')' )
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:446:7: ( coord_modifier )? '(' ')'
                     	{
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:446:7: ( coord_modifier )?
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:446:7: ( coord_modifier )?
                     		int alt66 = 2;
                     		int LA66_0 = input.LA(1);
 
-                    		if ( ((LA66_0 >= 89 && LA66_0 <= 90)) )
+                    		if ( ((LA66_0 >= 90 && LA66_0 <= 91)) )
                     		{
                     		    alt66 = 1;
                     		}
                     		switch (alt66) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:446:7: coord_modifier
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:446:7: coord_modifier
                     		        {
-                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2874);
-                    		        	coord_modifier268 = coord_modifier();
+                    		        	PushFollow(FOLLOW_coord_modifier_in_coord2885);
+                    		        	coord_modifier271 = coord_modifier();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier268.Tree);
+                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier271.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal269=(IToken)Match(input,52,FOLLOW_52_in_coord2877); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_52.Add(char_literal269);
+                    		char_literal272=(IToken)Match(input,53,FOLLOW_53_in_coord2888); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_53.Add(char_literal272);
 
-                    		char_literal270=(IToken)Match(input,53,FOLLOW_53_in_coord2879); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal270);
+                    		char_literal273=(IToken)Match(input,54,FOLLOW_54_in_coord2890); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_54.Add(char_literal273);
 
 
                     	}
@@ -8608,7 +8660,7 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 446:37: -> ^( IM_COORD )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:446:40: ^( IM_COORD )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:446:40: ^( IM_COORD )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_COORD, "IM_COORD"), root_1);
@@ -8651,7 +8703,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "coord_nooption"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:448:1: coord_nooption : ( nodename -> ^( IM_COORD nodename ) | ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' ) -> ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep ) | ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' ) -> ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep ) );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:448:1: coord_nooption : ( nodename -> ^( IM_COORD nodename ) | ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' ) -> ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep ) | ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' ) -> ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep ) );
     public simpletikzParser.coord_nooption_return coord_nooption() // throws RecognitionException [1]
     {   
         simpletikzParser.coord_nooption_return retval = new simpletikzParser.coord_nooption_return();
@@ -8659,55 +8711,55 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal273 = null;
-        IToken char_literal277 = null;
-        IToken char_literal279 = null;
-        IToken char_literal283 = null;
-        simpletikzParser.nodename_return nodename271 = default(simpletikzParser.nodename_return);
+        IToken char_literal276 = null;
+        IToken char_literal280 = null;
+        IToken char_literal282 = null;
+        IToken char_literal286 = null;
+        simpletikzParser.nodename_return nodename274 = default(simpletikzParser.nodename_return);
 
-        simpletikzParser.coord_modifier_return coord_modifier272 = default(simpletikzParser.coord_modifier_return);
+        simpletikzParser.coord_modifier_return coord_modifier275 = default(simpletikzParser.coord_modifier_return);
 
-        simpletikzParser.numberunit_return numberunit274 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit277 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.coord_sep_return coord_sep275 = default(simpletikzParser.coord_sep_return);
+        simpletikzParser.coord_sep_return coord_sep278 = default(simpletikzParser.coord_sep_return);
 
-        simpletikzParser.numberunit_return numberunit276 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit279 = default(simpletikzParser.numberunit_return);
 
-        simpletikzParser.coord_modifier_return coord_modifier278 = default(simpletikzParser.coord_modifier_return);
+        simpletikzParser.coord_modifier_return coord_modifier281 = default(simpletikzParser.coord_modifier_return);
 
-        simpletikzParser.coord_part_return coord_part280 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part283 = default(simpletikzParser.coord_part_return);
 
-        simpletikzParser.coord_sep_return coord_sep281 = default(simpletikzParser.coord_sep_return);
+        simpletikzParser.coord_sep_return coord_sep284 = default(simpletikzParser.coord_sep_return);
 
-        simpletikzParser.coord_part_return coord_part282 = default(simpletikzParser.coord_part_return);
+        simpletikzParser.coord_part_return coord_part285 = default(simpletikzParser.coord_part_return);
 
 
-        object char_literal273_tree=null;
-        object char_literal277_tree=null;
-        object char_literal279_tree=null;
-        object char_literal283_tree=null;
-        RewriteRuleTokenStream stream_52 = new RewriteRuleTokenStream(adaptor,"token 52");
+        object char_literal276_tree=null;
+        object char_literal280_tree=null;
+        object char_literal282_tree=null;
+        object char_literal286_tree=null;
         RewriteRuleTokenStream stream_53 = new RewriteRuleTokenStream(adaptor,"token 53");
-        RewriteRuleSubtreeStream stream_numberunit = new RewriteRuleSubtreeStream(adaptor,"rule numberunit");
-        RewriteRuleSubtreeStream stream_coord_part = new RewriteRuleSubtreeStream(adaptor,"rule coord_part");
-        RewriteRuleSubtreeStream stream_coord_sep = new RewriteRuleSubtreeStream(adaptor,"rule coord_sep");
+        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
         RewriteRuleSubtreeStream stream_nodename = new RewriteRuleSubtreeStream(adaptor,"rule nodename");
+        RewriteRuleSubtreeStream stream_coord_part = new RewriteRuleSubtreeStream(adaptor,"rule coord_part");
+        RewriteRuleSubtreeStream stream_numberunit = new RewriteRuleSubtreeStream(adaptor,"rule numberunit");
+        RewriteRuleSubtreeStream stream_coord_sep = new RewriteRuleSubtreeStream(adaptor,"rule coord_sep");
         RewriteRuleSubtreeStream stream_coord_modifier = new RewriteRuleSubtreeStream(adaptor,"rule coord_modifier");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:449:2: ( nodename -> ^( IM_COORD nodename ) | ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' ) -> ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep ) | ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' ) -> ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:449:2: ( nodename -> ^( IM_COORD nodename ) | ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' ) -> ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep ) | ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' ) -> ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep ) )
             int alt70 = 3;
             alt70 = dfa70.Predict(input);
             switch (alt70) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:449:6: nodename
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:449:6: nodename
                     {
-                    	PushFollow(FOLLOW_nodename_in_coord_nooption2907);
-                    	nodename271 = nodename();
+                    	PushFollow(FOLLOW_nodename_in_coord_nooption2918);
+                    	nodename274 = nodename();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_nodename.Add(nodename271.Tree);
+                    	if ( state.backtracking==0 ) stream_nodename.Add(nodename274.Tree);
 
 
                     	// AST REWRITE
@@ -8723,7 +8775,7 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 449:22: -> ^( IM_COORD nodename )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:449:25: ^( IM_COORD nodename )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:449:25: ^( IM_COORD nodename )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_COORD, "IM_COORD"), root_1);
@@ -8739,55 +8791,55 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:450:5: ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' )
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:450:5: ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' )
                     {
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:450:5: ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' )
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:450:7: ( coord_modifier )? '(' numberunit coord_sep numberunit ')'
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:450:5: ( ( coord_modifier )? '(' numberunit coord_sep numberunit ')' )
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:450:7: ( coord_modifier )? '(' numberunit coord_sep numberunit ')'
                     	{
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:450:7: ( coord_modifier )?
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:450:7: ( coord_modifier )?
                     		int alt68 = 2;
                     		int LA68_0 = input.LA(1);
 
-                    		if ( ((LA68_0 >= 89 && LA68_0 <= 90)) )
+                    		if ( ((LA68_0 >= 90 && LA68_0 <= 91)) )
                     		{
                     		    alt68 = 1;
                     		}
                     		switch (alt68) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:450:7: coord_modifier
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:450:7: coord_modifier
                     		        {
-                    		        	PushFollow(FOLLOW_coord_modifier_in_coord_nooption2931);
-                    		        	coord_modifier272 = coord_modifier();
+                    		        	PushFollow(FOLLOW_coord_modifier_in_coord_nooption2942);
+                    		        	coord_modifier275 = coord_modifier();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier272.Tree);
+                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier275.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal273=(IToken)Match(input,52,FOLLOW_52_in_coord_nooption2934); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_52.Add(char_literal273);
+                    		char_literal276=(IToken)Match(input,53,FOLLOW_53_in_coord_nooption2945); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_53.Add(char_literal276);
 
-                    		PushFollow(FOLLOW_numberunit_in_coord_nooption2936);
-                    		numberunit274 = numberunit();
+                    		PushFollow(FOLLOW_numberunit_in_coord_nooption2947);
+                    		numberunit277 = numberunit();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit274.Tree);
-                    		PushFollow(FOLLOW_coord_sep_in_coord_nooption2938);
-                    		coord_sep275 = coord_sep();
+                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit277.Tree);
+                    		PushFollow(FOLLOW_coord_sep_in_coord_nooption2949);
+                    		coord_sep278 = coord_sep();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep275.Tree);
-                    		PushFollow(FOLLOW_numberunit_in_coord_nooption2940);
-                    		numberunit276 = numberunit();
+                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep278.Tree);
+                    		PushFollow(FOLLOW_numberunit_in_coord_nooption2951);
+                    		numberunit279 = numberunit();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit276.Tree);
-                    		char_literal277=(IToken)Match(input,53,FOLLOW_53_in_coord_nooption2942); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal277);
+                    		if ( state.backtracking==0 ) stream_numberunit.Add(numberunit279.Tree);
+                    		char_literal280=(IToken)Match(input,54,FOLLOW_54_in_coord_nooption2953); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_54.Add(char_literal280);
 
 
                     	}
@@ -8795,7 +8847,7 @@ public partial class simpletikzParser : Parser
 
 
                     	// AST REWRITE
-                    	// elements:          coord_sep, numberunit, coord_modifier
+                    	// elements:          numberunit, coord_sep, coord_modifier
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -8807,12 +8859,12 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 450:65: -> ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:450:68: ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:450:68: ^( IM_COORD ( coord_modifier )? ( numberunit )+ coord_sep )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_COORD, "IM_COORD"), root_1);
 
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:450:79: ( coord_modifier )?
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:450:79: ( coord_modifier )?
                     	    if ( stream_coord_modifier.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_coord_modifier.NextTree());
@@ -8839,55 +8891,55 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 3 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:451:5: ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' )
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:451:5: ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' )
                     {
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:451:5: ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' )
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:451:7: ( coord_modifier )? '(' coord_part coord_sep coord_part ')'
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:451:5: ( ( coord_modifier )? '(' coord_part coord_sep coord_part ')' )
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:451:7: ( coord_modifier )? '(' coord_part coord_sep coord_part ')'
                     	{
-                    		// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:451:7: ( coord_modifier )?
+                    		// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:451:7: ( coord_modifier )?
                     		int alt69 = 2;
                     		int LA69_0 = input.LA(1);
 
-                    		if ( ((LA69_0 >= 89 && LA69_0 <= 90)) )
+                    		if ( ((LA69_0 >= 90 && LA69_0 <= 91)) )
                     		{
                     		    alt69 = 1;
                     		}
                     		switch (alt69) 
                     		{
                     		    case 1 :
-                    		        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:451:7: coord_modifier
+                    		        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:451:7: coord_modifier
                     		        {
-                    		        	PushFollow(FOLLOW_coord_modifier_in_coord_nooption2966);
-                    		        	coord_modifier278 = coord_modifier();
+                    		        	PushFollow(FOLLOW_coord_modifier_in_coord_nooption2977);
+                    		        	coord_modifier281 = coord_modifier();
                     		        	state.followingStackPointer--;
                     		        	if (state.failed) return retval;
-                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier278.Tree);
+                    		        	if ( state.backtracking==0 ) stream_coord_modifier.Add(coord_modifier281.Tree);
 
                     		        }
                     		        break;
 
                     		}
 
-                    		char_literal279=(IToken)Match(input,52,FOLLOW_52_in_coord_nooption2969); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_52.Add(char_literal279);
+                    		char_literal282=(IToken)Match(input,53,FOLLOW_53_in_coord_nooption2980); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_53.Add(char_literal282);
 
-                    		PushFollow(FOLLOW_coord_part_in_coord_nooption2971);
-                    		coord_part280 = coord_part();
+                    		PushFollow(FOLLOW_coord_part_in_coord_nooption2982);
+                    		coord_part283 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part280.Tree);
-                    		PushFollow(FOLLOW_coord_sep_in_coord_nooption2973);
-                    		coord_sep281 = coord_sep();
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part283.Tree);
+                    		PushFollow(FOLLOW_coord_sep_in_coord_nooption2984);
+                    		coord_sep284 = coord_sep();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep281.Tree);
-                    		PushFollow(FOLLOW_coord_part_in_coord_nooption2975);
-                    		coord_part282 = coord_part();
+                    		if ( state.backtracking==0 ) stream_coord_sep.Add(coord_sep284.Tree);
+                    		PushFollow(FOLLOW_coord_part_in_coord_nooption2986);
+                    		coord_part285 = coord_part();
                     		state.followingStackPointer--;
                     		if (state.failed) return retval;
-                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part282.Tree);
-                    		char_literal283=(IToken)Match(input,53,FOLLOW_53_in_coord_nooption2977); if (state.failed) return retval; 
-                    		if ( state.backtracking==0 ) stream_53.Add(char_literal283);
+                    		if ( state.backtracking==0 ) stream_coord_part.Add(coord_part285.Tree);
+                    		char_literal286=(IToken)Match(input,54,FOLLOW_54_in_coord_nooption2988); if (state.failed) return retval; 
+                    		if ( state.backtracking==0 ) stream_54.Add(char_literal286);
 
 
                     	}
@@ -8895,7 +8947,7 @@ public partial class simpletikzParser : Parser
 
 
                     	// AST REWRITE
-                    	// elements:          coord_modifier, coord_part, coord_sep
+                    	// elements:          coord_sep, coord_modifier, coord_part
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -8907,12 +8959,12 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 451:65: -> ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:451:68: ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:451:68: ^( IM_COORD ( coord_modifier )? ( coord_part )+ coord_sep )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_COORD, "IM_COORD"), root_1);
 
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:451:79: ( coord_modifier )?
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:451:79: ( coord_modifier )?
                     	    if ( stream_coord_modifier.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_coord_modifier.NextTree());
@@ -8968,7 +9020,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "coord_part"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:460:1: coord_part : ( idd -> ^( IM_DONTCARE idd ) | '{' idd '}' -> ^( IM_DONTCARE '{' idd '}' ) | ( idd '=' numberunit ( ',' )? )+ -> ^( IM_DONTCARE ( idd '=' numberunit ( ',' )? )+ ) );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:460:1: coord_part : ( idd -> ^( IM_DONTCARE idd ) | '{' idd '}' -> ^( IM_DONTCARE '{' idd '}' ) | ( idd '=' numberunit ( ',' )? )+ -> ^( IM_DONTCARE ( idd '=' numberunit ( ',' )? )+ ) );
     public simpletikzParser.coord_part_return coord_part() // throws RecognitionException [1]
     {   
         simpletikzParser.coord_part_return retval = new simpletikzParser.coord_part_return();
@@ -8976,44 +9028,44 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal285 = null;
-        IToken char_literal287 = null;
-        IToken char_literal289 = null;
-        IToken char_literal291 = null;
-        simpletikzParser.idd_return idd284 = default(simpletikzParser.idd_return);
+        IToken char_literal288 = null;
+        IToken char_literal290 = null;
+        IToken char_literal292 = null;
+        IToken char_literal294 = null;
+        simpletikzParser.idd_return idd287 = default(simpletikzParser.idd_return);
 
-        simpletikzParser.idd_return idd286 = default(simpletikzParser.idd_return);
+        simpletikzParser.idd_return idd289 = default(simpletikzParser.idd_return);
 
-        simpletikzParser.idd_return idd288 = default(simpletikzParser.idd_return);
+        simpletikzParser.idd_return idd291 = default(simpletikzParser.idd_return);
 
-        simpletikzParser.numberunit_return numberunit290 = default(simpletikzParser.numberunit_return);
+        simpletikzParser.numberunit_return numberunit293 = default(simpletikzParser.numberunit_return);
 
 
-        object char_literal285_tree=null;
-        object char_literal287_tree=null;
-        object char_literal289_tree=null;
-        object char_literal291_tree=null;
-        RewriteRuleTokenStream stream_45 = new RewriteRuleTokenStream(adaptor,"token 45");
-        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
+        object char_literal288_tree=null;
+        object char_literal290_tree=null;
+        object char_literal292_tree=null;
+        object char_literal294_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
+        RewriteRuleTokenStream stream_45 = new RewriteRuleTokenStream(adaptor,"token 45");
         RewriteRuleTokenStream stream_47 = new RewriteRuleTokenStream(adaptor,"token 47");
+        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
         RewriteRuleSubtreeStream stream_numberunit = new RewriteRuleSubtreeStream(adaptor,"rule numberunit");
         RewriteRuleSubtreeStream stream_idd = new RewriteRuleSubtreeStream(adaptor,"rule idd");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:461:2: ( idd -> ^( IM_DONTCARE idd ) | '{' idd '}' -> ^( IM_DONTCARE '{' idd '}' ) | ( idd '=' numberunit ( ',' )? )+ -> ^( IM_DONTCARE ( idd '=' numberunit ( ',' )? )+ ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:461:2: ( idd -> ^( IM_DONTCARE idd ) | '{' idd '}' -> ^( IM_DONTCARE '{' idd '}' ) | ( idd '=' numberunit ( ',' )? )+ -> ^( IM_DONTCARE ( idd '=' numberunit ( ',' )? )+ ) )
             int alt73 = 3;
             alt73 = dfa73.Predict(input);
             switch (alt73) 
             {
                 case 1 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:461:4: idd
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:461:4: idd
                     {
-                    	PushFollow(FOLLOW_idd_in_coord_part3010);
-                    	idd284 = idd();
+                    	PushFollow(FOLLOW_idd_in_coord_part3021);
+                    	idd287 = idd();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_idd.Add(idd284.Tree);
+                    	if ( state.backtracking==0 ) stream_idd.Add(idd287.Tree);
 
 
                     	// AST REWRITE
@@ -9029,7 +9081,7 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 461:9: -> ^( IM_DONTCARE idd )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:461:12: ^( IM_DONTCARE idd )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:461:12: ^( IM_DONTCARE idd )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_DONTCARE, "IM_DONTCARE"), root_1);
@@ -9045,23 +9097,23 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 2 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:462:4: '{' idd '}'
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:462:4: '{' idd '}'
                     {
-                    	char_literal285=(IToken)Match(input,43,FOLLOW_43_in_coord_part3025); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_43.Add(char_literal285);
+                    	char_literal288=(IToken)Match(input,43,FOLLOW_43_in_coord_part3036); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_43.Add(char_literal288);
 
-                    	PushFollow(FOLLOW_idd_in_coord_part3027);
-                    	idd286 = idd();
+                    	PushFollow(FOLLOW_idd_in_coord_part3038);
+                    	idd289 = idd();
                     	state.followingStackPointer--;
                     	if (state.failed) return retval;
-                    	if ( state.backtracking==0 ) stream_idd.Add(idd286.Tree);
-                    	char_literal287=(IToken)Match(input,44,FOLLOW_44_in_coord_part3029); if (state.failed) return retval; 
-                    	if ( state.backtracking==0 ) stream_44.Add(char_literal287);
+                    	if ( state.backtracking==0 ) stream_idd.Add(idd289.Tree);
+                    	char_literal290=(IToken)Match(input,44,FOLLOW_44_in_coord_part3040); if (state.failed) return retval; 
+                    	if ( state.backtracking==0 ) stream_44.Add(char_literal290);
 
 
 
                     	// AST REWRITE
-                    	// elements:          idd, 43, 44
+                    	// elements:          43, 44, idd
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -9073,7 +9125,7 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 462:16: -> ^( IM_DONTCARE '{' idd '}' )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:462:19: ^( IM_DONTCARE '{' idd '}' )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:462:19: ^( IM_DONTCARE '{' idd '}' )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_DONTCARE, "IM_DONTCARE"), root_1);
@@ -9091,16 +9143,16 @@ public partial class simpletikzParser : Parser
                     }
                     break;
                 case 3 :
-                    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:463:4: ( idd '=' numberunit ( ',' )? )+
+                    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:463:4: ( idd '=' numberunit ( ',' )? )+
                     {
-                    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:463:4: ( idd '=' numberunit ( ',' )? )+
+                    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:463:4: ( idd '=' numberunit ( ',' )? )+
                     	int cnt72 = 0;
                     	do 
                     	{
                     	    int alt72 = 2;
                     	    int LA72_0 = input.LA(1);
 
-                    	    if ( (LA72_0 == 78) )
+                    	    if ( (LA72_0 == 79) )
                     	    {
                     	        int LA72_2 = input.LA(2);
 
@@ -9108,32 +9160,32 @@ public partial class simpletikzParser : Parser
                     	        {
                     	            int LA72_4 = input.LA(3);
 
-                    	            if ( ((LA72_4 >= 57 && LA72_4 <= 62)) )
+                    	            if ( ((LA72_4 >= 58 && LA72_4 <= 63)) )
                     	            {
                     	                int LA72_5 = input.LA(4);
 
-                    	                if ( ((LA72_5 >= IM_PATH && LA72_5 <= 42) || (LA72_5 >= 45 && LA72_5 <= 46) || LA72_5 == 51 || (LA72_5 >= 57 && LA72_5 <= 94)) )
+                    	                if ( ((LA72_5 >= IM_PATH && LA72_5 <= 42) || (LA72_5 >= 45 && LA72_5 <= 46) || (LA72_5 >= 51 && LA72_5 <= 52) || (LA72_5 >= 58 && LA72_5 <= 95)) )
                     	                {
                     	                    alt72 = 1;
                     	                }
 
 
                     	            }
-                    	            else if ( ((LA72_4 >= IM_PATH && LA72_4 <= 42) || (LA72_4 >= 45 && LA72_4 <= 46) || LA72_4 == 51 || (LA72_4 >= 63 && LA72_4 <= 94)) )
+                    	            else if ( ((LA72_4 >= IM_PATH && LA72_4 <= 42) || (LA72_4 >= 45 && LA72_4 <= 46) || (LA72_4 >= 51 && LA72_4 <= 52) || (LA72_4 >= 64 && LA72_4 <= 95)) )
                     	            {
                     	                alt72 = 1;
                     	            }
 
 
                     	        }
-                    	        else if ( ((LA72_2 >= IM_PATH && LA72_2 <= COMMAND) || (LA72_2 >= WS && LA72_2 <= 42) || (LA72_2 >= 45 && LA72_2 <= 46) || LA72_2 == 51 || (LA72_2 >= 57 && LA72_2 <= 94)) )
+                    	        else if ( ((LA72_2 >= IM_PATH && LA72_2 <= COMMAND) || (LA72_2 >= WS && LA72_2 <= 42) || (LA72_2 >= 45 && LA72_2 <= 46) || (LA72_2 >= 51 && LA72_2 <= 52) || (LA72_2 >= 58 && LA72_2 <= 95)) )
                     	        {
                     	            alt72 = 1;
                     	        }
 
 
                     	    }
-                    	    else if ( ((LA72_0 >= IM_PATH && LA72_0 <= 42) || LA72_0 == 46 || LA72_0 == 51 || (LA72_0 >= 57 && LA72_0 <= 77) || (LA72_0 >= 79 && LA72_0 <= 94)) )
+                    	    else if ( ((LA72_0 >= IM_PATH && LA72_0 <= 42) || LA72_0 == 46 || (LA72_0 >= 51 && LA72_0 <= 52) || (LA72_0 >= 58 && LA72_0 <= 78) || (LA72_0 >= 80 && LA72_0 <= 95)) )
                     	    {
                     	        alt72 = 1;
                     	    }
@@ -9142,22 +9194,22 @@ public partial class simpletikzParser : Parser
                     	    switch (alt72) 
                     		{
                     			case 1 :
-                    			    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:463:5: idd '=' numberunit ( ',' )?
+                    			    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:463:5: idd '=' numberunit ( ',' )?
                     			    {
-                    			    	PushFollow(FOLLOW_idd_in_coord_part3047);
-                    			    	idd288 = idd();
+                    			    	PushFollow(FOLLOW_idd_in_coord_part3058);
+                    			    	idd291 = idd();
                     			    	state.followingStackPointer--;
                     			    	if (state.failed) return retval;
-                    			    	if ( state.backtracking==0 ) stream_idd.Add(idd288.Tree);
-                    			    	char_literal289=(IToken)Match(input,45,FOLLOW_45_in_coord_part3049); if (state.failed) return retval; 
-                    			    	if ( state.backtracking==0 ) stream_45.Add(char_literal289);
+                    			    	if ( state.backtracking==0 ) stream_idd.Add(idd291.Tree);
+                    			    	char_literal292=(IToken)Match(input,45,FOLLOW_45_in_coord_part3060); if (state.failed) return retval; 
+                    			    	if ( state.backtracking==0 ) stream_45.Add(char_literal292);
 
-                    			    	PushFollow(FOLLOW_numberunit_in_coord_part3051);
-                    			    	numberunit290 = numberunit();
+                    			    	PushFollow(FOLLOW_numberunit_in_coord_part3062);
+                    			    	numberunit293 = numberunit();
                     			    	state.followingStackPointer--;
                     			    	if (state.failed) return retval;
-                    			    	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit290.Tree);
-                    			    	// C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:463:24: ( ',' )?
+                    			    	if ( state.backtracking==0 ) stream_numberunit.Add(numberunit293.Tree);
+                    			    	// E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:463:24: ( ',' )?
                     			    	int alt71 = 2;
                     			    	int LA71_0 = input.LA(1);
 
@@ -9168,10 +9220,10 @@ public partial class simpletikzParser : Parser
                     			    	switch (alt71) 
                     			    	{
                     			    	    case 1 :
-                    			    	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:463:24: ','
+                    			    	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:463:24: ','
                     			    	        {
-                    			    	        	char_literal291=(IToken)Match(input,47,FOLLOW_47_in_coord_part3053); if (state.failed) return retval; 
-                    			    	        	if ( state.backtracking==0 ) stream_47.Add(char_literal291);
+                    			    	        	char_literal294=(IToken)Match(input,47,FOLLOW_47_in_coord_part3064); if (state.failed) return retval; 
+                    			    	        	if ( state.backtracking==0 ) stream_47.Add(char_literal294);
 
 
                     			    	        }
@@ -9199,7 +9251,7 @@ public partial class simpletikzParser : Parser
 
 
                     	// AST REWRITE
-                    	// elements:          47, numberunit, idd, 45
+                    	// elements:          45, idd, numberunit, 47
                     	// token labels:      
                     	// rule labels:       retval
                     	// token list labels: 
@@ -9211,20 +9263,20 @@ public partial class simpletikzParser : Parser
                     	root_0 = (object)adaptor.GetNilNode();
                     	// 463:31: -> ^( IM_DONTCARE ( idd '=' numberunit ( ',' )? )+ )
                     	{
-                    	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:463:34: ^( IM_DONTCARE ( idd '=' numberunit ( ',' )? )+ )
+                    	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:463:34: ^( IM_DONTCARE ( idd '=' numberunit ( ',' )? )+ )
                     	    {
                     	    object root_1 = (object)adaptor.GetNilNode();
                     	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_DONTCARE, "IM_DONTCARE"), root_1);
 
-                    	    if ( !(stream_numberunit.HasNext() || stream_idd.HasNext() || stream_45.HasNext()) ) {
+                    	    if ( !(stream_45.HasNext() || stream_idd.HasNext() || stream_numberunit.HasNext()) ) {
                     	        throw new RewriteEarlyExitException();
                     	    }
-                    	    while ( stream_numberunit.HasNext() || stream_idd.HasNext() || stream_45.HasNext() )
+                    	    while ( stream_45.HasNext() || stream_idd.HasNext() || stream_numberunit.HasNext() )
                     	    {
                     	        adaptor.AddChild(root_1, stream_idd.NextTree());
                     	        adaptor.AddChild(root_1, stream_45.NextNode());
                     	        adaptor.AddChild(root_1, stream_numberunit.NextTree());
-                    	        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:463:69: ( ',' )?
+                    	        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:463:69: ( ',' )?
                     	        if ( stream_47.HasNext() )
                     	        {
                     	            adaptor.AddChild(root_1, stream_47.NextNode());
@@ -9233,9 +9285,9 @@ public partial class simpletikzParser : Parser
                     	        stream_47.Reset();
 
                     	    }
-                    	    stream_numberunit.Reset();
-                    	    stream_idd.Reset();
                     	    stream_45.Reset();
+                    	    stream_idd.Reset();
+                    	    stream_numberunit.Reset();
 
                     	    adaptor.AddChild(root_0, root_1);
                     	    }
@@ -9275,7 +9327,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "coord_sep"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:465:1: coord_sep : ( ',' | ':' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:465:1: coord_sep : ( ',' | ':' ) ;
     public simpletikzParser.coord_sep_return coord_sep() // throws RecognitionException [1]
     {   
         simpletikzParser.coord_sep_return retval = new simpletikzParser.coord_sep_return();
@@ -9283,22 +9335,22 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set292 = null;
+        IToken set295 = null;
 
-        object set292_tree=null;
+        object set295_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:466:2: ( ( ',' | ':' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:466:4: ( ',' | ':' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:466:2: ( ( ',' | ':' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:466:4: ( ',' | ':' )
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set292 = (IToken)input.LT(1);
+            	set295 = (IToken)input.LT(1);
             	if ( (input.LA(1) >= 47 && input.LA(1) <= 48) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set292));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set295));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -9339,7 +9391,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "edgeop"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:470:1: edgeop : ( '--' | '->' | '|-' | '-|' | ID );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:470:1: edgeop : ( '--' | '->' | '|-' | '-|' | ID );
     public simpletikzParser.edgeop_return edgeop() // throws RecognitionException [1]
     {   
         simpletikzParser.edgeop_return retval = new simpletikzParser.edgeop_return();
@@ -9347,22 +9399,22 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set293 = null;
+        IToken set296 = null;
 
-        object set293_tree=null;
+        object set296_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:471:2: ( '--' | '->' | '|-' | '-|' | ID )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:471:2: ( '--' | '->' | '|-' | '-|' | ID )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set293 = (IToken)input.LT(1);
-            	if ( input.LA(1) == ID || (input.LA(1) >= 85 && input.LA(1) <= 88) ) 
+            	set296 = (IToken)input.LT(1);
+            	if ( input.LA(1) == ID || (input.LA(1) >= 86 && input.LA(1) <= 89) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set293));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set296));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -9403,7 +9455,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "coord_modifier"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:475:1: coord_modifier : ( '+' | '++' );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:475:1: coord_modifier : ( '+' | '++' );
     public simpletikzParser.coord_modifier_return coord_modifier() // throws RecognitionException [1]
     {   
         simpletikzParser.coord_modifier_return retval = new simpletikzParser.coord_modifier_return();
@@ -9411,22 +9463,22 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set294 = null;
+        IToken set297 = null;
 
-        object set294_tree=null;
+        object set297_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:476:2: ( '+' | '++' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:476:2: ( '+' | '++' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set294 = (IToken)input.LT(1);
-            	if ( (input.LA(1) >= 89 && input.LA(1) <= 90) ) 
+            	set297 = (IToken)input.LT(1);
+            	if ( (input.LA(1) >= 90 && input.LA(1) <= 91) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set294));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set297));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -9467,7 +9519,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "squarebr_start"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:518:1: squarebr_start : '[' -> ^( IM_STARTTAG '[' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:518:1: squarebr_start : '[' -> ^( IM_STARTTAG '[' ) ;
     public simpletikzParser.squarebr_start_return squarebr_start() // throws RecognitionException [1]
     {   
         simpletikzParser.squarebr_start_return retval = new simpletikzParser.squarebr_start_return();
@@ -9475,23 +9527,23 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal295 = null;
+        IToken char_literal298 = null;
 
-        object char_literal295_tree=null;
-        RewriteRuleTokenStream stream_54 = new RewriteRuleTokenStream(adaptor,"token 54");
+        object char_literal298_tree=null;
+        RewriteRuleTokenStream stream_55 = new RewriteRuleTokenStream(adaptor,"token 55");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:519:2: ( '[' -> ^( IM_STARTTAG '[' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:519:4: '['
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:519:2: ( '[' -> ^( IM_STARTTAG '[' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:519:4: '['
             {
-            	char_literal295=(IToken)Match(input,54,FOLLOW_54_in_squarebr_start3159); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_54.Add(char_literal295);
+            	char_literal298=(IToken)Match(input,55,FOLLOW_55_in_squarebr_start3170); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_55.Add(char_literal298);
 
 
 
             	// AST REWRITE
-            	// elements:          54
+            	// elements:          55
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -9503,12 +9555,12 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 519:8: -> ^( IM_STARTTAG '[' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:519:11: ^( IM_STARTTAG '[' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:519:11: ^( IM_STARTTAG '[' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_54.NextNode());
+            	    adaptor.AddChild(root_1, stream_55.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -9546,7 +9598,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "squarebr_end"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:521:1: squarebr_end : ']' -> ^( IM_ENDTAG ']' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:521:1: squarebr_end : ']' -> ^( IM_ENDTAG ']' ) ;
     public simpletikzParser.squarebr_end_return squarebr_end() // throws RecognitionException [1]
     {   
         simpletikzParser.squarebr_end_return retval = new simpletikzParser.squarebr_end_return();
@@ -9554,23 +9606,23 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal296 = null;
+        IToken char_literal299 = null;
 
-        object char_literal296_tree=null;
-        RewriteRuleTokenStream stream_55 = new RewriteRuleTokenStream(adaptor,"token 55");
+        object char_literal299_tree=null;
+        RewriteRuleTokenStream stream_56 = new RewriteRuleTokenStream(adaptor,"token 56");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:522:2: ( ']' -> ^( IM_ENDTAG ']' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:522:4: ']'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:522:2: ( ']' -> ^( IM_ENDTAG ']' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:522:4: ']'
             {
-            	char_literal296=(IToken)Match(input,55,FOLLOW_55_in_squarebr_end3177); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_55.Add(char_literal296);
+            	char_literal299=(IToken)Match(input,56,FOLLOW_56_in_squarebr_end3188); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_56.Add(char_literal299);
 
 
 
             	// AST REWRITE
-            	// elements:          55
+            	// elements:          56
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -9582,12 +9634,12 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 522:8: -> ^( IM_ENDTAG ']' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:522:11: ^( IM_ENDTAG ']' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:522:11: ^( IM_ENDTAG ']' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ENDTAG, "IM_ENDTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_55.NextNode());
+            	    adaptor.AddChild(root_1, stream_56.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -9625,7 +9677,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "semicolon_end"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:524:1: semicolon_end : ';' -> ^( IM_ENDTAG ';' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:524:1: semicolon_end : ';' -> ^( IM_ENDTAG ';' ) ;
     public simpletikzParser.semicolon_end_return semicolon_end() // throws RecognitionException [1]
     {   
         simpletikzParser.semicolon_end_return retval = new simpletikzParser.semicolon_end_return();
@@ -9633,23 +9685,23 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal297 = null;
+        IToken char_literal300 = null;
 
-        object char_literal297_tree=null;
-        RewriteRuleTokenStream stream_56 = new RewriteRuleTokenStream(adaptor,"token 56");
+        object char_literal300_tree=null;
+        RewriteRuleTokenStream stream_57 = new RewriteRuleTokenStream(adaptor,"token 57");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:525:2: ( ';' -> ^( IM_ENDTAG ';' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:525:4: ';'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:525:2: ( ';' -> ^( IM_ENDTAG ';' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:525:4: ';'
             {
-            	char_literal297=(IToken)Match(input,56,FOLLOW_56_in_semicolon_end3196); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_56.Add(char_literal297);
+            	char_literal300=(IToken)Match(input,57,FOLLOW_57_in_semicolon_end3207); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_57.Add(char_literal300);
 
 
 
             	// AST REWRITE
-            	// elements:          56
+            	// elements:          57
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -9661,12 +9713,12 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 525:8: -> ^( IM_ENDTAG ';' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:525:11: ^( IM_ENDTAG ';' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:525:11: ^( IM_ENDTAG ';' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ENDTAG, "IM_ENDTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_56.NextNode());
+            	    adaptor.AddChild(root_1, stream_57.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -9704,7 +9756,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "roundbr_start"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:527:1: roundbr_start : '{' -> ^( IM_STARTTAG '{' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:527:1: roundbr_start : '{' -> ^( IM_STARTTAG '{' ) ;
     public simpletikzParser.roundbr_start_return roundbr_start() // throws RecognitionException [1]
     {   
         simpletikzParser.roundbr_start_return retval = new simpletikzParser.roundbr_start_return();
@@ -9712,18 +9764,18 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal298 = null;
+        IToken char_literal301 = null;
 
-        object char_literal298_tree=null;
+        object char_literal301_tree=null;
         RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:528:2: ( '{' -> ^( IM_STARTTAG '{' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:528:4: '{'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:528:2: ( '{' -> ^( IM_STARTTAG '{' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:528:4: '{'
             {
-            	char_literal298=(IToken)Match(input,43,FOLLOW_43_in_roundbr_start3214); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal298);
+            	char_literal301=(IToken)Match(input,43,FOLLOW_43_in_roundbr_start3225); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal301);
 
 
 
@@ -9740,7 +9792,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 528:8: -> ^( IM_STARTTAG '{' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:528:11: ^( IM_STARTTAG '{' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:528:11: ^( IM_STARTTAG '{' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
@@ -9783,7 +9835,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "roundbr_end"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:530:1: roundbr_end : '}' -> ^( IM_ENDTAG '}' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:530:1: roundbr_end : '}' -> ^( IM_ENDTAG '}' ) ;
     public simpletikzParser.roundbr_end_return roundbr_end() // throws RecognitionException [1]
     {   
         simpletikzParser.roundbr_end_return retval = new simpletikzParser.roundbr_end_return();
@@ -9791,18 +9843,18 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken char_literal299 = null;
+        IToken char_literal302 = null;
 
-        object char_literal299_tree=null;
+        object char_literal302_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:531:2: ( '}' -> ^( IM_ENDTAG '}' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:531:4: '}'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:531:2: ( '}' -> ^( IM_ENDTAG '}' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:531:4: '}'
             {
-            	char_literal299=(IToken)Match(input,44,FOLLOW_44_in_roundbr_end3232); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_44.Add(char_literal299);
+            	char_literal302=(IToken)Match(input,44,FOLLOW_44_in_roundbr_end3243); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_44.Add(char_literal302);
 
 
 
@@ -9819,7 +9871,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 531:8: -> ^( IM_ENDTAG '}' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:531:11: ^( IM_ENDTAG '}' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:531:11: ^( IM_ENDTAG '}' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ENDTAG, "IM_ENDTAG"), root_1);
@@ -9862,7 +9914,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "controls_start"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:533:1: controls_start : '..' 'controls' -> ^( IM_STARTTAG '..' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:533:1: controls_start : '..' 'controls' -> ^( IM_STARTTAG '..' ) ;
     public simpletikzParser.controls_start_return controls_start() // throws RecognitionException [1]
     {   
         simpletikzParser.controls_start_return retval = new simpletikzParser.controls_start_return();
@@ -9870,29 +9922,29 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal300 = null;
-        IToken string_literal301 = null;
+        IToken string_literal303 = null;
+        IToken string_literal304 = null;
 
-        object string_literal300_tree=null;
-        object string_literal301_tree=null;
+        object string_literal303_tree=null;
+        object string_literal304_tree=null;
         RewriteRuleTokenStream stream_92 = new RewriteRuleTokenStream(adaptor,"token 92");
-        RewriteRuleTokenStream stream_91 = new RewriteRuleTokenStream(adaptor,"token 91");
+        RewriteRuleTokenStream stream_93 = new RewriteRuleTokenStream(adaptor,"token 93");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:534:2: ( '..' 'controls' -> ^( IM_STARTTAG '..' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:534:4: '..' 'controls'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:534:2: ( '..' 'controls' -> ^( IM_STARTTAG '..' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:534:4: '..' 'controls'
             {
-            	string_literal300=(IToken)Match(input,91,FOLLOW_91_in_controls_start3250); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_91.Add(string_literal300);
+            	string_literal303=(IToken)Match(input,92,FOLLOW_92_in_controls_start3261); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_92.Add(string_literal303);
 
-            	string_literal301=(IToken)Match(input,92,FOLLOW_92_in_controls_start3252); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_92.Add(string_literal301);
+            	string_literal304=(IToken)Match(input,93,FOLLOW_93_in_controls_start3263); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_93.Add(string_literal304);
 
 
 
             	// AST REWRITE
-            	// elements:          91
+            	// elements:          92
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -9904,12 +9956,12 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 534:20: -> ^( IM_STARTTAG '..' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:534:23: ^( IM_STARTTAG '..' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:534:23: ^( IM_STARTTAG '..' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_91.NextNode());
+            	    adaptor.AddChild(root_1, stream_92.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -9947,7 +9999,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "controls_end"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:536:1: controls_end : '..' -> ^( IM_ENDTAG '..' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:536:1: controls_end : '..' -> ^( IM_ENDTAG '..' ) ;
     public simpletikzParser.controls_end_return controls_end() // throws RecognitionException [1]
     {   
         simpletikzParser.controls_end_return retval = new simpletikzParser.controls_end_return();
@@ -9955,23 +10007,23 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal302 = null;
+        IToken string_literal305 = null;
 
-        object string_literal302_tree=null;
-        RewriteRuleTokenStream stream_91 = new RewriteRuleTokenStream(adaptor,"token 91");
+        object string_literal305_tree=null;
+        RewriteRuleTokenStream stream_92 = new RewriteRuleTokenStream(adaptor,"token 92");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:537:2: ( '..' -> ^( IM_ENDTAG '..' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:537:4: '..'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:537:2: ( '..' -> ^( IM_ENDTAG '..' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:537:4: '..'
             {
-            	string_literal302=(IToken)Match(input,91,FOLLOW_91_in_controls_end3270); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_91.Add(string_literal302);
+            	string_literal305=(IToken)Match(input,92,FOLLOW_92_in_controls_end3281); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_92.Add(string_literal305);
 
 
 
             	// AST REWRITE
-            	// elements:          91
+            	// elements:          92
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -9983,12 +10035,12 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 537:9: -> ^( IM_ENDTAG '..' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:537:12: ^( IM_ENDTAG '..' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:537:12: ^( IM_ENDTAG '..' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ENDTAG, "IM_ENDTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_91.NextNode());
+            	    adaptor.AddChild(root_1, stream_92.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -10026,7 +10078,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikz_set_start"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:539:1: tikz_set_start : '\\\\tikzset' '{' -> ^( IM_STARTTAG ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:539:1: tikz_set_start : '\\\\tikzset' '{' -> ^( IM_STARTTAG ) ;
     public simpletikzParser.tikz_set_start_return tikz_set_start() // throws RecognitionException [1]
     {   
         simpletikzParser.tikz_set_start_return retval = new simpletikzParser.tikz_set_start_return();
@@ -10034,24 +10086,24 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal303 = null;
-        IToken char_literal304 = null;
+        IToken string_literal306 = null;
+        IToken char_literal307 = null;
 
-        object string_literal303_tree=null;
-        object char_literal304_tree=null;
-        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
+        object string_literal306_tree=null;
+        object char_literal307_tree=null;
         RewriteRuleTokenStream stream_41 = new RewriteRuleTokenStream(adaptor,"token 41");
+        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:540:2: ( '\\\\tikzset' '{' -> ^( IM_STARTTAG ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:540:4: '\\\\tikzset' '{'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:540:2: ( '\\\\tikzset' '{' -> ^( IM_STARTTAG ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:540:4: '\\\\tikzset' '{'
             {
-            	string_literal303=(IToken)Match(input,41,FOLLOW_41_in_tikz_set_start3288); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_41.Add(string_literal303);
+            	string_literal306=(IToken)Match(input,41,FOLLOW_41_in_tikz_set_start3299); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_41.Add(string_literal306);
 
-            	char_literal304=(IToken)Match(input,43,FOLLOW_43_in_tikz_set_start3290); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal304);
+            	char_literal307=(IToken)Match(input,43,FOLLOW_43_in_tikz_set_start3301); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal307);
 
 
 
@@ -10068,7 +10120,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 540:21: -> ^( IM_STARTTAG )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:540:24: ^( IM_STARTTAG )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:540:24: ^( IM_STARTTAG )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
@@ -10109,7 +10161,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzpicture_start"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:542:1: tikzpicture_start : '\\\\begin' '{' 'tikzpicture' '}' -> ^( IM_STARTTAG '\\\\begin' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:542:1: tikzpicture_start : '\\\\begin' '{' 'tikzpicture' '}' -> ^( IM_STARTTAG '\\\\begin' ) ;
     public simpletikzParser.tikzpicture_start_return tikzpicture_start() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzpicture_start_return retval = new simpletikzParser.tikzpicture_start_return();
@@ -10117,36 +10169,36 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal305 = null;
-        IToken char_literal306 = null;
-        IToken string_literal307 = null;
-        IToken char_literal308 = null;
+        IToken string_literal308 = null;
+        IToken char_literal309 = null;
+        IToken string_literal310 = null;
+        IToken char_literal311 = null;
 
-        object string_literal305_tree=null;
-        object char_literal306_tree=null;
-        object string_literal307_tree=null;
-        object char_literal308_tree=null;
-        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
-        RewriteRuleTokenStream stream_93 = new RewriteRuleTokenStream(adaptor,"token 93");
+        object string_literal308_tree=null;
+        object char_literal309_tree=null;
+        object string_literal310_tree=null;
+        object char_literal311_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
         RewriteRuleTokenStream stream_39 = new RewriteRuleTokenStream(adaptor,"token 39");
+        RewriteRuleTokenStream stream_94 = new RewriteRuleTokenStream(adaptor,"token 94");
+        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:543:2: ( '\\\\begin' '{' 'tikzpicture' '}' -> ^( IM_STARTTAG '\\\\begin' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:543:4: '\\\\begin' '{' 'tikzpicture' '}'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:543:2: ( '\\\\begin' '{' 'tikzpicture' '}' -> ^( IM_STARTTAG '\\\\begin' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:543:4: '\\\\begin' '{' 'tikzpicture' '}'
             {
-            	string_literal305=(IToken)Match(input,39,FOLLOW_39_in_tikzpicture_start3309); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_39.Add(string_literal305);
+            	string_literal308=(IToken)Match(input,39,FOLLOW_39_in_tikzpicture_start3320); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_39.Add(string_literal308);
 
-            	char_literal306=(IToken)Match(input,43,FOLLOW_43_in_tikzpicture_start3311); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal306);
+            	char_literal309=(IToken)Match(input,43,FOLLOW_43_in_tikzpicture_start3322); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal309);
 
-            	string_literal307=(IToken)Match(input,93,FOLLOW_93_in_tikzpicture_start3313); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_93.Add(string_literal307);
+            	string_literal310=(IToken)Match(input,94,FOLLOW_94_in_tikzpicture_start3324); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_94.Add(string_literal310);
 
-            	char_literal308=(IToken)Match(input,44,FOLLOW_44_in_tikzpicture_start3315); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_44.Add(char_literal308);
+            	char_literal311=(IToken)Match(input,44,FOLLOW_44_in_tikzpicture_start3326); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_44.Add(char_literal311);
 
 
 
@@ -10163,7 +10215,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 543:36: -> ^( IM_STARTTAG '\\\\begin' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:543:39: ^( IM_STARTTAG '\\\\begin' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:543:39: ^( IM_STARTTAG '\\\\begin' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
@@ -10206,7 +10258,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikz_start"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:545:1: tikz_start : '\\\\tikz' -> ^( IM_STARTTAG '\\\\tikz' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:545:1: tikz_start : '\\\\tikz' -> ^( IM_STARTTAG '\\\\tikz' ) ;
     public simpletikzParser.tikz_start_return tikz_start() // throws RecognitionException [1]
     {   
         simpletikzParser.tikz_start_return retval = new simpletikzParser.tikz_start_return();
@@ -10214,18 +10266,18 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal309 = null;
+        IToken string_literal312 = null;
 
-        object string_literal309_tree=null;
+        object string_literal312_tree=null;
         RewriteRuleTokenStream stream_42 = new RewriteRuleTokenStream(adaptor,"token 42");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:546:2: ( '\\\\tikz' -> ^( IM_STARTTAG '\\\\tikz' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:546:4: '\\\\tikz'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:546:2: ( '\\\\tikz' -> ^( IM_STARTTAG '\\\\tikz' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:546:4: '\\\\tikz'
             {
-            	string_literal309=(IToken)Match(input,42,FOLLOW_42_in_tikz_start3333); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_42.Add(string_literal309);
+            	string_literal312=(IToken)Match(input,42,FOLLOW_42_in_tikz_start3344); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_42.Add(string_literal312);
 
 
 
@@ -10242,7 +10294,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 546:13: -> ^( IM_STARTTAG '\\\\tikz' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:546:16: ^( IM_STARTTAG '\\\\tikz' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:546:16: ^( IM_STARTTAG '\\\\tikz' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
@@ -10285,7 +10337,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzpicture_end"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:548:1: tikzpicture_end : '\\\\end' '{' 'tikzpicture' '}' -> ^( IM_ENDTAG '\\\\end' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:548:1: tikzpicture_end : '\\\\end' '{' 'tikzpicture' '}' -> ^( IM_ENDTAG '\\\\end' ) ;
     public simpletikzParser.tikzpicture_end_return tikzpicture_end() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzpicture_end_return retval = new simpletikzParser.tikzpicture_end_return();
@@ -10293,41 +10345,41 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal310 = null;
-        IToken char_literal311 = null;
-        IToken string_literal312 = null;
-        IToken char_literal313 = null;
+        IToken string_literal313 = null;
+        IToken char_literal314 = null;
+        IToken string_literal315 = null;
+        IToken char_literal316 = null;
 
-        object string_literal310_tree=null;
-        object char_literal311_tree=null;
-        object string_literal312_tree=null;
-        object char_literal313_tree=null;
-        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
-        RewriteRuleTokenStream stream_93 = new RewriteRuleTokenStream(adaptor,"token 93");
+        object string_literal313_tree=null;
+        object char_literal314_tree=null;
+        object string_literal315_tree=null;
+        object char_literal316_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
-        RewriteRuleTokenStream stream_63 = new RewriteRuleTokenStream(adaptor,"token 63");
+        RewriteRuleTokenStream stream_94 = new RewriteRuleTokenStream(adaptor,"token 94");
+        RewriteRuleTokenStream stream_64 = new RewriteRuleTokenStream(adaptor,"token 64");
+        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:549:2: ( '\\\\end' '{' 'tikzpicture' '}' -> ^( IM_ENDTAG '\\\\end' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:549:4: '\\\\end' '{' 'tikzpicture' '}'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:549:2: ( '\\\\end' '{' 'tikzpicture' '}' -> ^( IM_ENDTAG '\\\\end' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:549:4: '\\\\end' '{' 'tikzpicture' '}'
             {
-            	string_literal310=(IToken)Match(input,63,FOLLOW_63_in_tikzpicture_end3351); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_63.Add(string_literal310);
+            	string_literal313=(IToken)Match(input,64,FOLLOW_64_in_tikzpicture_end3362); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_64.Add(string_literal313);
 
-            	char_literal311=(IToken)Match(input,43,FOLLOW_43_in_tikzpicture_end3353); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal311);
+            	char_literal314=(IToken)Match(input,43,FOLLOW_43_in_tikzpicture_end3364); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal314);
 
-            	string_literal312=(IToken)Match(input,93,FOLLOW_93_in_tikzpicture_end3355); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_93.Add(string_literal312);
+            	string_literal315=(IToken)Match(input,94,FOLLOW_94_in_tikzpicture_end3366); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_94.Add(string_literal315);
 
-            	char_literal313=(IToken)Match(input,44,FOLLOW_44_in_tikzpicture_end3357); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_44.Add(char_literal313);
+            	char_literal316=(IToken)Match(input,44,FOLLOW_44_in_tikzpicture_end3368); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_44.Add(char_literal316);
 
 
 
             	// AST REWRITE
-            	// elements:          63
+            	// elements:          64
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -10339,12 +10391,12 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 549:34: -> ^( IM_ENDTAG '\\\\end' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:549:37: ^( IM_ENDTAG '\\\\end' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:549:37: ^( IM_ENDTAG '\\\\end' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ENDTAG, "IM_ENDTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_63.NextNode());
+            	    adaptor.AddChild(root_1, stream_64.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -10382,7 +10434,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzscope_start"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:551:1: tikzscope_start : '\\\\begin' '{' 'scope' '}' -> ^( IM_STARTTAG '\\\\begin' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:551:1: tikzscope_start : '\\\\begin' '{' 'scope' '}' -> ^( IM_STARTTAG '\\\\begin' ) ;
     public simpletikzParser.tikzscope_start_return tikzscope_start() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzscope_start_return retval = new simpletikzParser.tikzscope_start_return();
@@ -10390,36 +10442,36 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal314 = null;
-        IToken char_literal315 = null;
-        IToken string_literal316 = null;
-        IToken char_literal317 = null;
+        IToken string_literal317 = null;
+        IToken char_literal318 = null;
+        IToken string_literal319 = null;
+        IToken char_literal320 = null;
 
-        object string_literal314_tree=null;
-        object char_literal315_tree=null;
-        object string_literal316_tree=null;
-        object char_literal317_tree=null;
-        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
-        RewriteRuleTokenStream stream_94 = new RewriteRuleTokenStream(adaptor,"token 94");
+        object string_literal317_tree=null;
+        object char_literal318_tree=null;
+        object string_literal319_tree=null;
+        object char_literal320_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
         RewriteRuleTokenStream stream_39 = new RewriteRuleTokenStream(adaptor,"token 39");
+        RewriteRuleTokenStream stream_95 = new RewriteRuleTokenStream(adaptor,"token 95");
+        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:552:2: ( '\\\\begin' '{' 'scope' '}' -> ^( IM_STARTTAG '\\\\begin' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:552:4: '\\\\begin' '{' 'scope' '}'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:552:2: ( '\\\\begin' '{' 'scope' '}' -> ^( IM_STARTTAG '\\\\begin' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:552:4: '\\\\begin' '{' 'scope' '}'
             {
-            	string_literal314=(IToken)Match(input,39,FOLLOW_39_in_tikzscope_start3375); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_39.Add(string_literal314);
+            	string_literal317=(IToken)Match(input,39,FOLLOW_39_in_tikzscope_start3386); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_39.Add(string_literal317);
 
-            	char_literal315=(IToken)Match(input,43,FOLLOW_43_in_tikzscope_start3377); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal315);
+            	char_literal318=(IToken)Match(input,43,FOLLOW_43_in_tikzscope_start3388); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal318);
 
-            	string_literal316=(IToken)Match(input,94,FOLLOW_94_in_tikzscope_start3379); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_94.Add(string_literal316);
+            	string_literal319=(IToken)Match(input,95,FOLLOW_95_in_tikzscope_start3390); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_95.Add(string_literal319);
 
-            	char_literal317=(IToken)Match(input,44,FOLLOW_44_in_tikzscope_start3381); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_44.Add(char_literal317);
+            	char_literal320=(IToken)Match(input,44,FOLLOW_44_in_tikzscope_start3392); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_44.Add(char_literal320);
 
 
 
@@ -10436,7 +10488,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 552:30: -> ^( IM_STARTTAG '\\\\begin' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:552:33: ^( IM_STARTTAG '\\\\begin' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:552:33: ^( IM_STARTTAG '\\\\begin' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
@@ -10479,7 +10531,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "tikzscope_end"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:554:1: tikzscope_end : '\\\\end' '{' 'scope' '}' -> ^( IM_ENDTAG '\\\\end' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:554:1: tikzscope_end : '\\\\end' '{' 'scope' '}' -> ^( IM_ENDTAG '\\\\end' ) ;
     public simpletikzParser.tikzscope_end_return tikzscope_end() // throws RecognitionException [1]
     {   
         simpletikzParser.tikzscope_end_return retval = new simpletikzParser.tikzscope_end_return();
@@ -10487,41 +10539,41 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal318 = null;
-        IToken char_literal319 = null;
-        IToken string_literal320 = null;
-        IToken char_literal321 = null;
+        IToken string_literal321 = null;
+        IToken char_literal322 = null;
+        IToken string_literal323 = null;
+        IToken char_literal324 = null;
 
-        object string_literal318_tree=null;
-        object char_literal319_tree=null;
-        object string_literal320_tree=null;
-        object char_literal321_tree=null;
-        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
-        RewriteRuleTokenStream stream_94 = new RewriteRuleTokenStream(adaptor,"token 94");
+        object string_literal321_tree=null;
+        object char_literal322_tree=null;
+        object string_literal323_tree=null;
+        object char_literal324_tree=null;
         RewriteRuleTokenStream stream_44 = new RewriteRuleTokenStream(adaptor,"token 44");
-        RewriteRuleTokenStream stream_63 = new RewriteRuleTokenStream(adaptor,"token 63");
+        RewriteRuleTokenStream stream_95 = new RewriteRuleTokenStream(adaptor,"token 95");
+        RewriteRuleTokenStream stream_64 = new RewriteRuleTokenStream(adaptor,"token 64");
+        RewriteRuleTokenStream stream_43 = new RewriteRuleTokenStream(adaptor,"token 43");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:555:2: ( '\\\\end' '{' 'scope' '}' -> ^( IM_ENDTAG '\\\\end' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:555:4: '\\\\end' '{' 'scope' '}'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:555:2: ( '\\\\end' '{' 'scope' '}' -> ^( IM_ENDTAG '\\\\end' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:555:4: '\\\\end' '{' 'scope' '}'
             {
-            	string_literal318=(IToken)Match(input,63,FOLLOW_63_in_tikzscope_end3399); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_63.Add(string_literal318);
+            	string_literal321=(IToken)Match(input,64,FOLLOW_64_in_tikzscope_end3410); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_64.Add(string_literal321);
 
-            	char_literal319=(IToken)Match(input,43,FOLLOW_43_in_tikzscope_end3401); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_43.Add(char_literal319);
+            	char_literal322=(IToken)Match(input,43,FOLLOW_43_in_tikzscope_end3412); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_43.Add(char_literal322);
 
-            	string_literal320=(IToken)Match(input,94,FOLLOW_94_in_tikzscope_end3403); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_94.Add(string_literal320);
+            	string_literal323=(IToken)Match(input,95,FOLLOW_95_in_tikzscope_end3414); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_95.Add(string_literal323);
 
-            	char_literal321=(IToken)Match(input,44,FOLLOW_44_in_tikzscope_end3405); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_44.Add(char_literal321);
+            	char_literal324=(IToken)Match(input,44,FOLLOW_44_in_tikzscope_end3416); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_44.Add(char_literal324);
 
 
 
             	// AST REWRITE
-            	// elements:          63
+            	// elements:          64
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -10533,12 +10585,12 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 555:28: -> ^( IM_ENDTAG '\\\\end' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:555:31: ^( IM_ENDTAG '\\\\end' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:555:31: ^( IM_ENDTAG '\\\\end' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_ENDTAG, "IM_ENDTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_63.NextNode());
+            	    adaptor.AddChild(root_1, stream_64.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -10576,7 +10628,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "path_start"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:557:1: path_start : path_start_tag -> ^( IM_STARTTAG path_start_tag ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:557:1: path_start : path_start_tag -> ^( IM_STARTTAG path_start_tag ) ;
     public simpletikzParser.path_start_return path_start() // throws RecognitionException [1]
     {   
         simpletikzParser.path_start_return retval = new simpletikzParser.path_start_return();
@@ -10584,20 +10636,20 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.path_start_tag_return path_start_tag322 = default(simpletikzParser.path_start_tag_return);
+        simpletikzParser.path_start_tag_return path_start_tag325 = default(simpletikzParser.path_start_tag_return);
 
 
         RewriteRuleSubtreeStream stream_path_start_tag = new RewriteRuleSubtreeStream(adaptor,"rule path_start_tag");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:558:2: ( path_start_tag -> ^( IM_STARTTAG path_start_tag ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:558:4: path_start_tag
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:558:2: ( path_start_tag -> ^( IM_STARTTAG path_start_tag ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:558:4: path_start_tag
             {
-            	PushFollow(FOLLOW_path_start_tag_in_path_start3424);
-            	path_start_tag322 = path_start_tag();
+            	PushFollow(FOLLOW_path_start_tag_in_path_start3435);
+            	path_start_tag325 = path_start_tag();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_path_start_tag.Add(path_start_tag322.Tree);
+            	if ( state.backtracking==0 ) stream_path_start_tag.Add(path_start_tag325.Tree);
 
 
             	// AST REWRITE
@@ -10613,7 +10665,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 558:19: -> ^( IM_STARTTAG path_start_tag )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:558:22: ^( IM_STARTTAG path_start_tag )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:558:22: ^( IM_STARTTAG path_start_tag )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
@@ -10656,7 +10708,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "node_start"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:560:1: node_start : node_start_tag -> ^( IM_STARTTAG node_start_tag ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:560:1: node_start : node_start_tag -> ^( IM_STARTTAG node_start_tag ) ;
     public simpletikzParser.node_start_return node_start() // throws RecognitionException [1]
     {   
         simpletikzParser.node_start_return retval = new simpletikzParser.node_start_return();
@@ -10664,20 +10716,20 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.node_start_tag_return node_start_tag323 = default(simpletikzParser.node_start_tag_return);
+        simpletikzParser.node_start_tag_return node_start_tag326 = default(simpletikzParser.node_start_tag_return);
 
 
         RewriteRuleSubtreeStream stream_node_start_tag = new RewriteRuleSubtreeStream(adaptor,"rule node_start_tag");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:561:2: ( node_start_tag -> ^( IM_STARTTAG node_start_tag ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:561:4: node_start_tag
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:561:2: ( node_start_tag -> ^( IM_STARTTAG node_start_tag ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:561:4: node_start_tag
             {
-            	PushFollow(FOLLOW_node_start_tag_in_node_start3442);
-            	node_start_tag323 = node_start_tag();
+            	PushFollow(FOLLOW_node_start_tag_in_node_start3453);
+            	node_start_tag326 = node_start_tag();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_node_start_tag.Add(node_start_tag323.Tree);
+            	if ( state.backtracking==0 ) stream_node_start_tag.Add(node_start_tag326.Tree);
 
 
             	// AST REWRITE
@@ -10693,7 +10745,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 561:19: -> ^( IM_STARTTAG node_start_tag )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:561:22: ^( IM_STARTTAG node_start_tag )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:561:22: ^( IM_STARTTAG node_start_tag )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
@@ -10736,7 +10788,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "def_start"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:563:1: def_start : def_start_tag -> ^( IM_STARTTAG def_start_tag ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:563:1: def_start : def_start_tag -> ^( IM_STARTTAG def_start_tag ) ;
     public simpletikzParser.def_start_return def_start() // throws RecognitionException [1]
     {   
         simpletikzParser.def_start_return retval = new simpletikzParser.def_start_return();
@@ -10744,20 +10796,20 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.def_start_tag_return def_start_tag324 = default(simpletikzParser.def_start_tag_return);
+        simpletikzParser.def_start_tag_return def_start_tag327 = default(simpletikzParser.def_start_tag_return);
 
 
         RewriteRuleSubtreeStream stream_def_start_tag = new RewriteRuleSubtreeStream(adaptor,"rule def_start_tag");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:564:2: ( def_start_tag -> ^( IM_STARTTAG def_start_tag ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:564:4: def_start_tag
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:564:2: ( def_start_tag -> ^( IM_STARTTAG def_start_tag ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:564:4: def_start_tag
             {
-            	PushFollow(FOLLOW_def_start_tag_in_def_start3460);
-            	def_start_tag324 = def_start_tag();
+            	PushFollow(FOLLOW_def_start_tag_in_def_start3471);
+            	def_start_tag327 = def_start_tag();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_def_start_tag.Add(def_start_tag324.Tree);
+            	if ( state.backtracking==0 ) stream_def_start_tag.Add(def_start_tag327.Tree);
 
 
             	// AST REWRITE
@@ -10773,7 +10825,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 564:18: -> ^( IM_STARTTAG def_start_tag )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:564:21: ^( IM_STARTTAG def_start_tag )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:564:21: ^( IM_STARTTAG def_start_tag )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
@@ -10816,7 +10868,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "matrix_start"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:566:1: matrix_start : matrix_start_tag -> ^( IM_STARTTAG matrix_start_tag ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:566:1: matrix_start : matrix_start_tag -> ^( IM_STARTTAG matrix_start_tag ) ;
     public simpletikzParser.matrix_start_return matrix_start() // throws RecognitionException [1]
     {   
         simpletikzParser.matrix_start_return retval = new simpletikzParser.matrix_start_return();
@@ -10824,20 +10876,20 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        simpletikzParser.matrix_start_tag_return matrix_start_tag325 = default(simpletikzParser.matrix_start_tag_return);
+        simpletikzParser.matrix_start_tag_return matrix_start_tag328 = default(simpletikzParser.matrix_start_tag_return);
 
 
         RewriteRuleSubtreeStream stream_matrix_start_tag = new RewriteRuleSubtreeStream(adaptor,"rule matrix_start_tag");
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:567:2: ( matrix_start_tag -> ^( IM_STARTTAG matrix_start_tag ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:567:4: matrix_start_tag
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:567:2: ( matrix_start_tag -> ^( IM_STARTTAG matrix_start_tag ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:567:4: matrix_start_tag
             {
-            	PushFollow(FOLLOW_matrix_start_tag_in_matrix_start3478);
-            	matrix_start_tag325 = matrix_start_tag();
+            	PushFollow(FOLLOW_matrix_start_tag_in_matrix_start3489);
+            	matrix_start_tag328 = matrix_start_tag();
             	state.followingStackPointer--;
             	if (state.failed) return retval;
-            	if ( state.backtracking==0 ) stream_matrix_start_tag.Add(matrix_start_tag325.Tree);
+            	if ( state.backtracking==0 ) stream_matrix_start_tag.Add(matrix_start_tag328.Tree);
 
 
             	// AST REWRITE
@@ -10853,7 +10905,7 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 567:21: -> ^( IM_STARTTAG matrix_start_tag )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:567:24: ^( IM_STARTTAG matrix_start_tag )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:567:24: ^( IM_STARTTAG matrix_start_tag )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
@@ -10896,7 +10948,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "node_start_tag"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:569:1: node_start_tag : '\\\\node' ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:569:1: node_start_tag : '\\\\node' ;
     public simpletikzParser.node_start_tag_return node_start_tag() // throws RecognitionException [1]
     {   
         simpletikzParser.node_start_tag_return retval = new simpletikzParser.node_start_tag_return();
@@ -10904,21 +10956,21 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal326 = null;
+        IToken string_literal329 = null;
 
-        object string_literal326_tree=null;
+        object string_literal329_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:570:2: ( '\\\\node' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:570:4: '\\\\node'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:570:2: ( '\\\\node' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:570:4: '\\\\node'
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	string_literal326=(IToken)Match(input,64,FOLLOW_64_in_node_start_tag3496); if (state.failed) return retval;
+            	string_literal329=(IToken)Match(input,65,FOLLOW_65_in_node_start_tag3507); if (state.failed) return retval;
             	if ( state.backtracking == 0 )
-            	{string_literal326_tree = (object)adaptor.Create(string_literal326);
-            		adaptor.AddChild(root_0, string_literal326_tree);
+            	{string_literal329_tree = (object)adaptor.Create(string_literal329);
+            		adaptor.AddChild(root_0, string_literal329_tree);
             	}
 
             }
@@ -10951,7 +11003,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "def_start_tag"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:572:1: def_start_tag : '\\\\def' ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:572:1: def_start_tag : '\\\\def' ;
     public simpletikzParser.def_start_tag_return def_start_tag() // throws RecognitionException [1]
     {   
         simpletikzParser.def_start_tag_return retval = new simpletikzParser.def_start_tag_return();
@@ -10959,21 +11011,21 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal327 = null;
+        IToken string_literal330 = null;
 
-        object string_literal327_tree=null;
+        object string_literal330_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:573:2: ( '\\\\def' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:573:4: '\\\\def'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:573:2: ( '\\\\def' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:573:4: '\\\\def'
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	string_literal327=(IToken)Match(input,69,FOLLOW_69_in_def_start_tag3506); if (state.failed) return retval;
+            	string_literal330=(IToken)Match(input,70,FOLLOW_70_in_def_start_tag3517); if (state.failed) return retval;
             	if ( state.backtracking == 0 )
-            	{string_literal327_tree = (object)adaptor.Create(string_literal327);
-            		adaptor.AddChild(root_0, string_literal327_tree);
+            	{string_literal330_tree = (object)adaptor.Create(string_literal330);
+            		adaptor.AddChild(root_0, string_literal330_tree);
             	}
 
             }
@@ -11006,7 +11058,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "matrix_start_tag"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:575:1: matrix_start_tag : '\\\\matrix' ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:575:1: matrix_start_tag : '\\\\matrix' ;
     public simpletikzParser.matrix_start_tag_return matrix_start_tag() // throws RecognitionException [1]
     {   
         simpletikzParser.matrix_start_tag_return retval = new simpletikzParser.matrix_start_tag_return();
@@ -11014,21 +11066,21 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal328 = null;
+        IToken string_literal331 = null;
 
-        object string_literal328_tree=null;
+        object string_literal331_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:576:2: ( '\\\\matrix' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:576:4: '\\\\matrix'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:576:2: ( '\\\\matrix' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:576:4: '\\\\matrix'
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	string_literal328=(IToken)Match(input,65,FOLLOW_65_in_matrix_start_tag3516); if (state.failed) return retval;
+            	string_literal331=(IToken)Match(input,66,FOLLOW_66_in_matrix_start_tag3527); if (state.failed) return retval;
             	if ( state.backtracking == 0 )
-            	{string_literal328_tree = (object)adaptor.Create(string_literal328);
-            		adaptor.AddChild(root_0, string_literal328_tree);
+            	{string_literal331_tree = (object)adaptor.Create(string_literal331);
+            		adaptor.AddChild(root_0, string_literal331_tree);
             	}
 
             }
@@ -11061,7 +11113,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "coordinate_start"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:578:1: coordinate_start : '\\\\coordinate' -> ^( IM_STARTTAG '\\\\coordinate' ) ;
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:578:1: coordinate_start : '\\\\coordinate' -> ^( IM_STARTTAG '\\\\coordinate' ) ;
     public simpletikzParser.coordinate_start_return coordinate_start() // throws RecognitionException [1]
     {   
         simpletikzParser.coordinate_start_return retval = new simpletikzParser.coordinate_start_return();
@@ -11069,23 +11121,23 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken string_literal329 = null;
+        IToken string_literal332 = null;
 
-        object string_literal329_tree=null;
-        RewriteRuleTokenStream stream_66 = new RewriteRuleTokenStream(adaptor,"token 66");
+        object string_literal332_tree=null;
+        RewriteRuleTokenStream stream_67 = new RewriteRuleTokenStream(adaptor,"token 67");
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:579:2: ( '\\\\coordinate' -> ^( IM_STARTTAG '\\\\coordinate' ) )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:579:4: '\\\\coordinate'
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:579:2: ( '\\\\coordinate' -> ^( IM_STARTTAG '\\\\coordinate' ) )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:579:4: '\\\\coordinate'
             {
-            	string_literal329=(IToken)Match(input,66,FOLLOW_66_in_coordinate_start3526); if (state.failed) return retval; 
-            	if ( state.backtracking==0 ) stream_66.Add(string_literal329);
+            	string_literal332=(IToken)Match(input,67,FOLLOW_67_in_coordinate_start3537); if (state.failed) return retval; 
+            	if ( state.backtracking==0 ) stream_67.Add(string_literal332);
 
 
 
             	// AST REWRITE
-            	// elements:          66
+            	// elements:          67
             	// token labels:      
             	// rule labels:       retval
             	// token list labels: 
@@ -11097,12 +11149,12 @@ public partial class simpletikzParser : Parser
             	root_0 = (object)adaptor.GetNilNode();
             	// 579:19: -> ^( IM_STARTTAG '\\\\coordinate' )
             	{
-            	    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:579:22: ^( IM_STARTTAG '\\\\coordinate' )
+            	    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:579:22: ^( IM_STARTTAG '\\\\coordinate' )
             	    {
             	    object root_1 = (object)adaptor.GetNilNode();
             	    root_1 = (object)adaptor.BecomeRoot((object)adaptor.Create(IM_STARTTAG, "IM_STARTTAG"), root_1);
 
-            	    adaptor.AddChild(root_1, stream_66.NextNode());
+            	    adaptor.AddChild(root_1, stream_67.NextNode());
 
             	    adaptor.AddChild(root_0, root_1);
             	    }
@@ -11140,7 +11192,7 @@ public partial class simpletikzParser : Parser
     };
 
     // $ANTLR start "path_start_tag"
-    // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:581:1: path_start_tag : ( '\\\\draw' | '\\\\fill' | '\\\\path' | '\\\\clip' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' );
+    // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:581:1: path_start_tag : ( '\\\\draw' | '\\\\fill' | '\\\\path' | '\\\\clip' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' );
     public simpletikzParser.path_start_tag_return path_start_tag() // throws RecognitionException [1]
     {   
         simpletikzParser.path_start_tag_return retval = new simpletikzParser.path_start_tag_return();
@@ -11148,22 +11200,22 @@ public partial class simpletikzParser : Parser
 
         object root_0 = null;
 
-        IToken set330 = null;
+        IToken set333 = null;
 
-        object set330_tree=null;
+        object set333_tree=null;
 
         try 
     	{
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:582:2: ( '\\\\draw' | '\\\\fill' | '\\\\path' | '\\\\clip' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' )
-            // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:582:2: ( '\\\\draw' | '\\\\fill' | '\\\\path' | '\\\\clip' | '\\\\filldraw' | '\\\\pattern' | '\\\\shade' | '\\\\shadedraw' | '\\\\useasboundingbox' )
+            // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:
             {
             	root_0 = (object)adaptor.GetNilNode();
 
-            	set330 = (IToken)input.LT(1);
-            	if ( (input.LA(1) >= 67 && input.LA(1) <= 68) || (input.LA(1) >= 70 && input.LA(1) <= 76) ) 
+            	set333 = (IToken)input.LT(1);
+            	if ( (input.LA(1) >= 68 && input.LA(1) <= 69) || (input.LA(1) >= 71 && input.LA(1) <= 77) ) 
             	{
             	    input.Consume();
-            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set330));
+            	    if ( state.backtracking == 0 ) adaptor.AddChild(root_0, (object)adaptor.Create(set333));
             	    state.errorRecovery = false;state.failed = false;
             	}
             	else 
@@ -11195,10 +11247,10 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred1_simpletikz"
     public void synpred1_simpletikz_fragment() {
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:331:5: ( coord )
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:331:6: coord
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:331:5: ( coord )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:331:6: coord
         {
-        	PushFollow(FOLLOW_coord_in_synpred1_simpletikz1878);
+        	PushFollow(FOLLOW_coord_in_synpred1_simpletikz1889);
         	coord();
         	state.followingStackPointer--;
         	if (state.failed) return ;
@@ -11209,10 +11261,10 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred2_simpletikz"
     public void synpred2_simpletikz_fragment() {
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:359:8: ( tikzcoordinate_core3 )
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:359:9: tikzcoordinate_core3
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:8: ( tikzcoordinate_core3 )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:359:9: tikzcoordinate_core3
         {
-        	PushFollow(FOLLOW_tikzcoordinate_core3_in_synpred2_simpletikz2121);
+        	PushFollow(FOLLOW_tikzcoordinate_core3_in_synpred2_simpletikz2132);
         	tikzcoordinate_core3();
         	state.followingStackPointer--;
         	if (state.failed) return ;
@@ -11223,10 +11275,10 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred3_simpletikz"
     public void synpred3_simpletikz_fragment() {
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:360:12: ( tikzcoordinate_core2 )
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:360:13: tikzcoordinate_core2
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:360:12: ( tikzcoordinate_core2 )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:360:13: tikzcoordinate_core2
         {
-        	PushFollow(FOLLOW_tikzcoordinate_core2_in_synpred3_simpletikz2140);
+        	PushFollow(FOLLOW_tikzcoordinate_core2_in_synpred3_simpletikz2151);
         	tikzcoordinate_core2();
         	state.followingStackPointer--;
         	if (state.failed) return ;
@@ -11237,10 +11289,10 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred4_simpletikz"
     public void synpred4_simpletikz_fragment() {
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:361:12: ( tikzcoordinate_core1 )
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:361:13: tikzcoordinate_core1
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:361:12: ( tikzcoordinate_core1 )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:361:13: tikzcoordinate_core1
         {
-        	PushFollow(FOLLOW_tikzcoordinate_core1_in_synpred4_simpletikz2160);
+        	PushFollow(FOLLOW_tikzcoordinate_core1_in_synpred4_simpletikz2171);
         	tikzcoordinate_core1();
         	state.followingStackPointer--;
         	if (state.failed) return ;
@@ -11251,10 +11303,10 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred5_simpletikz"
     public void synpred5_simpletikz_fragment() {
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:370:21: ( tikzcoordinate_core3 )
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:370:22: tikzcoordinate_core3
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:21: ( tikzcoordinate_core3 )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:370:22: tikzcoordinate_core3
         {
-        	PushFollow(FOLLOW_tikzcoordinate_core3_in_synpred5_simpletikz2245);
+        	PushFollow(FOLLOW_tikzcoordinate_core3_in_synpred5_simpletikz2256);
         	tikzcoordinate_core3();
         	state.followingStackPointer--;
         	if (state.failed) return ;
@@ -11265,10 +11317,10 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred6_simpletikz"
     public void synpred6_simpletikz_fragment() {
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:371:12: ( tikzcoordinate_core2 )
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:371:13: tikzcoordinate_core2
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:371:12: ( tikzcoordinate_core2 )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:371:13: tikzcoordinate_core2
         {
-        	PushFollow(FOLLOW_tikzcoordinate_core2_in_synpred6_simpletikz2264);
+        	PushFollow(FOLLOW_tikzcoordinate_core2_in_synpred6_simpletikz2275);
         	tikzcoordinate_core2();
         	state.followingStackPointer--;
         	if (state.failed) return ;
@@ -11279,10 +11331,10 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred7_simpletikz"
     public void synpred7_simpletikz_fragment() {
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:372:12: ( tikzcoordinate_core1 )
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:372:13: tikzcoordinate_core1
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:372:12: ( tikzcoordinate_core1 )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:372:13: tikzcoordinate_core1
         {
-        	PushFollow(FOLLOW_tikzcoordinate_core1_in_synpred7_simpletikz2284);
+        	PushFollow(FOLLOW_tikzcoordinate_core1_in_synpred7_simpletikz2295);
         	tikzcoordinate_core1();
         	state.followingStackPointer--;
         	if (state.failed) return ;
@@ -11293,10 +11345,10 @@ public partial class simpletikzParser : Parser
 
     // $ANTLR start "synpred8_simpletikz"
     public void synpred8_simpletikz_fragment() {
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:420:28: ( size )
-        // C:\\_TUHH\\SVN\\projects\\wsn\\dibus\\SvgMap\\SvgNaviMap\\bargraph\\tikzedt\\TikzParser\\simpletikz.g:420:29: size
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:28: ( size )
+        // E:\\Promotion\\svn\\tikz\\tikzedt\\TikzParser\\simpletikz.g:420:29: size
         {
-        	PushFollow(FOLLOW_size_in_synpred8_simpletikz2576);
+        	PushFollow(FOLLOW_size_in_synpred8_simpletikz2587);
         	size();
         	state.followingStackPointer--;
         	if (state.failed) return ;
@@ -11307,103 +11359,13 @@ public partial class simpletikzParser : Parser
 
     // Delegated rules
 
-   	public bool synpred7_simpletikz() 
+   	public bool synpred8_simpletikz() 
    	{
    	    state.backtracking++;
    	    int start = input.Mark();
    	    try 
    	    {
-   	        synpred7_simpletikz_fragment(); // can never throw exception
-   	    }
-   	    catch (RecognitionException re) 
-   	    {
-   	        Console.Error.WriteLine("impossible: "+re);
-   	    }
-   	    bool success = !state.failed;
-   	    input.Rewind(start);
-   	    state.backtracking--;
-   	    state.failed = false;
-   	    return success;
-   	}
-   	public bool synpred4_simpletikz() 
-   	{
-   	    state.backtracking++;
-   	    int start = input.Mark();
-   	    try 
-   	    {
-   	        synpred4_simpletikz_fragment(); // can never throw exception
-   	    }
-   	    catch (RecognitionException re) 
-   	    {
-   	        Console.Error.WriteLine("impossible: "+re);
-   	    }
-   	    bool success = !state.failed;
-   	    input.Rewind(start);
-   	    state.backtracking--;
-   	    state.failed = false;
-   	    return success;
-   	}
-   	public bool synpred5_simpletikz() 
-   	{
-   	    state.backtracking++;
-   	    int start = input.Mark();
-   	    try 
-   	    {
-   	        synpred5_simpletikz_fragment(); // can never throw exception
-   	    }
-   	    catch (RecognitionException re) 
-   	    {
-   	        Console.Error.WriteLine("impossible: "+re);
-   	    }
-   	    bool success = !state.failed;
-   	    input.Rewind(start);
-   	    state.backtracking--;
-   	    state.failed = false;
-   	    return success;
-   	}
-   	public bool synpred3_simpletikz() 
-   	{
-   	    state.backtracking++;
-   	    int start = input.Mark();
-   	    try 
-   	    {
-   	        synpred3_simpletikz_fragment(); // can never throw exception
-   	    }
-   	    catch (RecognitionException re) 
-   	    {
-   	        Console.Error.WriteLine("impossible: "+re);
-   	    }
-   	    bool success = !state.failed;
-   	    input.Rewind(start);
-   	    state.backtracking--;
-   	    state.failed = false;
-   	    return success;
-   	}
-   	public bool synpred6_simpletikz() 
-   	{
-   	    state.backtracking++;
-   	    int start = input.Mark();
-   	    try 
-   	    {
-   	        synpred6_simpletikz_fragment(); // can never throw exception
-   	    }
-   	    catch (RecognitionException re) 
-   	    {
-   	        Console.Error.WriteLine("impossible: "+re);
-   	    }
-   	    bool success = !state.failed;
-   	    input.Rewind(start);
-   	    state.backtracking--;
-   	    state.failed = false;
-   	    return success;
-   	}
-   	public bool synpred2_simpletikz() 
-   	{
-   	    state.backtracking++;
-   	    int start = input.Mark();
-   	    try 
-   	    {
-   	        synpred2_simpletikz_fragment(); // can never throw exception
+   	        synpred8_simpletikz_fragment(); // can never throw exception
    	    }
    	    catch (RecognitionException re) 
    	    {
@@ -11433,13 +11395,103 @@ public partial class simpletikzParser : Parser
    	    state.failed = false;
    	    return success;
    	}
-   	public bool synpred8_simpletikz() 
+   	public bool synpred4_simpletikz() 
    	{
    	    state.backtracking++;
    	    int start = input.Mark();
    	    try 
    	    {
-   	        synpred8_simpletikz_fragment(); // can never throw exception
+   	        synpred4_simpletikz_fragment(); // can never throw exception
+   	    }
+   	    catch (RecognitionException re) 
+   	    {
+   	        Console.Error.WriteLine("impossible: "+re);
+   	    }
+   	    bool success = !state.failed;
+   	    input.Rewind(start);
+   	    state.backtracking--;
+   	    state.failed = false;
+   	    return success;
+   	}
+   	public bool synpred7_simpletikz() 
+   	{
+   	    state.backtracking++;
+   	    int start = input.Mark();
+   	    try 
+   	    {
+   	        synpred7_simpletikz_fragment(); // can never throw exception
+   	    }
+   	    catch (RecognitionException re) 
+   	    {
+   	        Console.Error.WriteLine("impossible: "+re);
+   	    }
+   	    bool success = !state.failed;
+   	    input.Rewind(start);
+   	    state.backtracking--;
+   	    state.failed = false;
+   	    return success;
+   	}
+   	public bool synpred3_simpletikz() 
+   	{
+   	    state.backtracking++;
+   	    int start = input.Mark();
+   	    try 
+   	    {
+   	        synpred3_simpletikz_fragment(); // can never throw exception
+   	    }
+   	    catch (RecognitionException re) 
+   	    {
+   	        Console.Error.WriteLine("impossible: "+re);
+   	    }
+   	    bool success = !state.failed;
+   	    input.Rewind(start);
+   	    state.backtracking--;
+   	    state.failed = false;
+   	    return success;
+   	}
+   	public bool synpred2_simpletikz() 
+   	{
+   	    state.backtracking++;
+   	    int start = input.Mark();
+   	    try 
+   	    {
+   	        synpred2_simpletikz_fragment(); // can never throw exception
+   	    }
+   	    catch (RecognitionException re) 
+   	    {
+   	        Console.Error.WriteLine("impossible: "+re);
+   	    }
+   	    bool success = !state.failed;
+   	    input.Rewind(start);
+   	    state.backtracking--;
+   	    state.failed = false;
+   	    return success;
+   	}
+   	public bool synpred5_simpletikz() 
+   	{
+   	    state.backtracking++;
+   	    int start = input.Mark();
+   	    try 
+   	    {
+   	        synpred5_simpletikz_fragment(); // can never throw exception
+   	    }
+   	    catch (RecognitionException re) 
+   	    {
+   	        Console.Error.WriteLine("impossible: "+re);
+   	    }
+   	    bool success = !state.failed;
+   	    input.Rewind(start);
+   	    state.backtracking--;
+   	    state.failed = false;
+   	    return success;
+   	}
+   	public bool synpred6_simpletikz() 
+   	{
+   	    state.backtracking++;
+   	    int start = input.Mark();
+   	    try 
+   	    {
+   	        synpred6_simpletikz_fragment(); // can never throw exception
    	    }
    	    catch (RecognitionException re) 
    	    {
@@ -11506,15 +11558,15 @@ public partial class simpletikzParser : Parser
     const string DFA10_minS =
         "\x02\x04\x02\uffff";
     const string DFA10_maxS =
-        "\x02\x5e\x02\uffff";
+        "\x02\x5f\x02\uffff";
     const string DFA10_acceptS =
         "\x02\uffff\x01\x02\x01\x01";
     const string DFA10_specialS =
         "\x04\uffff}>";
     static readonly string[] DFA10_transitionS = {
-            "\x27\x01\x03\uffff\x01\x01\x04\uffff\x01\x01\x05\uffff\x26"+
+            "\x27\x01\x03\uffff\x01\x01\x04\uffff\x02\x01\x05\uffff\x26"+
             "\x01",
-            "\x27\x01\x03\x02\x01\x01\x01\x02\x01\uffff\x02\x03\x01\x01"+
+            "\x27\x01\x03\x02\x01\x01\x01\x02\x01\uffff\x02\x03\x02\x01"+
             "\x03\uffff\x01\x02\x01\uffff\x26\x01",
             "",
             ""
@@ -11556,109 +11608,109 @@ public partial class simpletikzParser : Parser
     const string DFA16_eofS =
         "\x39\uffff";
     const string DFA16_minS =
-        "\x01\x04\x01\x2b\x01\x04\x01\uffff\x01\x2b\x01\x1e\x01\uffff\x01"+
-        "\x04\x01\uffff\x01\x04\x01\uffff\x11\x04\x01\uffff\x1c\x04";
+        "\x01\x04\x01\x2b\x01\x04\x01\uffff\x01\x2b\x01\x1e\x01\uffff\x02"+
+        "\x04\x02\uffff\x10\x04\x01\uffff\x1d\x04";
     const string DFA16_maxS =
-        "\x01\x5e\x01\x3e\x01\x5e\x01\uffff\x01\x37\x01\x2b\x01\uffff\x01"+
-        "\x5e\x01\uffff\x01\x5e\x01\uffff\x11\x5e\x01\uffff\x1c\x5e";
+        "\x01\x5f\x01\x3f\x01\x5f\x01\uffff\x01\x38\x01\x2b\x01\uffff\x02"+
+        "\x5f\x02\uffff\x10\x5f\x01\uffff\x1d\x5f";
     const string DFA16_acceptS =
-        "\x03\uffff\x01\x04\x02\uffff\x01\x02\x01\uffff\x01\x05\x01\uffff"+
-        "\x01\x01\x11\uffff\x01\x03\x1c\uffff";
+        "\x03\uffff\x01\x04\x02\uffff\x01\x02\x02\uffff\x01\x05\x01\x01"+
+        "\x10\uffff\x01\x03\x1d\uffff";
     const string DFA16_specialS =
         "\x39\uffff}>";
     static readonly string[] DFA16_transitionS = {
             "\x1a\x03\x02\x01\x0b\x03\x01\x02\x02\uffff\x01\x03\x04\uffff"+
-            "\x01\x03\x05\uffff\x26\x03",
-            "\x02\x06\x02\uffff\x01\x06\x01\x05\x06\uffff\x01\x06\x01\uffff"+
+            "\x02\x03\x05\uffff\x26\x03",
+            "\x02\x06\x02\uffff\x01\x06\x01\x05\x07\uffff\x01\x06\x01\uffff"+
             "\x06\x04",
-            "\x30\x08\x01\x07\x24\x08\x02\x09\x04\x08",
+            "\x31\x09\x01\x07\x24\x09\x02\x08\x04\x09",
             "",
-            "\x02\x06\x02\uffff\x01\x06\x01\x0a\x06\uffff\x01\x06",
-            "\x02\x0a\x0b\uffff\x01\x08",
+            "\x02\x06\x02\uffff\x01\x06\x01\x0a\x07\uffff\x01\x06",
+            "\x02\x0a\x0b\uffff\x01\x09",
             "",
-            "\x1a\x0d\x02\x0c\x0b\x0d\x01\x0b\x02\x08\x01\x0d\x04\x08\x01"+
-            "\x0d\x05\x08\x26\x0d",
+            "\x1a\x0c\x02\x0b\x0b\x0c\x01\x0d\x02\x09\x01\x0c\x04\x09\x02"+
+            "\x0c\x05\x09\x26\x0c",
+            "\x31\x09\x01\x0e\x2a\x09",
             "",
-            "\x30\x08\x01\x0e\x2a\x08",
             "",
-            "\x27\x0f\x03\x08\x01\x0f\x04\x08\x01\x0f\x05\x08\x26\x0f",
-            "\x27\x0d\x02\x08\x01\x12\x01\x0d\x02\x11\x02\x08\x01\x0d\x01"+
-            "\x08\x01\x13\x03\x08\x06\x10\x20\x0d",
-            "\x27\x0d\x02\x08\x01\x12\x01\x0d\x02\x14\x02\x08\x01\x0d\x01"+
-            "\x08\x01\x13\x03\x08\x26\x0d",
-            "\x1a\x16\x02\x15\x0b\x16\x01\x0b\x02\x08\x01\x16\x04\x08\x01"+
-            "\x16\x05\x08\x26\x16",
-            "\x27\x0f\x01\x08\x01\x17\x01\x08\x01\x0f\x04\x08\x01\x0f\x05"+
-            "\x08\x26\x0f",
-            "\x27\x0d\x02\x08\x01\x12\x01\x0d\x02\x11\x02\x08\x01\x0d\x01"+
-            "\x08\x01\x13\x03\x08\x26\x0d",
-            "\x1a\x1a\x02\x19\x0b\x1a\x01\x18\x02\x08\x01\x1a\x04\x08\x01"+
-            "\x1a\x05\x08\x26\x1a",
-            "\x1a\x08\x02\x1b\x3f\x08",
-            "\x28\x08\x01\x1c\x32\x08",
-            "\x27\x1a\x01\x18\x02\x08\x01\x1a\x04\x08\x01\x1a\x05\x08\x26"+
+            "\x27\x0c\x02\x09\x01\x0f\x01\x0c\x02\x11\x02\x09\x02\x0c\x01"+
+            "\x09\x01\x12\x03\x09\x06\x10\x20\x0c",
+            "\x27\x0c\x02\x09\x01\x0f\x01\x0c\x02\x13\x02\x09\x02\x0c\x01"+
+            "\x09\x01\x12\x03\x09\x26\x0c",
+            "\x27\x14\x03\x09\x01\x14\x04\x09\x02\x14\x05\x09\x26\x14",
+            "\x1a\x16\x02\x15\x0b\x16\x01\x0d\x02\x09\x01\x16\x04\x09\x02"+
+            "\x16\x05\x09\x26\x16",
+            "\x1a\x09\x02\x17\x40\x09",
+            "\x27\x0c\x02\x09\x01\x0f\x01\x0c\x02\x11\x02\x09\x02\x0c\x01"+
+            "\x09\x01\x12\x03\x09\x26\x0c",
+            "\x1a\x1a\x02\x18\x0b\x1a\x01\x19\x02\x09\x01\x1a\x04\x09\x02"+
+            "\x1a\x05\x09\x26\x1a",
+            "\x28\x09\x01\x1b\x33\x09",
+            "\x27\x1a\x01\x19\x02\x09\x01\x1a\x04\x09\x02\x1a\x05\x09\x26"+
             "\x1a",
-            "\x27\x16\x02\x08\x01\x12\x01\x16\x02\x11\x02\x08\x01\x16\x05"+
-            "\x08\x06\x1d\x20\x16",
-            "\x27\x16\x02\x08\x01\x12\x01\x16\x02\x14\x02\x08\x01\x16\x05"+
-            "\x08\x26\x16",
-            "\x2b\x08\x02\x1e\x2e\x08",
-            "\x27\x1f\x03\x08\x01\x1f\x04\x08\x01\x1f\x05\x08\x26\x1f",
-            "\x27\x1a\x02\x08\x01\x20\x01\x1a\x04\x08\x01\x1a\x01\x08\x01"+
-            "\x22\x03\x08\x06\x21\x20\x1a",
-            "\x27\x1a\x02\x08\x01\x20\x01\x1a\x04\x08\x01\x1a\x01\x08\x01"+
-            "\x23\x03\x08\x26\x1a",
-            "\x27\x26\x03\x08\x01\x26\x01\x25\x01\x14\x02\x08\x01\x26\x05"+
-            "\x08\x06\x24\x20\x26",
+            "\x27\x14\x01\x09\x01\x1c\x01\x09\x01\x14\x04\x09\x02\x14\x05"+
+            "\x09\x26\x14",
+            "\x27\x16\x02\x09\x01\x0f\x01\x16\x02\x11\x02\x09\x02\x16\x05"+
+            "\x09\x06\x1d\x20\x16",
+            "\x27\x16\x02\x09\x01\x0f\x01\x16\x02\x13\x02\x09\x02\x16\x05"+
+            "\x09\x26\x16",
+            "\x27\x20\x03\x09\x01\x20\x01\x1f\x01\x13\x02\x09\x02\x20\x05"+
+            "\x09\x06\x1e\x20\x20",
+            "\x27\x1a\x02\x09\x01\x23\x01\x1a\x04\x09\x02\x1a\x01\x09\x01"+
+            "\x21\x03\x09\x06\x22\x20\x1a",
+            "\x27\x24\x03\x09\x01\x24\x04\x09\x02\x24\x05\x09\x26\x24",
+            "\x27\x1a\x02\x09\x01\x23\x01\x1a\x04\x09\x02\x1a\x01\x09\x01"+
+            "\x25\x03\x09\x26\x1a",
             "",
-            "\x27\x16\x02\x08\x01\x12\x01\x16\x02\x11\x02\x08\x01\x16\x05"+
-            "\x08\x26\x16",
-            "\x27\x27\x01\x18\x02\x08\x01\x27\x04\x08\x01\x27\x05\x08\x26"+
-            "\x27",
-            "\x27\x1f\x01\x08\x01\x28\x01\x08\x01\x1f\x04\x08\x01\x1f\x05"+
-            "\x08\x26\x1f",
-            "\x1a\x08\x02\x29\x3f\x08",
-            "\x27\x1a\x02\x08\x01\x20\x01\x1a\x04\x08\x01\x1a\x01\x08\x01"+
-            "\x22\x03\x08\x26\x1a",
-            "\x28\x08\x01\x1c\x32\x08",
-            "\x28\x08\x01\x1c\x32\x08",
-            "\x27\x26\x02\x08\x01\x12\x01\x26\x01\x25\x01\x14\x02\x08\x01"+
-            "\x26\x05\x08\x26\x26",
-            "\x27\x2a\x01\x18\x02\x08\x01\x2a\x02\x14\x02\x08\x01\x2a\x05"+
-            "\x08\x26\x2a",
-            "\x27\x26\x02\x08\x01\x12\x01\x26\x04\x08\x01\x26\x05\x08\x26"+
-            "\x26",
-            "\x27\x27\x02\x08\x01\x2b\x01\x27\x04\x08\x01\x27\x01\x08\x01"+
-            "\x2c\x03\x08\x26\x27",
-            "\x31\x08\x01\x2c\x29\x08",
-            "\x27\x2f\x03\x08\x01\x2f\x01\x2e\x03\x08\x01\x2f\x01\x08\x01"+
-            "\x23\x03\x08\x06\x2d\x20\x2f",
-            "\x27\x2a\x02\x08\x01\x30\x01\x2a\x04\x08\x01\x2a\x01\x08\x01"+
-            "\x23\x03\x08\x26\x2a",
-            "\x1a\x08\x02\x31\x3f\x08",
-            "\x28\x08\x01\x1c\x32\x08",
-            "\x27\x2f\x02\x08\x01\x20\x01\x2f\x01\x2e\x03\x08\x01\x2f\x01"+
-            "\x08\x01\x23\x03\x08\x26\x2f",
-            "\x27\x2f\x03\x08\x01\x2f\x04\x08\x01\x2f\x01\x08\x01\x23\x03"+
-            "\x08\x26\x2f",
-            "\x27\x2f\x02\x08\x01\x20\x01\x2f\x04\x08\x01\x2f\x05\x08\x26"+
-            "\x2f",
-            "\x1a\x08\x02\x32\x3f\x08",
-            "\x27\x35\x03\x08\x01\x35\x01\x34\x03\x08\x01\x35\x01\x08\x01"+
-            "\x2c\x03\x08\x06\x33\x20\x35",
-            "\x27\x38\x03\x08\x01\x38\x01\x37\x01\x14\x02\x08\x01\x38\x01"+
-            "\x08\x01\x23\x03\x08\x06\x36\x20\x38",
-            "\x27\x35\x02\x08\x01\x2b\x01\x35\x01\x34\x03\x08\x01\x35\x01"+
-            "\x08\x01\x2c\x03\x08\x26\x35",
-            "\x27\x35\x03\x08\x01\x35\x04\x08\x01\x35\x01\x08\x01\x2c\x03"+
-            "\x08\x26\x35",
-            "\x27\x35\x02\x08\x01\x2b\x01\x35\x04\x08\x01\x35\x05\x08\x26"+
+            "\x2b\x09\x02\x26\x2f\x09",
+            "\x27\x16\x02\x09\x01\x0f\x01\x16\x02\x11\x02\x09\x02\x16\x05"+
+            "\x09\x26\x16",
+            "\x27\x20\x02\x09\x01\x0f\x01\x20\x01\x1f\x01\x13\x02\x09\x02"+
+            "\x20\x05\x09\x26\x20",
+            "\x27\x27\x01\x19\x02\x09\x01\x27\x02\x13\x02\x09\x02\x27\x05"+
+            "\x09\x26\x27",
+            "\x27\x20\x02\x09\x01\x0f\x01\x20\x04\x09\x02\x20\x05\x09\x26"+
+            "\x20",
+            "\x28\x09\x01\x1b\x33\x09",
+            "\x27\x1a\x02\x09\x01\x23\x01\x1a\x04\x09\x02\x1a\x01\x09\x01"+
+            "\x21\x03\x09\x26\x1a",
+            "\x1a\x09\x02\x28\x40\x09",
+            "\x27\x24\x01\x09\x01\x29\x01\x09\x01\x24\x04\x09\x02\x24\x05"+
+            "\x09\x26\x24",
+            "\x28\x09\x01\x1b\x33\x09",
+            "\x27\x2a\x01\x19\x02\x09\x01\x2a\x04\x09\x02\x2a\x05\x09\x26"+
+            "\x2a",
+            "\x27\x27\x02\x09\x01\x2b\x01\x27\x04\x09\x02\x27\x01\x09\x01"+
+            "\x25\x03\x09\x26\x27",
+            "\x27\x2e\x03\x09\x01\x2e\x01\x2d\x03\x09\x02\x2e\x01\x09\x01"+
+            "\x25\x03\x09\x06\x2c\x20\x2e",
+            "\x32\x09\x01\x2f\x29\x09",
+            "\x27\x2a\x02\x09\x01\x30\x01\x2a\x04\x09\x02\x2a\x01\x09\x01"+
+            "\x2f\x03\x09\x26\x2a",
+            "\x1a\x09\x02\x31\x40\x09",
+            "\x27\x2e\x02\x09\x01\x23\x01\x2e\x01\x2d\x03\x09\x02\x2e\x01"+
+            "\x09\x01\x25\x03\x09\x26\x2e",
+            "\x27\x2e\x03\x09\x01\x2e\x04\x09\x02\x2e\x01\x09\x01\x25\x03"+
+            "\x09\x26\x2e",
+            "\x27\x2e\x02\x09\x01\x23\x01\x2e\x04\x09\x02\x2e\x05\x09\x26"+
+            "\x2e",
+            "\x28\x09\x01\x1b\x33\x09",
+            "\x1a\x09\x02\x32\x40\x09",
+            "\x27\x35\x03\x09\x01\x35\x01\x34\x01\x13\x02\x09\x02\x35\x01"+
+            "\x09\x01\x25\x03\x09\x06\x33\x20\x35",
+            "\x27\x38\x03\x09\x01\x38\x01\x37\x03\x09\x02\x38\x01\x09\x01"+
+            "\x2f\x03\x09\x06\x36\x20\x38",
+            "\x27\x35\x02\x09\x01\x2b\x01\x35\x01\x34\x01\x13\x02\x09\x02"+
+            "\x35\x01\x09\x01\x25\x03\x09\x26\x35",
+            "\x27\x27\x01\x19\x02\x09\x01\x27\x02\x13\x02\x09\x02\x27\x01"+
+            "\x09\x01\x25\x03\x09\x26\x27",
+            "\x27\x35\x02\x09\x01\x2b\x01\x35\x04\x09\x02\x35\x05\x09\x26"+
             "\x35",
-            "\x27\x38\x02\x08\x01\x30\x01\x38\x01\x37\x01\x14\x02\x08\x01"+
-            "\x38\x01\x08\x01\x23\x03\x08\x26\x38",
-            "\x27\x2a\x01\x18\x02\x08\x01\x2a\x02\x14\x02\x08\x01\x2a\x01"+
-            "\x08\x01\x23\x03\x08\x26\x2a",
-            "\x27\x38\x02\x08\x01\x30\x01\x38\x04\x08\x01\x38\x05\x08\x26"+
+            "\x27\x38\x02\x09\x01\x30\x01\x38\x01\x37\x03\x09\x02\x38\x01"+
+            "\x09\x01\x2f\x03\x09\x26\x38",
+            "\x27\x38\x03\x09\x01\x38\x04\x09\x02\x38\x01\x09\x01\x2f\x03"+
+            "\x09\x26\x38",
+            "\x27\x38\x02\x09\x01\x30\x01\x38\x04\x09\x02\x38\x05\x09\x26"+
             "\x38"
     };
 
@@ -11700,14 +11752,14 @@ public partial class simpletikzParser : Parser
     const string DFA33_minS =
         "\x01\x04\x01\x2b\x09\uffff\x01\x1c\x02\uffff";
     const string DFA33_maxS =
-        "\x01\x5e\x01\x2b\x09\uffff\x01\x5e\x02\uffff";
+        "\x01\x5f\x01\x2b\x09\uffff\x01\x5f\x02\uffff";
     const string DFA33_acceptS =
         "\x02\uffff\x01\x02\x01\x03\x01\x04\x01\x05\x01\x06\x01\x07\x01"+
         "\x08\x01\x0a\x01\x0b\x01\uffff\x01\x01\x01\x09";
     const string DFA33_specialS =
         "\x0e\uffff}>";
     static readonly string[] DFA33_transitionS = {
-            "\x23\x0a\x01\x01\x01\x08\x01\x07\x0c\x0a\x01\uffff\x08\x0a"+
+            "\x23\x0a\x01\x01\x01\x08\x01\x07\x0d\x0a\x01\uffff\x08\x0a"+
             "\x01\x09\x01\x03\x01\x05\x01\x06\x02\x02\x01\x04\x07\x02\x12"+
             "\x0a",
             "\x01\x0b",
@@ -11720,7 +11772,7 @@ public partial class simpletikzParser : Parser
             "",
             "",
             "",
-            "\x01\x0d\x41\uffff\x01\x0c",
+            "\x01\x0d\x42\uffff\x01\x0c",
             "",
             ""
     };
@@ -11763,14 +11815,14 @@ public partial class simpletikzParser : Parser
     const string DFA34_minS =
         "\x01\x04\x02\x2b\x08\uffff\x02\x1c\x04\uffff";
     const string DFA34_maxS =
-        "\x01\x5e\x02\x2b\x08\uffff\x02\x5e\x04\uffff";
+        "\x01\x5f\x02\x2b\x08\uffff\x02\x5f\x04\uffff";
     const string DFA34_acceptS =
         "\x03\uffff\x01\x02\x01\x03\x01\x04\x01\x05\x01\x06\x01\x07\x01"+
         "\x08\x01\x0b\x02\uffff\x01\x0c\x01\x0a\x01\x01\x01\x09";
     const string DFA34_specialS =
         "\x11\uffff}>";
     static readonly string[] DFA34_transitionS = {
-            "\x23\x0a\x01\x02\x01\x09\x01\x08\x15\x0a\x01\x01\x01\x04\x01"+
+            "\x23\x0a\x01\x02\x01\x09\x01\x08\x16\x0a\x01\x01\x01\x04\x01"+
             "\x06\x01\x07\x02\x03\x01\x05\x07\x03\x12\x0a",
             "\x01\x0b",
             "\x01\x0c",
@@ -11782,8 +11834,8 @@ public partial class simpletikzParser : Parser
             "",
             "",
             "",
-            "\x01\x0e\x40\uffff\x02\x0d",
-            "\x01\x10\x41\uffff\x01\x0f",
+            "\x01\x0e\x41\uffff\x02\x0d",
+            "\x01\x10\x42\uffff\x01\x0f",
             "",
             "",
             "",
@@ -11828,14 +11880,14 @@ public partial class simpletikzParser : Parser
     const string DFA35_minS =
         "\x01\x04\x01\x2b\x09\uffff\x01\x1c\x02\uffff";
     const string DFA35_maxS =
-        "\x01\x5e\x01\x2b\x09\uffff\x01\x5e\x02\uffff";
+        "\x01\x5f\x01\x2b\x09\uffff\x01\x5f\x02\uffff";
     const string DFA35_acceptS =
         "\x02\uffff\x01\x02\x01\x03\x01\x04\x01\x05\x01\x06\x01\x07\x01"+
         "\x08\x01\x0a\x01\x0b\x01\uffff\x01\x01\x01\x09";
     const string DFA35_specialS =
         "\x0e\uffff}>";
     static readonly string[] DFA35_transitionS = {
-            "\x23\x0a\x01\x01\x01\x08\x01\x07\x01\x0a\x02\uffff\x09\x0a"+
+            "\x23\x0a\x01\x01\x01\x08\x01\x07\x01\x0a\x02\uffff\x0a\x0a"+
             "\x01\uffff\x08\x0a\x01\x09\x01\x03\x01\x05\x01\x06\x02\x02\x01"+
             "\x04\x07\x02\x12\x0a",
             "\x01\x0b",
@@ -11848,7 +11900,7 @@ public partial class simpletikzParser : Parser
             "",
             "",
             "",
-            "\x01\x0d\x41\uffff\x01\x0c",
+            "\x01\x0d\x42\uffff\x01\x0c",
             "",
             ""
     };
@@ -11891,7 +11943,7 @@ public partial class simpletikzParser : Parser
     const string DFA36_minS =
         "\x01\x04\x01\uffff\x01\x2b\x09\uffff\x01\x1c\x02\uffff";
     const string DFA36_maxS =
-        "\x01\x5e\x01\uffff\x01\x2b\x09\uffff\x01\x5e\x02\uffff";
+        "\x01\x5f\x01\uffff\x01\x2b\x09\uffff\x01\x5f\x02\uffff";
     const string DFA36_acceptS =
         "\x01\uffff\x01\x0c\x01\uffff\x01\x02\x01\x03\x01\x04\x01\x05\x01"+
         "\x06\x01\x07\x01\x08\x01\x0a\x01\x0b\x01\uffff\x01\x01\x01\x09";
@@ -11899,7 +11951,7 @@ public partial class simpletikzParser : Parser
         "\x0f\uffff}>";
     static readonly string[] DFA36_transitionS = {
             "\x23\x0b\x01\x02\x01\x09\x01\x08\x01\x0b\x01\uffff\x01\x01"+
-            "\x12\x0b\x01\x0a\x01\x04\x01\x06\x01\x07\x02\x03\x01\x05\x07"+
+            "\x13\x0b\x01\x0a\x01\x04\x01\x06\x01\x07\x02\x03\x01\x05\x07"+
             "\x03\x12\x0b",
             "",
             "\x01\x0c",
@@ -11912,7 +11964,7 @@ public partial class simpletikzParser : Parser
             "",
             "",
             "",
-            "\x01\x0e\x41\uffff\x01\x0d",
+            "\x01\x0e\x42\uffff\x01\x0d",
             "",
             ""
     };
@@ -11955,14 +12007,14 @@ public partial class simpletikzParser : Parser
     const string DFA43_minS =
         "\x01\x1c\x04\uffff\x01\x00\x08\uffff";
     const string DFA43_maxS =
-        "\x01\x5b\x04\uffff\x01\x00\x08\uffff";
+        "\x01\x5c\x04\uffff\x01\x00\x08\uffff";
     const string DFA43_acceptS =
         "\x01\uffff\x01\x01\x01\x02\x01\x03\x01\x04\x01\uffff\x01\x05\x01"+
         "\x06\x01\x07\x01\x08\x01\uffff\x01\x09\x01\x0b\x01\x0a";
     const string DFA43_specialS =
         "\x01\x00\x04\uffff\x01\x01\x08\uffff}>";
     static readonly string[] DFA43_transitionS = {
-            "\x01\x0c\x01\x02\x0d\uffff\x01\x0b\x01\uffff\x01\x02\x06\uffff"+
+            "\x01\x0c\x01\x02\x0d\uffff\x01\x0b\x01\uffff\x01\x02\x07\uffff"+
             "\x01\x05\x01\uffff\x01\x01\x03\uffff\x01\x02\x12\uffff\x01\x02"+
             "\x01\uffff\x01\x08\x01\x07\x01\uffff\x02\x09\x01\x03\x04\x0c"+
             "\x02\x04\x01\x06",
@@ -12026,27 +12078,27 @@ public partial class simpletikzParser : Parser
                    	int index43_0 = input.Index();
                    	input.Rewind();
                    	s = -1;
-                   	if ( (LA43_0 == 54) ) { s = 1; }
+                   	if ( (LA43_0 == 55) ) { s = 1; }
 
-                   	else if ( (LA43_0 == COMMAND || LA43_0 == 45 || LA43_0 == 58 || LA43_0 == 77) ) { s = 2; }
+                   	else if ( (LA43_0 == COMMAND || LA43_0 == 45 || LA43_0 == 59 || LA43_0 == 78) ) { s = 2; }
 
-                   	else if ( (LA43_0 == 84) ) { s = 3; }
+                   	else if ( (LA43_0 == 85) ) { s = 3; }
 
-                   	else if ( ((LA43_0 >= 89 && LA43_0 <= 90)) && (synpred1_simpletikz()) ) { s = 4; }
+                   	else if ( ((LA43_0 >= 90 && LA43_0 <= 91)) && (synpred1_simpletikz()) ) { s = 4; }
 
-                   	else if ( (LA43_0 == 52) ) { s = 5; }
+                   	else if ( (LA43_0 == 53) ) { s = 5; }
 
-                   	else if ( (LA43_0 == 91) ) { s = 6; }
+                   	else if ( (LA43_0 == 92) ) { s = 6; }
 
-                   	else if ( (LA43_0 == 80) ) { s = 7; }
+                   	else if ( (LA43_0 == 81) ) { s = 7; }
 
-                   	else if ( (LA43_0 == 79) ) { s = 8; }
+                   	else if ( (LA43_0 == 80) ) { s = 8; }
 
-                   	else if ( ((LA43_0 >= 82 && LA43_0 <= 83)) ) { s = 9; }
+                   	else if ( ((LA43_0 >= 83 && LA43_0 <= 84)) ) { s = 9; }
 
                    	else if ( (LA43_0 == 43) ) { s = 11; }
 
-                   	else if ( (LA43_0 == ID || (LA43_0 >= 85 && LA43_0 <= 88)) ) { s = 12; }
+                   	else if ( (LA43_0 == ID || (LA43_0 >= 86 && LA43_0 <= 89)) ) { s = 12; }
 
                    	 
                    	input.Seek(index43_0);
@@ -12081,13 +12133,13 @@ public partial class simpletikzParser : Parser
     const string DFA48_minS =
         "\x01\x1c\x03\x00\x0e\uffff";
     const string DFA48_maxS =
-        "\x01\x5b\x03\x00\x0e\uffff";
+        "\x01\x5c\x03\x00\x0e\uffff";
     const string DFA48_acceptS =
         "\x04\uffff\x01\x04\x0a\uffff\x01\x01\x01\x02\x01\x03";
     const string DFA48_specialS =
         "\x01\uffff\x01\x00\x01\x01\x01\x02\x0e\uffff}>";
     static readonly string[] DFA48_transitionS = {
-            "\x02\x04\x0d\uffff\x01\x04\x01\uffff\x01\x04\x06\uffff\x01"+
+            "\x02\x04\x0d\uffff\x01\x04\x01\uffff\x01\x04\x07\uffff\x01"+
             "\x01\x01\uffff\x01\x03\x01\uffff\x01\x04\x01\uffff\x01\x04\x12"+
             "\uffff\x01\x04\x01\uffff\x02\x04\x01\x02\x0a\x04",
             "\x01\uffff",
@@ -12216,13 +12268,13 @@ public partial class simpletikzParser : Parser
     const string DFA50_minS =
         "\x01\x1c\x03\x00\x11\uffff";
     const string DFA50_maxS =
-        "\x01\x5b\x03\x00\x11\uffff";
+        "\x01\x5c\x03\x00\x11\uffff";
     const string DFA50_acceptS =
         "\x04\uffff\x01\x04\x0d\uffff\x01\x01\x01\x02\x01\x03";
     const string DFA50_specialS =
         "\x01\uffff\x01\x00\x01\x01\x01\x02\x11\uffff}>";
     static readonly string[] DFA50_transitionS = {
-            "\x02\x04\x0d\uffff\x03\x04\x01\uffff\x01\x04\x04\uffff\x01"+
+            "\x02\x04\x0d\uffff\x03\x04\x01\uffff\x01\x04\x05\uffff\x01"+
             "\x01\x01\x04\x01\x03\x01\uffff\x01\x04\x01\uffff\x01\x04\x12"+
             "\uffff\x01\x04\x01\uffff\x02\x04\x01\x02\x0a\x04",
             "\x01\uffff",
@@ -12352,34 +12404,34 @@ public partial class simpletikzParser : Parser
     const string DFA57_eofS =
         "\x0a\uffff";
     const string DFA57_minS =
-        "\x01\x1c\x01\x04\x01\uffff\x01\x04\x01\x00\x02\x04\x01\uffff\x02"+
+        "\x01\x1c\x01\x04\x01\uffff\x03\x04\x01\x00\x01\x04\x01\uffff\x01"+
         "\x04";
     const string DFA57_maxS =
-        "\x01\x5b\x01\x5e\x01\uffff\x01\x5e\x01\x00\x02\x5e\x01\uffff\x02"+
-        "\x5e";
+        "\x01\x5c\x01\x5f\x01\uffff\x03\x5f\x01\x00\x01\x5f\x01\uffff\x01"+
+        "\x5f";
     const string DFA57_acceptS =
-        "\x02\uffff\x01\x02\x04\uffff\x01\x01\x02\uffff";
+        "\x02\uffff\x01\x02\x05\uffff\x01\x01\x01\uffff";
     const string DFA57_specialS =
-        "\x04\uffff\x01\x00\x05\uffff}>";
+        "\x06\uffff\x01\x00\x03\uffff}>";
     static readonly string[] DFA57_transitionS = {
-            "\x02\x02\x0d\uffff\x03\x02\x01\uffff\x01\x02\x04\uffff\x01"+
+            "\x02\x02\x0d\uffff\x03\x02\x01\uffff\x01\x02\x05\uffff\x01"+
             "\x01\x02\x02\x01\uffff\x01\x02\x01\uffff\x01\x02\x12\uffff\x01"+
             "\x02\x01\uffff\x02\x02\x01\uffff\x0a\x02",
-            "\x1a\x02\x02\x03\x0c\x02\x01\uffff\x02\x02\x04\uffff\x04\x02"+
+            "\x1a\x02\x02\x03\x0c\x02\x01\uffff\x02\x02\x04\uffff\x05\x02"+
             "\x02\uffff\x26\x02",
             "",
-            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x01\x02\x01\uffff\x01"+
-            "\x04\x03\uffff\x06\x05\x0f\x02\x01\x06\x10\x02",
-            "\x01\uffff",
-            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x01\x02\x01\uffff\x01"+
-            "\x04\x03\uffff\x15\x02\x01\x06\x10\x02",
-            "\x1a\x02\x02\x08\x0b\x02\x02\uffff\x04\x02\x02\uffff\x01\x02"+
+            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x02\x02\x01\uffff\x01"+
+            "\x06\x03\uffff\x06\x04\x0f\x02\x01\x05\x10\x02",
+            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x02\x02\x01\uffff\x01"+
+            "\x06\x03\uffff\x15\x02\x01\x05\x10\x02",
+            "\x1a\x02\x02\x07\x0b\x02\x02\uffff\x04\x02\x02\uffff\x02\x02"+
             "\x01\uffff\x01\x02\x03\uffff\x26\x02",
+            "\x01\uffff",
+            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x02\x02\x01\uffff\x01"+
+            "\x06\x03\uffff\x06\x09\x20\x02",
             "",
-            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x01\x02\x01\uffff\x01"+
-            "\x04\x03\uffff\x06\x09\x20\x02",
-            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x01\x02\x01\uffff\x01"+
-            "\x04\x03\uffff\x26\x02"
+            "\x27\x02\x02\uffff\x04\x02\x02\uffff\x02\x02\x01\uffff\x01"+
+            "\x06\x03\uffff\x26\x02"
     };
 
     static readonly short[] DFA57_eot = DFA.UnpackEncodedString(DFA57_eotS);
@@ -12421,18 +12473,18 @@ public partial class simpletikzParser : Parser
         switch ( s )
         {
                	case 0 : 
-                   	int LA57_4 = input.LA(1);
+                   	int LA57_6 = input.LA(1);
 
                    	 
-                   	int index57_4 = input.Index();
+                   	int index57_6 = input.Index();
                    	input.Rewind();
                    	s = -1;
-                   	if ( (synpred8_simpletikz()) ) { s = 7; }
+                   	if ( (synpred8_simpletikz()) ) { s = 8; }
 
                    	else if ( (true) ) { s = 2; }
 
                    	 
-                   	input.Seek(index57_4);
+                   	input.Seek(index57_6);
                    	if ( s >= 0 ) return s;
                    	break;
         }
@@ -12447,51 +12499,51 @@ public partial class simpletikzParser : Parser
     const string DFA60_eofS =
         "\x14\uffff";
     const string DFA60_minS =
-        "\x01\x54\x01\x34\x01\x04\x01\uffff\x02\x04\x01\uffff\x0a\x04\x01"+
-        "\uffff\x02\x04";
+        "\x01\x55\x01\x35\x01\x04\x01\uffff\x01\x04\x01\uffff\x0a\x04\x01"+
+        "\uffff\x03\x04";
     const string DFA60_maxS =
-        "\x01\x54\x01\x36\x01\x5e\x01\uffff\x02\x5e\x01\uffff\x0a\x5e\x01"+
-        "\uffff\x02\x5e";
+        "\x01\x55\x01\x37\x01\x5f\x01\uffff\x01\x5f\x01\uffff\x0a\x5f\x01"+
+        "\uffff\x03\x5f";
     const string DFA60_acceptS =
-        "\x03\uffff\x01\x03\x02\uffff\x01\x02\x0a\uffff\x01\x01\x02\uffff";
+        "\x03\uffff\x01\x03\x01\uffff\x01\x02\x0a\uffff\x01\x01\x03\uffff";
     const string DFA60_specialS =
         "\x14\uffff}>";
     static readonly string[] DFA60_transitionS = {
             "\x01\x01",
             "\x01\x02\x01\uffff\x01\x03",
-            "\x19\x06\x01\x05\x02\x04\x0c\x06\x02\uffff\x01\x06\x04\uffff"+
-            "\x01\x06\x05\uffff\x26\x06",
+            "\x19\x05\x01\x06\x02\x04\x0c\x05\x02\uffff\x01\x05\x04\uffff"+
+            "\x02\x05\x05\uffff\x26\x05",
             "",
-            "\x27\x06\x02\uffff\x02\x06\x01\uffff\x01\x07\x02\uffff\x01"+
-            "\x06\x05\uffff\x06\x08\x20\x06",
-            "\x27\x06\x02\uffff\x02\x06\x01\uffff\x01\x07\x02\uffff\x01"+
-            "\x06\x05\uffff\x26\x06",
+            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x08\x02\uffff\x02"+
+            "\x05\x05\uffff\x06\x07\x20\x05",
             "",
-            "\x19\x06\x01\x0a\x02\x09\x0c\x06\x02\uffff\x01\x06\x04\uffff"+
-            "\x01\x06\x05\uffff\x26\x06",
-            "\x27\x06\x02\uffff\x02\x06\x01\uffff\x01\x07\x02\uffff\x01"+
-            "\x06\x05\uffff\x26\x06",
-            "\x27\x06\x02\uffff\x02\x06\x01\uffff\x01\x0c\x02\uffff\x01"+
-            "\x06\x05\uffff\x06\x0b\x20\x06",
-            "\x27\x06\x02\uffff\x02\x06\x01\uffff\x01\x0c\x02\uffff\x01"+
-            "\x06\x05\uffff\x26\x06",
-            "\x27\x06\x02\uffff\x02\x06\x01\uffff\x01\x0c\x02\uffff\x01"+
-            "\x06\x05\uffff\x26\x06",
-            "\x19\x06\x01\x0e\x02\x0d\x0c\x06\x02\uffff\x01\x06\x04\uffff"+
-            "\x01\x06\x05\uffff\x26\x06",
-            "\x27\x06\x02\uffff\x02\x06\x04\uffff\x01\x06\x01\uffff\x01"+
-            "\x11\x03\uffff\x06\x0f\x0f\x06\x01\x10\x10\x06",
-            "\x27\x06\x02\uffff\x02\x06\x04\uffff\x01\x06\x01\uffff\x01"+
-            "\x11\x03\uffff\x15\x06\x01\x10\x10\x06",
-            "\x27\x06\x02\uffff\x02\x06\x04\uffff\x01\x06\x01\uffff\x01"+
-            "\x11\x03\uffff\x15\x06\x01\x10\x10\x06",
-            "\x1a\x06\x02\x12\x0b\x06\x02\uffff\x02\x06\x04\uffff\x01\x06"+
-            "\x01\uffff\x01\x06\x03\uffff\x26\x06",
+            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x08\x02\uffff\x02"+
+            "\x05\x05\uffff\x26\x05",
+            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x08\x02\uffff\x02"+
+            "\x05\x05\uffff\x26\x05",
+            "\x19\x05\x01\x0a\x02\x09\x0c\x05\x02\uffff\x01\x05\x04\uffff"+
+            "\x02\x05\x05\uffff\x26\x05",
+            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x0c\x02\uffff\x02"+
+            "\x05\x05\uffff\x06\x0b\x20\x05",
+            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x0c\x02\uffff\x02"+
+            "\x05\x05\uffff\x26\x05",
+            "\x27\x05\x02\uffff\x02\x05\x01\uffff\x01\x0c\x02\uffff\x02"+
+            "\x05\x05\uffff\x26\x05",
+            "\x19\x05\x01\x0e\x02\x0d\x0c\x05\x02\uffff\x01\x05\x04\uffff"+
+            "\x02\x05\x05\uffff\x26\x05",
+            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x02\x05\x01\uffff\x01"+
+            "\x10\x03\uffff\x06\x11\x0f\x05\x01\x0f\x10\x05",
+            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x02\x05\x01\uffff\x01"+
+            "\x10\x03\uffff\x15\x05\x01\x0f\x10\x05",
+            "\x1a\x05\x02\x12\x0b\x05\x02\uffff\x02\x05\x04\uffff\x02\x05"+
+            "\x01\uffff\x01\x05\x03\uffff\x26\x05",
             "",
-            "\x27\x06\x02\uffff\x02\x06\x04\uffff\x01\x06\x01\uffff\x01"+
-            "\x11\x03\uffff\x06\x13\x20\x06",
-            "\x27\x06\x02\uffff\x02\x06\x04\uffff\x01\x06\x01\uffff\x01"+
-            "\x11\x03\uffff\x26\x06"
+            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x02\x05\x01\uffff\x01"+
+            "\x10\x03\uffff\x15\x05\x01\x0f\x10\x05",
+            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x02\x05\x01\uffff\x01"+
+            "\x10\x03\uffff\x06\x13\x20\x05",
+            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x02\x05\x01\uffff\x01"+
+            "\x10\x03\uffff\x26\x05"
     };
 
     static readonly short[] DFA60_eot = DFA.UnpackEncodedString(DFA60_eotS);
@@ -12530,37 +12582,35 @@ public partial class simpletikzParser : Parser
     const string DFA67_eofS =
         "\x0d\uffff";
     const string DFA67_minS =
-        "\x02\x34\x01\x04\x01\uffff\x01\x04\x01\uffff\x01\x04\x01\uffff"+
-        "\x03\x04\x01\uffff\x01\x04";
+        "\x02\x35\x01\x04\x01\uffff\x02\x04\x02\uffff\x04\x04\x01\uffff";
     const string DFA67_maxS =
-        "\x01\x5a\x01\x34\x01\x5e\x01\uffff\x01\x5e\x01\uffff\x01\x5e\x01"+
-        "\uffff\x03\x5e\x01\uffff\x01\x5e";
+        "\x01\x5b\x01\x35\x01\x5f\x01\uffff\x02\x5f\x02\uffff\x04\x5f\x01"+
+        "\uffff";
     const string DFA67_acceptS =
-        "\x03\uffff\x01\x04\x01\uffff\x01\x01\x01\uffff\x01\x03\x03\uffff"+
-        "\x01\x02\x01\uffff";
+        "\x03\uffff\x01\x04\x02\uffff\x01\x03\x01\x01\x04\uffff\x01\x02";
     const string DFA67_specialS =
         "\x0d\uffff}>";
     static readonly string[] DFA67_transitionS = {
             "\x01\x02\x24\uffff\x02\x01",
             "\x01\x02",
-            "\x1a\x06\x02\x04\x0b\x06\x01\x07\x02\uffff\x01\x06\x04\uffff"+
-            "\x01\x06\x01\uffff\x01\x03\x01\x05\x02\uffff\x26\x06",
+            "\x1a\x05\x02\x04\x0b\x05\x01\x06\x02\uffff\x01\x05\x04\uffff"+
+            "\x02\x05\x01\uffff\x01\x03\x01\x07\x02\uffff\x26\x05",
             "",
-            "\x27\x06\x02\uffff\x01\x07\x01\x06\x02\x09\x02\uffff\x01\x06"+
-            "\x01\uffff\x01\x05\x03\uffff\x06\x08\x20\x06",
+            "\x27\x05\x02\uffff\x01\x06\x01\x05\x02\x09\x02\uffff\x02\x05"+
+            "\x01\uffff\x01\x07\x03\uffff\x06\x08\x20\x05",
+            "\x27\x05\x02\uffff\x01\x06\x01\x05\x02\x06\x02\uffff\x02\x05"+
+            "\x01\uffff\x01\x07\x03\uffff\x26\x05",
             "",
-            "\x27\x06\x02\uffff\x01\x07\x01\x06\x02\x07\x02\uffff\x01\x06"+
-            "\x01\uffff\x01\x05\x03\uffff\x26\x06",
             "",
-            "\x27\x06\x02\uffff\x01\x07\x01\x06\x02\x09\x02\uffff\x01\x06"+
-            "\x01\uffff\x01\x05\x03\uffff\x26\x06",
-            "\x1a\x07\x02\x0a\x0c\x07\x02\uffff\x01\x07\x04\uffff\x01\x07"+
-            "\x05\uffff\x26\x07",
-            "\x27\x07\x02\uffff\x02\x07\x04\uffff\x01\x07\x01\uffff\x01"+
-            "\x0b\x03\uffff\x06\x0c\x20\x07",
-            "",
-            "\x27\x07\x02\uffff\x02\x07\x04\uffff\x01\x07\x01\uffff\x01"+
-            "\x0b\x03\uffff\x26\x07"
+            "\x27\x05\x02\uffff\x01\x06\x01\x05\x02\x09\x02\uffff\x02\x05"+
+            "\x01\uffff\x01\x07\x03\uffff\x26\x05",
+            "\x1a\x06\x02\x0a\x0c\x06\x02\uffff\x01\x06\x04\uffff\x02\x06"+
+            "\x05\uffff\x26\x06",
+            "\x27\x06\x02\uffff\x02\x06\x04\uffff\x02\x06\x01\uffff\x01"+
+            "\x0c\x03\uffff\x06\x0b\x20\x06",
+            "\x27\x06\x02\uffff\x02\x06\x04\uffff\x02\x06\x01\uffff\x01"+
+            "\x0c\x03\uffff\x26\x06",
+            ""
     };
 
     static readonly short[] DFA67_eot = DFA.UnpackEncodedString(DFA67_eotS);
@@ -12599,40 +12649,40 @@ public partial class simpletikzParser : Parser
     const string DFA70_eofS =
         "\x0f\uffff";
     const string DFA70_minS =
-        "\x01\x34\x01\x04\x01\x34\x02\x04\x01\uffff\x02\x04\x01\uffff\x05"+
+        "\x01\x35\x01\x04\x01\x35\x01\x04\x01\uffff\x02\x04\x01\uffff\x06"+
         "\x04\x01\uffff";
     const string DFA70_maxS =
-        "\x01\x5a\x01\x5e\x01\x34\x02\x5e\x01\uffff\x02\x5e\x01\uffff\x05"+
-        "\x5e\x01\uffff";
+        "\x01\x5b\x01\x5f\x01\x35\x01\x5f\x01\uffff\x02\x5f\x01\uffff\x06"+
+        "\x5f\x01\uffff";
     const string DFA70_acceptS =
-        "\x05\uffff\x01\x03\x02\uffff\x01\x01\x05\uffff\x01\x02";
+        "\x04\uffff\x01\x03\x02\uffff\x01\x01\x06\uffff\x01\x02";
     const string DFA70_specialS =
         "\x0f\uffff}>";
     static readonly string[] DFA70_transitionS = {
             "\x01\x01\x24\uffff\x02\x02",
-            "\x1a\x04\x02\x03\x0b\x04\x01\x05\x02\uffff\x01\x04\x04\uffff"+
-            "\x01\x04\x05\uffff\x26\x04",
+            "\x1a\x05\x02\x03\x0b\x05\x01\x04\x02\uffff\x01\x05\x04\uffff"+
+            "\x02\x05\x05\uffff\x26\x05",
             "\x01\x06",
-            "\x27\x04\x02\uffff\x01\x05\x01\x04\x02\x09\x02\uffff\x01\x04"+
-            "\x01\uffff\x01\x08\x03\uffff\x06\x07\x20\x04",
-            "\x27\x04\x02\uffff\x01\x05\x01\x04\x02\x05\x02\uffff\x01\x04"+
-            "\x01\uffff\x01\x08\x03\uffff\x26\x04",
+            "\x27\x05\x02\uffff\x01\x04\x01\x05\x02\x09\x02\uffff\x02\x05"+
+            "\x01\uffff\x01\x07\x03\uffff\x06\x08\x20\x05",
             "",
-            "\x1a\x05\x02\x0a\x0c\x05\x02\uffff\x01\x05\x04\uffff\x01\x05"+
-            "\x05\uffff\x26\x05",
-            "\x27\x04\x02\uffff\x01\x05\x01\x04\x02\x09\x02\uffff\x01\x04"+
-            "\x01\uffff\x01\x08\x03\uffff\x26\x04",
+            "\x27\x05\x02\uffff\x01\x04\x01\x05\x02\x04\x02\uffff\x02\x05"+
+            "\x01\uffff\x01\x07\x03\uffff\x26\x05",
+            "\x1a\x04\x02\x0a\x0c\x04\x02\uffff\x01\x04\x04\uffff\x02\x04"+
+            "\x05\uffff\x26\x04",
             "",
-            "\x1a\x05\x02\x0b\x0c\x05\x02\uffff\x01\x05\x04\uffff\x01\x05"+
-            "\x05\uffff\x26\x05",
-            "\x27\x05\x02\uffff\x02\x05\x02\x09\x02\uffff\x01\x05\x05\uffff"+
-            "\x06\x0c\x20\x05",
-            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x01\x05\x01\uffff\x01"+
-            "\x0e\x03\uffff\x06\x0d\x20\x05",
-            "\x27\x05\x02\uffff\x02\x05\x02\x09\x02\uffff\x01\x05\x05\uffff"+
-            "\x26\x05",
-            "\x27\x05\x02\uffff\x02\x05\x04\uffff\x01\x05\x01\uffff\x01"+
-            "\x0e\x03\uffff\x26\x05",
+            "\x27\x05\x02\uffff\x01\x04\x01\x05\x02\x09\x02\uffff\x02\x05"+
+            "\x01\uffff\x01\x07\x03\uffff\x26\x05",
+            "\x1a\x04\x02\x0b\x0c\x04\x02\uffff\x01\x04\x04\uffff\x02\x04"+
+            "\x05\uffff\x26\x04",
+            "\x27\x04\x02\uffff\x02\x04\x02\x09\x02\uffff\x02\x04\x05\uffff"+
+            "\x06\x0c\x20\x04",
+            "\x27\x04\x02\uffff\x02\x04\x04\uffff\x02\x04\x01\uffff\x01"+
+            "\x0e\x03\uffff\x06\x0d\x20\x04",
+            "\x27\x04\x02\uffff\x02\x04\x02\x09\x02\uffff\x02\x04\x05\uffff"+
+            "\x26\x04",
+            "\x27\x04\x02\uffff\x02\x04\x04\uffff\x02\x04\x01\uffff\x01"+
+            "\x0e\x03\uffff\x26\x04",
             ""
     };
 
@@ -12674,25 +12724,25 @@ public partial class simpletikzParser : Parser
     const string DFA73_minS =
         "\x02\x04\x02\uffff\x01\x04\x01\uffff\x02\x04";
     const string DFA73_maxS =
-        "\x02\x5e\x02\uffff\x01\x5e\x01\uffff\x02\x5e";
+        "\x02\x5f\x02\uffff\x01\x5f\x01\uffff\x02\x5f";
     const string DFA73_acceptS =
         "\x02\uffff\x01\x02\x01\x03\x01\uffff\x01\x01\x02\uffff";
     const string DFA73_specialS =
         "\x08\uffff}>";
     static readonly string[] DFA73_transitionS = {
-            "\x27\x01\x01\x02\x02\uffff\x01\x01\x04\uffff\x01\x01\x05\uffff"+
+            "\x27\x01\x01\x02\x02\uffff\x01\x01\x04\uffff\x02\x01\x05\uffff"+
             "\x26\x01",
-            "\x27\x01\x02\uffff\x01\x03\x01\x01\x02\x05\x02\uffff\x01\x01"+
+            "\x27\x01\x02\uffff\x01\x03\x01\x01\x02\x05\x02\uffff\x02\x01"+
             "\x01\uffff\x01\x05\x03\uffff\x15\x01\x01\x04\x10\x01",
             "",
             "",
             "\x1a\x01\x02\x06\x0b\x01\x02\uffff\x01\x03\x01\x01\x02\x05"+
-            "\x02\uffff\x01\x01\x01\uffff\x01\x05\x03\uffff\x15\x01\x01\x04"+
+            "\x02\uffff\x02\x01\x01\uffff\x01\x05\x03\uffff\x15\x01\x01\x04"+
             "\x10\x01",
             "",
-            "\x27\x01\x02\uffff\x01\x03\x01\x01\x02\x05\x02\uffff\x01\x01"+
+            "\x27\x01\x02\uffff\x01\x03\x01\x01\x02\x05\x02\uffff\x02\x01"+
             "\x01\uffff\x01\x05\x03\uffff\x06\x07\x0f\x01\x01\x04\x10\x01",
-            "\x27\x01\x02\uffff\x01\x03\x01\x01\x02\x05\x02\uffff\x01\x01"+
+            "\x27\x01\x02\uffff\x01\x03\x01\x01\x02\x05\x02\uffff\x02\x01"+
             "\x01\uffff\x01\x05\x03\uffff\x15\x01\x01\x04\x10\x01"
     };
 
@@ -12729,13 +12779,13 @@ public partial class simpletikzParser : Parser
 
  
 
-    public static readonly BitSet FOLLOW_dontcare_preamble_in_tikzdocument257 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_styleorsetorcmd_in_tikzdocument261 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherbegin_in_tikzdocument265 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpicture_in_tikzdocument270 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_dontcare_preamble_in_tikzdocument_wo_tikzpicture296 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_styleorsetorcmd_in_tikzdocument_wo_tikzpicture300 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherbegin_in_tikzdocument_wo_tikzpicture304 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
+    public static readonly BitSet FOLLOW_dontcare_preamble_in_tikzdocument257 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_styleorsetorcmd_in_tikzdocument261 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherbegin_in_tikzdocument265 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpicture_in_tikzdocument270 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_dontcare_preamble_in_tikzdocument_wo_tikzpicture296 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_styleorsetorcmd_in_tikzdocument_wo_tikzpicture300 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherbegin_in_tikzdocument_wo_tikzpicture304 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
     public static readonly BitSet FOLLOW_EOF_in_tikzdocument_wo_tikzpicture309 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_TIKZEDT_CMD_COMMENT_in_tikz_cmd_comment330 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_tikz_style_in_tikz_styleorsetorcmd352 = new BitSet(new ulong[]{0x0000000000000002UL});
@@ -12747,28 +12797,28 @@ public partial class simpletikzParser : Parser
     public static readonly BitSet FOLLOW_idd2_in_otherbegin404 = new BitSet(new ulong[]{0x0000100000000000UL});
     public static readonly BitSet FOLLOW_44_in_otherbegin406 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_40_in_tikz_style418 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikz_style420 = new BitSet(new ulong[]{0xFE0847FFFFFFFFF0UL,0x000000007FFFFFFFUL});
+    public static readonly BitSet FOLLOW_43_in_tikz_style420 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
     public static readonly BitSet FOLLOW_idd_in_tikz_style422 = new BitSet(new ulong[]{0x0000100000000000UL});
     public static readonly BitSet FOLLOW_44_in_tikz_style424 = new BitSet(new ulong[]{0x0000600000000000UL});
-    public static readonly BitSet FOLLOW_45_in_tikz_style427 = new BitSet(new ulong[]{0x0040000000000000UL});
-    public static readonly BitSet FOLLOW_46_in_tikz_style431 = new BitSet(new ulong[]{0x0040000000000000UL});
+    public static readonly BitSet FOLLOW_45_in_tikz_style427 = new BitSet(new ulong[]{0x0080000000000000UL});
+    public static readonly BitSet FOLLOW_46_in_tikz_style431 = new BitSet(new ulong[]{0x0080000000000000UL});
     public static readonly BitSet FOLLOW_tikz_options_in_tikz_style434 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_squarebr_start_in_tikz_options456 = new BitSet(new ulong[]{0xFE884FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_option_in_tikz_options459 = new BitSet(new ulong[]{0xFE88CFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_47_in_tikz_options462 = new BitSet(new ulong[]{0xFE0847FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_option_in_tikz_options464 = new BitSet(new ulong[]{0xFE88CFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_47_in_tikz_options468 = new BitSet(new ulong[]{0xFE884FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzstring_in_tikz_options473 = new BitSet(new ulong[]{0xFE884FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
+    public static readonly BitSet FOLLOW_squarebr_start_in_tikz_options456 = new BitSet(new ulong[]{0xFD184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_option_in_tikz_options459 = new BitSet(new ulong[]{0xFD18CFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_47_in_tikz_options462 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_option_in_tikz_options464 = new BitSet(new ulong[]{0xFD18CFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_47_in_tikz_options468 = new BitSet(new ulong[]{0xFD184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzstring_in_tikz_options473 = new BitSet(new ulong[]{0xFD184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
     public static readonly BitSet FOLLOW_squarebr_end_in_tikz_options476 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_option_style_in_option501 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_option_kv_in_option510 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_idd_in_option_kv524 = new BitSet(new ulong[]{0x0000200000000002UL});
-    public static readonly BitSet FOLLOW_45_in_option_kv527 = new BitSet(new ulong[]{0xFE084FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
+    public static readonly BitSet FOLLOW_45_in_option_kv527 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
     public static readonly BitSet FOLLOW_iddornumberunitorstringorrange_in_option_kv529 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_43_in_tikzstring557 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_no_rlbrace_in_tikzstring559 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzstring_in_tikzstring563 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_no_rlbrace_in_tikzstring565 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
+    public static readonly BitSet FOLLOW_43_in_tikzstring557 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_no_rlbrace_in_tikzstring559 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzstring_in_tikzstring563 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_no_rlbrace_in_tikzstring565 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
     public static readonly BitSet FOLLOW_44_in_tikzstring570 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_set_in_no_rlbrace593 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_range_in_iddornumberunitorstringorrange611 = new BitSet(new ulong[]{0x0000000000000002UL});
@@ -12778,7 +12828,7 @@ public partial class simpletikzParser : Parser
     public static readonly BitSet FOLLOW_number_in_iddornumberunitorstringorrange630 = new BitSet(new ulong[]{0x0001000000000000UL});
     public static readonly BitSet FOLLOW_48_in_iddornumberunitorstringorrange633 = new BitSet(new ulong[]{0x0000080000000000UL});
     public static readonly BitSet FOLLOW_tikzstring_in_iddornumberunitorstringorrange638 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_43_in_bracedcoord652 = new BitSet(new ulong[]{0x0010000000000000UL,0x0000000006000000UL});
+    public static readonly BitSet FOLLOW_43_in_bracedcoord652 = new BitSet(new ulong[]{0x0020000000000000UL,0x000000000C000000UL});
     public static readonly BitSet FOLLOW_coord_nooption_in_bracedcoord656 = new BitSet(new ulong[]{0x0000100000000000UL});
     public static readonly BitSet FOLLOW_44_in_bracedcoord658 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_numberunit_in_range669 = new BitSet(new ulong[]{0x0001000000000000UL});
@@ -12788,283 +12838,286 @@ public partial class simpletikzParser : Parser
     public static readonly BitSet FOLLOW_49_in_option_style700 = new BitSet(new ulong[]{0x0000200000000000UL});
     public static readonly BitSet FOLLOW_50_in_option_style705 = new BitSet(new ulong[]{0x0008000000000000UL});
     public static readonly BitSet FOLLOW_51_in_option_style707 = new BitSet(new ulong[]{0x0000200000000000UL});
-    public static readonly BitSet FOLLOW_45_in_option_style711 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_option_style713 = new BitSet(new ulong[]{0xFE08D7FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_option_kv_in_option_style716 = new BitSet(new ulong[]{0x0000900000000000UL});
-    public static readonly BitSet FOLLOW_47_in_option_style719 = new BitSet(new ulong[]{0xFE0847FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_option_kv_in_option_style721 = new BitSet(new ulong[]{0x0000900000000000UL});
-    public static readonly BitSet FOLLOW_47_in_option_style728 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_option_style731 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_idd_heavenknowswhythisisnecessary_in_idd766 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_set_in_idd_heavenknowswhythisisnecessary786 = new BitSet(new ulong[]{0xFE0847FFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_ID_in_idd2846 = new BitSet(new ulong[]{0x0000000010000002UL});
-    public static readonly BitSet FOLLOW_numberunit_in_numberunitorvariable865 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_COMMAND_in_numberunitorvariable870 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_number_in_numberunit883 = new BitSet(new ulong[]{0x7E00000000000002UL});
-    public static readonly BitSet FOLLOW_unit_in_numberunit885 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_set_in_number911 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_49_in_option_style714 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_number_in_option_style716 = new BitSet(new ulong[]{0x0010000000000000UL});
+    public static readonly BitSet FOLLOW_52_in_option_style718 = new BitSet(new ulong[]{0x0000200000000000UL});
+    public static readonly BitSet FOLLOW_45_in_option_style722 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_option_style724 = new BitSet(new ulong[]{0xFC18D7FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_option_kv_in_option_style727 = new BitSet(new ulong[]{0x0000900000000000UL});
+    public static readonly BitSet FOLLOW_47_in_option_style730 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_option_kv_in_option_style732 = new BitSet(new ulong[]{0x0000900000000000UL});
+    public static readonly BitSet FOLLOW_47_in_option_style739 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_option_style742 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_idd_heavenknowswhythisisnecessary_in_idd777 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_set_in_idd_heavenknowswhythisisnecessary797 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_ID_in_idd2857 = new BitSet(new ulong[]{0x0000000010000002UL});
+    public static readonly BitSet FOLLOW_numberunit_in_numberunitorvariable876 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_COMMAND_in_numberunitorvariable881 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_number_in_numberunit894 = new BitSet(new ulong[]{0xFC00000000000002UL});
+    public static readonly BitSet FOLLOW_unit_in_numberunit896 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_set_in_number922 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_set_in_unit0 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikz_set_start_in_tikz_set966 = new BitSet(new ulong[]{0xFE0857FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_option_in_tikz_set969 = new BitSet(new ulong[]{0xFE08D7FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_47_in_tikz_set972 = new BitSet(new ulong[]{0xFE0847FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_option_in_tikz_set974 = new BitSet(new ulong[]{0xFE08D7FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_47_in_tikz_set978 = new BitSet(new ulong[]{0xFE0857FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_roundbr_end_in_tikz_set983 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzpicture_start_in_tikzpicture1015 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_options_in_tikzpicture1017 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzbody_in_tikzpicture1020 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpicture_end_in_tikzpicture1023 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikz_start_in_tikzpicture1048 = new BitSet(new ulong[]{0x0040080000000000UL});
-    public static readonly BitSet FOLLOW_tikz_options_in_tikzpicture1051 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikzpicture1054 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzbody2_in_tikzpicture1056 = new BitSet(new ulong[]{0xFE0857FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_roundbr_end_in_tikzpicture1059 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody1091 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody1095 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody1099 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody1103 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody1107 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody1111 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody1115 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody1119 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody1123 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherend_in_tikzbody1128 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_dontcare_body_nobr_in_tikzbody1133 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody1144 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody1148 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody1152 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody1156 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody1160 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody1164 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody1168 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody1172 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody1176 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherend_in_tikzbody1181 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_dontcare_body_in_tikzbody1186 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody21202 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody21206 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody21210 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody21214 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody21218 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody21222 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody21226 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody21230 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody21234 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherend_in_tikzbody21239 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_dontcare_body_nobr2_in_tikzbody21244 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody21255 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody21259 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody21263 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody21267 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody21271 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody21275 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody21279 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody21283 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody21287 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_otherend_in_tikzbody21292 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_dontcare_body2_in_tikzbody21297 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_set_in_dontcare_body_nobr21314 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_set_in_dontcare_body21408 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_set_in_dontcare_body_nobr1498 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_set_in_dontcare_body1585 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_63_in_otherend1668 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_otherend1670 = new BitSet(new ulong[]{0x0000000010000000UL});
-    public static readonly BitSet FOLLOW_idd2_in_otherend1672 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_otherend1674 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzscope_start_in_tikzscope1701 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_options_in_tikzscope1703 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzbody_in_tikzscope1706 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzscope_end_in_tikzscope1709 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_path_start_in_tikzpath1765 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzpath1767 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_semicolon_end_in_tikzpath1770 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikz_set_start_in_tikz_set977 = new BitSet(new ulong[]{0xFC1857FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_option_in_tikz_set980 = new BitSet(new ulong[]{0xFC18D7FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_47_in_tikz_set983 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_option_in_tikz_set985 = new BitSet(new ulong[]{0xFC18D7FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_47_in_tikz_set989 = new BitSet(new ulong[]{0xFC1857FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_roundbr_end_in_tikz_set994 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzpicture_start_in_tikzpicture1026 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_options_in_tikzpicture1028 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzbody_in_tikzpicture1031 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpicture_end_in_tikzpicture1034 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikz_start_in_tikzpicture1059 = new BitSet(new ulong[]{0x0080080000000000UL});
+    public static readonly BitSet FOLLOW_tikz_options_in_tikzpicture1062 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_tikzpicture1065 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzbody2_in_tikzpicture1067 = new BitSet(new ulong[]{0xFC1857FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_roundbr_end_in_tikzpicture1070 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody1102 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody1106 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody1110 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody1114 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody1118 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody1122 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody1126 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody1130 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody1134 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherend_in_tikzbody1139 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_dontcare_body_nobr_in_tikzbody1144 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody1155 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody1159 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody1163 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody1167 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody1171 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody1175 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody1179 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody1183 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody1187 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherend_in_tikzbody1192 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_dontcare_body_in_tikzbody1197 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody21213 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody21217 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody21221 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody21225 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody21229 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody21233 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody21237 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody21241 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody21245 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherend_in_tikzbody21250 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_dontcare_body_nobr2_in_tikzbody21255 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzscope_in_tikzbody21266 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpath_in_tikzbody21270 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikznode_ext_in_tikzbody21274 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzdef_ext_in_tikzbody21278 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzmatrix_ext_in_tikzbody21282 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_ext_in_tikzbody21286 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_set_in_tikzbody21290 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_style_in_tikzbody21294 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherbegin_in_tikzbody21298 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_otherend_in_tikzbody21303 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_dontcare_body2_in_tikzbody21308 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_set_in_dontcare_body_nobr21325 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_set_in_dontcare_body21419 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_set_in_dontcare_body_nobr1509 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_set_in_dontcare_body1596 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_64_in_otherend1679 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_otherend1681 = new BitSet(new ulong[]{0x0000000010000000UL});
+    public static readonly BitSet FOLLOW_idd2_in_otherend1683 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_otherend1685 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzscope_start_in_tikzscope1712 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_options_in_tikzscope1714 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzbody_in_tikzscope1717 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzscope_end_in_tikzscope1720 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_path_start_in_tikzpath1776 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzpath1778 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_semicolon_end_in_tikzpath1781 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_set_in_let_cmd_parts0 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_single_in_tikzpath_element1826 = new BitSet(new ulong[]{0x0000800000000002UL});
-    public static readonly BitSet FOLLOW_47_in_tikzpath_element1828 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikz_options_in_tikzpath_element_single1846 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_let_cmd_parts_in_tikzpath_element_single1853 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_arc_in_tikzpath_element_single1871 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_in_tikzpath_element_single1881 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_controls_in_tikzpath_element_single1887 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikznode_int_in_tikzpath_element_single1893 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_int_in_tikzpath_element_single1899 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_circle_in_tikzpath_element_single1905 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_roundbr_start_in_tikzpath_element_single1912 = new BitSet(new ulong[]{0xFE587FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzpath_element_single1914 = new BitSet(new ulong[]{0xFE587FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_roundbr_end_in_tikzpath_element_single1917 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_52_in_tikzpath_element_single1937 = new BitSet(new ulong[]{0x0470280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzpath_element_single1939 = new BitSet(new ulong[]{0x0470280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_53_in_tikzpath_element_single1942 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_edgeop_in_tikzpath_element_single1961 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_controls_start_in_controls1976 = new BitSet(new ulong[]{0x0010000000000000UL,0x0000000006000000UL});
-    public static readonly BitSet FOLLOW_coord_in_controls1978 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000008004000UL});
-    public static readonly BitSet FOLLOW_78_in_controls1981 = new BitSet(new ulong[]{0x0010000000000000UL,0x0000000006000000UL});
-    public static readonly BitSet FOLLOW_coord_in_controls1983 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000008004000UL});
-    public static readonly BitSet FOLLOW_controls_end_in_controls1987 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_node_start_in_tikznode_ext2013 = new BitSet(new ulong[]{0x0050080000000000UL,0x0000000000020000UL});
-    public static readonly BitSet FOLLOW_tikznode_core_in_tikznode_ext2015 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikznode_ext2017 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_semicolon_end_in_tikznode_ext2020 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_def_start_in_tikzdef_ext2045 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzdef_ext2047 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_semicolon_end_in_tikzdef_ext2050 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_matrix_start_in_tikzmatrix_ext2075 = new BitSet(new ulong[]{0x0050080000000000UL,0x0000000000020000UL});
-    public static readonly BitSet FOLLOW_tikznode_core_in_tikzmatrix_ext2077 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzmatrix_ext2079 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_semicolon_end_in_tikzmatrix_ext2082 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coordinate_start_in_tikzcoordinate_ext2110 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFFA000UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_ext2125 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_ext2144 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_ext2164 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzcoordinate_ext2175 = new BitSet(new ulong[]{0x0550280030000000UL,0x000000000FFDA000UL});
-    public static readonly BitSet FOLLOW_semicolon_end_in_tikzcoordinate_ext2178 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_79_in_tikzcoordinate_int2238 = new BitSet(new ulong[]{0x0050000000000002UL,0x0000000000020000UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_int2249 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_int2268 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_int2288 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_80_in_tikznode_int2304 = new BitSet(new ulong[]{0x0050080000000000UL,0x0000000000020000UL});
-    public static readonly BitSet FOLLOW_tikznode_core_in_tikznode_int2307 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikznode_core2317 = new BitSet(new ulong[]{0x0050080000000000UL,0x0000000000020000UL});
-    public static readonly BitSet FOLLOW_tikzstring_in_tikznode_core2320 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core32345 = new BitSet(new ulong[]{0x0050000000000000UL,0x0000000000020000UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core32347 = new BitSet(new ulong[]{0x0050000000000000UL,0x0000000000020000UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core32349 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core22383 = new BitSet(new ulong[]{0x0050000000000000UL,0x0000000000020000UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core22385 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core12418 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_nodename_in_tikznode_decorator2455 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_81_in_tikznode_decorator2462 = new BitSet(new ulong[]{0x0000000020000000UL});
-    public static readonly BitSet FOLLOW_COMMAND_in_tikznode_decorator2465 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_81_in_tikznode_decorator2471 = new BitSet(new ulong[]{0x0010000000000000UL,0x0000000006000000UL});
-    public static readonly BitSet FOLLOW_coord_in_tikznode_decorator2474 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikz_options_dontcare_in_tikznode_decorator2480 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_54_in_tikz_options_dontcare2490 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_no_rlbracket_in_tikz_options_dontcare2492 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_options_dontcare_in_tikz_options_dontcare2496 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_no_rlbracket_in_tikz_options_dontcare2498 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_55_in_tikz_options_dontcare2503 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_set_in_no_rlbracket2521 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_52_in_nodename2538 = new BitSet(new ulong[]{0xFE0847FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_idd_in_nodename2540 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_nodename2542 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_82_in_circle2567 = new BitSet(new ulong[]{0x0010000000000002UL});
-    public static readonly BitSet FOLLOW_83_in_circle2571 = new BitSet(new ulong[]{0x0010000000000002UL});
-    public static readonly BitSet FOLLOW_size_in_circle2580 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_84_in_arc2595 = new BitSet(new ulong[]{0x0010000000000000UL});
-    public static readonly BitSet FOLLOW_52_in_arc2598 = new BitSet(new ulong[]{0x00000000E0000000UL});
-    public static readonly BitSet FOLLOW_numberunitorvariable_in_arc2600 = new BitSet(new ulong[]{0x0001000000000000UL});
-    public static readonly BitSet FOLLOW_48_in_arc2602 = new BitSet(new ulong[]{0x00000000E0000000UL});
-    public static readonly BitSet FOLLOW_numberunitorvariable_in_arc2604 = new BitSet(new ulong[]{0x0001000000000000UL});
-    public static readonly BitSet FOLLOW_48_in_arc2606 = new BitSet(new ulong[]{0x00000000E0000000UL});
-    public static readonly BitSet FOLLOW_numberunitorvariable_in_arc2608 = new BitSet(new ulong[]{0x0020000000000000UL,0x0000000000004000UL});
-    public static readonly BitSet FOLLOW_78_in_arc2611 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_arc2613 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_arc2617 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_84_in_arc2635 = new BitSet(new ulong[]{0x0010000000000000UL});
-    public static readonly BitSet FOLLOW_52_in_arc2638 = new BitSet(new ulong[]{0xFE084FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_arc2640 = new BitSet(new ulong[]{0x0001000000000000UL});
-    public static readonly BitSet FOLLOW_48_in_arc2642 = new BitSet(new ulong[]{0xFE084FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_arc2644 = new BitSet(new ulong[]{0x0001000000000000UL});
-    public static readonly BitSet FOLLOW_48_in_arc2646 = new BitSet(new ulong[]{0xFE084FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_arc2648 = new BitSet(new ulong[]{0x0020000000000000UL,0x0000000000004000UL});
-    public static readonly BitSet FOLLOW_78_in_arc2651 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_arc2653 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_arc2657 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_84_in_arc2675 = new BitSet(new ulong[]{0x0040000000000000UL});
-    public static readonly BitSet FOLLOW_tikz_options_in_arc2677 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_52_in_size2702 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_size2704 = new BitSet(new ulong[]{0x0020000000000000UL,0x0000000000004000UL});
-    public static readonly BitSet FOLLOW_78_in_size2707 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_size2709 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_size2713 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_52_in_coord_nodename2741 = new BitSet(new ulong[]{0xFE4847FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_tikz_options_in_coord_nodename2743 = new BitSet(new ulong[]{0xFE0847FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_idd_in_coord_nodename2746 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_coord_nodename2749 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_modifier_in_coord2775 = new BitSet(new ulong[]{0x0010000000000000UL,0x0000000006000000UL});
-    public static readonly BitSet FOLLOW_coord_nodename_in_coord2778 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_modifier_in_coord2804 = new BitSet(new ulong[]{0x0010000000000000UL});
-    public static readonly BitSet FOLLOW_52_in_coord2807 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_coord2809 = new BitSet(new ulong[]{0x0001800000000000UL});
-    public static readonly BitSet FOLLOW_coord_sep_in_coord2811 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_coord2813 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_coord2815 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_modifier_in_coord2839 = new BitSet(new ulong[]{0x0010000000000000UL});
-    public static readonly BitSet FOLLOW_52_in_coord2842 = new BitSet(new ulong[]{0xFE084FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_coord2844 = new BitSet(new ulong[]{0x0001800000000000UL});
-    public static readonly BitSet FOLLOW_coord_sep_in_coord2846 = new BitSet(new ulong[]{0xFE084FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_coord2848 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_coord2850 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_modifier_in_coord2874 = new BitSet(new ulong[]{0x0010000000000000UL});
-    public static readonly BitSet FOLLOW_52_in_coord2877 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_coord2879 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_nodename_in_coord_nooption2907 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_modifier_in_coord_nooption2931 = new BitSet(new ulong[]{0x0010000000000000UL});
-    public static readonly BitSet FOLLOW_52_in_coord_nooption2934 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_coord_nooption2936 = new BitSet(new ulong[]{0x0001800000000000UL});
-    public static readonly BitSet FOLLOW_coord_sep_in_coord_nooption2938 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_coord_nooption2940 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_coord_nooption2942 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_modifier_in_coord_nooption2966 = new BitSet(new ulong[]{0x0010000000000000UL});
-    public static readonly BitSet FOLLOW_52_in_coord_nooption2969 = new BitSet(new ulong[]{0xFE084FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_coord_nooption2971 = new BitSet(new ulong[]{0x0001800000000000UL});
-    public static readonly BitSet FOLLOW_coord_sep_in_coord_nooption2973 = new BitSet(new ulong[]{0xFE084FFFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_coord_part_in_coord_nooption2975 = new BitSet(new ulong[]{0x0020000000000000UL});
-    public static readonly BitSet FOLLOW_53_in_coord_nooption2977 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_idd_in_coord_part3010 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_43_in_coord_part3025 = new BitSet(new ulong[]{0xFE0847FFFFFFFFF0UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_idd_in_coord_part3027 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_coord_part3029 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_idd_in_coord_part3047 = new BitSet(new ulong[]{0x0000200000000000UL});
-    public static readonly BitSet FOLLOW_45_in_coord_part3049 = new BitSet(new ulong[]{0x00000000C0000000UL});
-    public static readonly BitSet FOLLOW_numberunit_in_coord_part3051 = new BitSet(new ulong[]{0xFE08C7FFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_47_in_coord_part3053 = new BitSet(new ulong[]{0xFE0847FFFFFFFFF2UL,0x000000007FFFFFFFUL});
-    public static readonly BitSet FOLLOW_set_in_coord_sep3085 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_single_in_tikzpath_element1837 = new BitSet(new ulong[]{0x0000800000000002UL});
+    public static readonly BitSet FOLLOW_47_in_tikzpath_element1839 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikz_options_in_tikzpath_element_single1857 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_let_cmd_parts_in_tikzpath_element_single1864 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_arc_in_tikzpath_element_single1882 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_in_tikzpath_element_single1892 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_controls_in_tikzpath_element_single1898 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikznode_int_in_tikzpath_element_single1904 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_int_in_tikzpath_element_single1910 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_circle_in_tikzpath_element_single1916 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_roundbr_start_in_tikzpath_element_single1923 = new BitSet(new ulong[]{0xFCB87FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzpath_element_single1925 = new BitSet(new ulong[]{0xFCB87FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_roundbr_end_in_tikzpath_element_single1928 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_53_in_tikzpath_element_single1948 = new BitSet(new ulong[]{0x08E0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzpath_element_single1950 = new BitSet(new ulong[]{0x08E0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_54_in_tikzpath_element_single1953 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_edgeop_in_tikzpath_element_single1972 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_controls_start_in_controls1987 = new BitSet(new ulong[]{0x0020000000000000UL,0x000000000C000000UL});
+    public static readonly BitSet FOLLOW_coord_in_controls1989 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000010008000UL});
+    public static readonly BitSet FOLLOW_79_in_controls1992 = new BitSet(new ulong[]{0x0020000000000000UL,0x000000000C000000UL});
+    public static readonly BitSet FOLLOW_coord_in_controls1994 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000010008000UL});
+    public static readonly BitSet FOLLOW_controls_end_in_controls1998 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_node_start_in_tikznode_ext2024 = new BitSet(new ulong[]{0x00A0080000000000UL,0x0000000000040000UL});
+    public static readonly BitSet FOLLOW_tikznode_core_in_tikznode_ext2026 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikznode_ext2028 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_semicolon_end_in_tikznode_ext2031 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_def_start_in_tikzdef_ext2056 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzdef_ext2058 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_semicolon_end_in_tikzdef_ext2061 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_matrix_start_in_tikzmatrix_ext2086 = new BitSet(new ulong[]{0x00A0080000000000UL,0x0000000000040000UL});
+    public static readonly BitSet FOLLOW_tikznode_core_in_tikzmatrix_ext2088 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzmatrix_ext2090 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_semicolon_end_in_tikzmatrix_ext2093 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coordinate_start_in_tikzcoordinate_ext2121 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFF4000UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_ext2136 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_ext2155 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_ext2175 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_tikzpath_element_in_tikzcoordinate_ext2186 = new BitSet(new ulong[]{0x0AA0280030000000UL,0x000000001FFB4000UL});
+    public static readonly BitSet FOLLOW_semicolon_end_in_tikzcoordinate_ext2189 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_80_in_tikzcoordinate_int2249 = new BitSet(new ulong[]{0x00A0000000000002UL,0x0000000000040000UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_tikzcoordinate_int2260 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_tikzcoordinate_int2279 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_tikzcoordinate_int2299 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_81_in_tikznode_int2315 = new BitSet(new ulong[]{0x00A0080000000000UL,0x0000000000040000UL});
+    public static readonly BitSet FOLLOW_tikznode_core_in_tikznode_int2318 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikznode_core2328 = new BitSet(new ulong[]{0x00A0080000000000UL,0x0000000000040000UL});
+    public static readonly BitSet FOLLOW_tikzstring_in_tikznode_core2331 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core32356 = new BitSet(new ulong[]{0x00A0000000000000UL,0x0000000000040000UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core32358 = new BitSet(new ulong[]{0x00A0000000000000UL,0x0000000000040000UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core32360 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core22394 = new BitSet(new ulong[]{0x00A0000000000000UL,0x0000000000040000UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core22396 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikznode_decorator_in_tikzcoordinate_core12429 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_nodename_in_tikznode_decorator2466 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_82_in_tikznode_decorator2473 = new BitSet(new ulong[]{0x0000000020000000UL});
+    public static readonly BitSet FOLLOW_COMMAND_in_tikznode_decorator2476 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_82_in_tikznode_decorator2482 = new BitSet(new ulong[]{0x0020000000000000UL,0x000000000C000000UL});
+    public static readonly BitSet FOLLOW_coord_in_tikznode_decorator2485 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikz_options_dontcare_in_tikznode_decorator2491 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_55_in_tikz_options_dontcare2501 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_no_rlbracket_in_tikz_options_dontcare2503 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_options_dontcare_in_tikz_options_dontcare2507 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_no_rlbracket_in_tikz_options_dontcare2509 = new BitSet(new ulong[]{0xFFFFFFFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_56_in_tikz_options_dontcare2514 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_set_in_no_rlbracket2532 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_53_in_nodename2549 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_idd_in_nodename2551 = new BitSet(new ulong[]{0x0040000000000000UL});
+    public static readonly BitSet FOLLOW_54_in_nodename2553 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_83_in_circle2578 = new BitSet(new ulong[]{0x0020000000000002UL});
+    public static readonly BitSet FOLLOW_84_in_circle2582 = new BitSet(new ulong[]{0x0020000000000002UL});
+    public static readonly BitSet FOLLOW_size_in_circle2591 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_85_in_arc2606 = new BitSet(new ulong[]{0x0020000000000000UL});
+    public static readonly BitSet FOLLOW_53_in_arc2609 = new BitSet(new ulong[]{0x00000000E0000000UL});
+    public static readonly BitSet FOLLOW_numberunitorvariable_in_arc2611 = new BitSet(new ulong[]{0x0001000000000000UL});
+    public static readonly BitSet FOLLOW_48_in_arc2613 = new BitSet(new ulong[]{0x00000000E0000000UL});
+    public static readonly BitSet FOLLOW_numberunitorvariable_in_arc2615 = new BitSet(new ulong[]{0x0001000000000000UL});
+    public static readonly BitSet FOLLOW_48_in_arc2617 = new BitSet(new ulong[]{0x00000000E0000000UL});
+    public static readonly BitSet FOLLOW_numberunitorvariable_in_arc2619 = new BitSet(new ulong[]{0x0040000000000000UL,0x0000000000008000UL});
+    public static readonly BitSet FOLLOW_79_in_arc2622 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_arc2624 = new BitSet(new ulong[]{0x0040000000000000UL});
+    public static readonly BitSet FOLLOW_54_in_arc2628 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_85_in_arc2646 = new BitSet(new ulong[]{0x0020000000000000UL});
+    public static readonly BitSet FOLLOW_53_in_arc2649 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_arc2651 = new BitSet(new ulong[]{0x0001000000000000UL});
+    public static readonly BitSet FOLLOW_48_in_arc2653 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_arc2655 = new BitSet(new ulong[]{0x0001000000000000UL});
+    public static readonly BitSet FOLLOW_48_in_arc2657 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_arc2659 = new BitSet(new ulong[]{0x0040000000000000UL,0x0000000000008000UL});
+    public static readonly BitSet FOLLOW_79_in_arc2662 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_arc2664 = new BitSet(new ulong[]{0x0040000000000000UL});
+    public static readonly BitSet FOLLOW_54_in_arc2668 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_85_in_arc2686 = new BitSet(new ulong[]{0x0080000000000000UL});
+    public static readonly BitSet FOLLOW_tikz_options_in_arc2688 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_53_in_size2713 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_size2715 = new BitSet(new ulong[]{0x0040000000000000UL,0x0000000000008000UL});
+    public static readonly BitSet FOLLOW_79_in_size2718 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_size2720 = new BitSet(new ulong[]{0x0040000000000000UL});
+    public static readonly BitSet FOLLOW_54_in_size2724 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_53_in_coord_nodename2752 = new BitSet(new ulong[]{0xFC9847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_tikz_options_in_coord_nodename2754 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_idd_in_coord_nodename2757 = new BitSet(new ulong[]{0x0040000000000000UL});
+    public static readonly BitSet FOLLOW_54_in_coord_nodename2760 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_modifier_in_coord2786 = new BitSet(new ulong[]{0x0020000000000000UL,0x000000000C000000UL});
+    public static readonly BitSet FOLLOW_coord_nodename_in_coord2789 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_modifier_in_coord2815 = new BitSet(new ulong[]{0x0020000000000000UL});
+    public static readonly BitSet FOLLOW_53_in_coord2818 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_coord2820 = new BitSet(new ulong[]{0x0001800000000000UL});
+    public static readonly BitSet FOLLOW_coord_sep_in_coord2822 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_coord2824 = new BitSet(new ulong[]{0x0040000000000000UL});
+    public static readonly BitSet FOLLOW_54_in_coord2826 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_modifier_in_coord2850 = new BitSet(new ulong[]{0x0020000000000000UL});
+    public static readonly BitSet FOLLOW_53_in_coord2853 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_coord2855 = new BitSet(new ulong[]{0x0001800000000000UL});
+    public static readonly BitSet FOLLOW_coord_sep_in_coord2857 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_coord2859 = new BitSet(new ulong[]{0x0040000000000000UL});
+    public static readonly BitSet FOLLOW_54_in_coord2861 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_modifier_in_coord2885 = new BitSet(new ulong[]{0x0020000000000000UL});
+    public static readonly BitSet FOLLOW_53_in_coord2888 = new BitSet(new ulong[]{0x0040000000000000UL});
+    public static readonly BitSet FOLLOW_54_in_coord2890 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_nodename_in_coord_nooption2918 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_modifier_in_coord_nooption2942 = new BitSet(new ulong[]{0x0020000000000000UL});
+    public static readonly BitSet FOLLOW_53_in_coord_nooption2945 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_coord_nooption2947 = new BitSet(new ulong[]{0x0001800000000000UL});
+    public static readonly BitSet FOLLOW_coord_sep_in_coord_nooption2949 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_coord_nooption2951 = new BitSet(new ulong[]{0x0040000000000000UL});
+    public static readonly BitSet FOLLOW_54_in_coord_nooption2953 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_modifier_in_coord_nooption2977 = new BitSet(new ulong[]{0x0020000000000000UL});
+    public static readonly BitSet FOLLOW_53_in_coord_nooption2980 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_coord_nooption2982 = new BitSet(new ulong[]{0x0001800000000000UL});
+    public static readonly BitSet FOLLOW_coord_sep_in_coord_nooption2984 = new BitSet(new ulong[]{0xFC184FFFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_coord_part_in_coord_nooption2986 = new BitSet(new ulong[]{0x0040000000000000UL});
+    public static readonly BitSet FOLLOW_54_in_coord_nooption2988 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_idd_in_coord_part3021 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_43_in_coord_part3036 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF0UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_idd_in_coord_part3038 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_coord_part3040 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_idd_in_coord_part3058 = new BitSet(new ulong[]{0x0000200000000000UL});
+    public static readonly BitSet FOLLOW_45_in_coord_part3060 = new BitSet(new ulong[]{0x00000000C0000000UL});
+    public static readonly BitSet FOLLOW_numberunit_in_coord_part3062 = new BitSet(new ulong[]{0xFC18C7FFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_47_in_coord_part3064 = new BitSet(new ulong[]{0xFC1847FFFFFFFFF2UL,0x00000000FFFFFFFFUL});
+    public static readonly BitSet FOLLOW_set_in_coord_sep3096 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_set_in_edgeop0 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_set_in_coord_modifier0 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_54_in_squarebr_start3159 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_55_in_squarebr_end3177 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_56_in_semicolon_end3196 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_43_in_roundbr_start3214 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_44_in_roundbr_end3232 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_91_in_controls_start3250 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000010000000UL});
-    public static readonly BitSet FOLLOW_92_in_controls_start3252 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_91_in_controls_end3270 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_41_in_tikz_set_start3288 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikz_set_start3290 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_39_in_tikzpicture_start3309 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikzpicture_start3311 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000020000000UL});
-    public static readonly BitSet FOLLOW_93_in_tikzpicture_start3313 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_tikzpicture_start3315 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_42_in_tikz_start3333 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_63_in_tikzpicture_end3351 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikzpicture_end3353 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000020000000UL});
-    public static readonly BitSet FOLLOW_93_in_tikzpicture_end3355 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_tikzpicture_end3357 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_39_in_tikzscope_start3375 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikzscope_start3377 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000040000000UL});
-    public static readonly BitSet FOLLOW_94_in_tikzscope_start3379 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_tikzscope_start3381 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_63_in_tikzscope_end3399 = new BitSet(new ulong[]{0x0000080000000000UL});
-    public static readonly BitSet FOLLOW_43_in_tikzscope_end3401 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000040000000UL});
-    public static readonly BitSet FOLLOW_94_in_tikzscope_end3403 = new BitSet(new ulong[]{0x0000100000000000UL});
-    public static readonly BitSet FOLLOW_44_in_tikzscope_end3405 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_path_start_tag_in_path_start3424 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_node_start_tag_in_node_start3442 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_def_start_tag_in_def_start3460 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_matrix_start_tag_in_matrix_start3478 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_64_in_node_start_tag3496 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_69_in_def_start_tag3506 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_65_in_matrix_start_tag3516 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_66_in_coordinate_start3526 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_55_in_squarebr_start3170 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_56_in_squarebr_end3188 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_57_in_semicolon_end3207 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_43_in_roundbr_start3225 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_44_in_roundbr_end3243 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_92_in_controls_start3261 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000020000000UL});
+    public static readonly BitSet FOLLOW_93_in_controls_start3263 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_92_in_controls_end3281 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_41_in_tikz_set_start3299 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_tikz_set_start3301 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_39_in_tikzpicture_start3320 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_tikzpicture_start3322 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000040000000UL});
+    public static readonly BitSet FOLLOW_94_in_tikzpicture_start3324 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_tikzpicture_start3326 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_42_in_tikz_start3344 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_64_in_tikzpicture_end3362 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_tikzpicture_end3364 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000040000000UL});
+    public static readonly BitSet FOLLOW_94_in_tikzpicture_end3366 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_tikzpicture_end3368 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_39_in_tikzscope_start3386 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_tikzscope_start3388 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000080000000UL});
+    public static readonly BitSet FOLLOW_95_in_tikzscope_start3390 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_tikzscope_start3392 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_64_in_tikzscope_end3410 = new BitSet(new ulong[]{0x0000080000000000UL});
+    public static readonly BitSet FOLLOW_43_in_tikzscope_end3412 = new BitSet(new ulong[]{0x0000000000000000UL,0x0000000080000000UL});
+    public static readonly BitSet FOLLOW_95_in_tikzscope_end3414 = new BitSet(new ulong[]{0x0000100000000000UL});
+    public static readonly BitSet FOLLOW_44_in_tikzscope_end3416 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_path_start_tag_in_path_start3435 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_node_start_tag_in_node_start3453 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_def_start_tag_in_def_start3471 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_matrix_start_tag_in_matrix_start3489 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_65_in_node_start_tag3507 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_70_in_def_start_tag3517 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_66_in_matrix_start_tag3527 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_67_in_coordinate_start3537 = new BitSet(new ulong[]{0x0000000000000002UL});
     public static readonly BitSet FOLLOW_set_in_path_start_tag0 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_coord_in_synpred1_simpletikz1878 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_synpred2_simpletikz2121 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_synpred3_simpletikz2140 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_synpred4_simpletikz2160 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_synpred5_simpletikz2245 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_synpred6_simpletikz2264 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_synpred7_simpletikz2284 = new BitSet(new ulong[]{0x0000000000000002UL});
-    public static readonly BitSet FOLLOW_size_in_synpred8_simpletikz2576 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_coord_in_synpred1_simpletikz1889 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_synpred2_simpletikz2132 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_synpred3_simpletikz2151 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_synpred4_simpletikz2171 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core3_in_synpred5_simpletikz2256 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core2_in_synpred6_simpletikz2275 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_tikzcoordinate_core1_in_synpred7_simpletikz2295 = new BitSet(new ulong[]{0x0000000000000002UL});
+    public static readonly BitSet FOLLOW_size_in_synpred8_simpletikz2587 = new BitSet(new ulong[]{0x0000000000000002UL});
 
 }

--- a/TikzParser/simpletikz.g
+++ b/TikzParser/simpletikz.g
@@ -194,7 +194,7 @@ range
 	: numberunit ':' numberunit	->	^(IM_STRING numberunit ':' numberunit )
 	;	
 option_style
-	:	idd ('/.style' | ('/.append' 'style')  | ('/.style' number 'args')) '=' '{' (option_kv (',' option_kv)*)?  ','? '}'  -> ^(IM_OPTION_STYLE idd option_kv*)  // '{' option '}' todo: optional ,
+	:	idd ('/.style' | ('/.append' 'style') ) ((('n' 'args')=> ('n' 'args') '=' '{' number '}' ) | ('2' 'args')? '=') '{' (option_kv (',' option_kv)*)?  ','? '}'  -> ^(IM_OPTION_STYLE idd option_kv*)  // '{' option '}' todo: optional ,
 	;
 
 

--- a/TikzParser/simpletikz.g
+++ b/TikzParser/simpletikz.g
@@ -194,7 +194,7 @@ range
 	: numberunit ':' numberunit	->	^(IM_STRING numberunit ':' numberunit )
 	;	
 option_style
-	:	idd ('/.style' | ('/.append' 'style')) '=' '{' (option_kv (',' option_kv)*)?  ','? '}'  -> ^(IM_OPTION_STYLE idd option_kv*)  // '{' option '}' todo: optional ,
+	:	idd ('/.style' | ('/.append' 'style')  | ('/.style' number 'args')) '=' '{' (option_kv (',' option_kv)*)?  ','? '}'  -> ^(IM_OPTION_STYLE idd option_kv*)  // '{' option '}' todo: optional ,
 	;
 
 


### PR DESCRIPTION
This fixes handling of style definitions of the form -/style n args = {}

I stumbled upon this quite a few times now and decided to produce a quick fix.
